### PR TITLE
Run CI tests on one thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
-        run: cargo test --workspace --all-features
+        run: cargo test --workspace --all-features -- --test-threads 1


### PR DESCRIPTION
This is quick and dirty fix to resolve xmr-btc-swap and
monero-harness tests failing in CI when run concurrently.