### PR TITLE
Add 60 second sleep to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
-        run: cargo test --workspace --all-features -- --test-threads 1
+        run: cargo test --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,5 @@ jobs:
 
       - name: Cargo test
         run: cargo test --workspace --all-features
+        env:
+          MONERO_ADDITIONAL_SLEEP_PERIOD: 60000


### PR DESCRIPTION
There is some sort of timing issue when spinning up the monero containers on github CI. I do not know exactly what is the cause but we have a configurable 'additional sleep time' already available for `testcontainers` that can resolve this issue.

- Patch 1 - Reverts the recent change to use a single thread on CI runs.
- Patch 2 - Uses the environment variable MONERO_ADDITIONAL_SLEEP_PERIOD to tell `testcontainers` to wait an additional 60 secconds while bringing up the monero container.


## Time justification

60 seconds is a guess, it can probably be optimised down. The tests run in parallel though so its not that much of a inconvenience it increase total test time by 60 seconds.