### PR TITLE
Save and recover protocol state from disk

### DIFF
--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -346,16 +346,16 @@ pub struct State3 {
     pub S_b_bitcoin: bitcoin::PublicKey,
     pub v: monero::PrivateViewKey,
     #[serde(with = "bitcoin_amount")]
-    btc: bitcoin::Amount,
-    xmr: monero::Amount,
-    refund_timelock: u32,
-    punish_timelock: u32,
-    refund_address: bitcoin::Address,
-    redeem_address: bitcoin::Address,
-    punish_address: bitcoin::Address,
-    tx_lock: bitcoin::TxLock,
-    tx_punish_sig_bob: bitcoin::Signature,
-    tx_cancel_sig_bob: bitcoin::Signature,
+    pub btc: bitcoin::Amount,
+    pub xmr: monero::Amount,
+    pub refund_timelock: u32,
+    pub punish_timelock: u32,
+    pub refund_address: bitcoin::Address,
+    pub redeem_address: bitcoin::Address,
+    pub punish_address: bitcoin::Address,
+    pub tx_lock: bitcoin::TxLock,
+    pub tx_punish_sig_bob: bitcoin::Signature,
+    pub tx_cancel_sig_bob: bitcoin::Signature,
 }
 
 impl State3 {

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -3,7 +3,7 @@ use crate::{
     bitcoin::{BroadcastSignedTransaction, WatchForRawTransaction},
     bob, monero,
     monero::{CreateWalletForOutput, Transfer},
-    serde::{bitcoin_amount, cross_curve_dleq_scalar, ecdsa_fun_signature},
+    serde::{bitcoin_amount, cross_curve_dleq_scalar},
     transport::{ReceiveMessage, SendMessage},
 };
 use anyhow::{anyhow, Result};
@@ -347,17 +347,15 @@ pub struct State3 {
     pub v: monero::PrivateViewKey,
     #[serde(with = "bitcoin_amount")]
     btc: bitcoin::Amount,
-    pub xmr: monero::Amount,
-    pub refund_timelock: u32,
-    pub punish_timelock: u32,
-    pub refund_address: bitcoin::Address,
-    pub redeem_address: bitcoin::Address,
-    pub punish_address: bitcoin::Address,
-    pub tx_lock: bitcoin::TxLock,
-    #[serde(with = "ecdsa_fun_signature")]
-    pub tx_punish_sig_bob: bitcoin::Signature,
-    #[serde(with = "ecdsa_fun_signature")]
-    pub tx_cancel_sig_bob: bitcoin::Signature,
+    xmr: monero::Amount,
+    refund_timelock: u32,
+    punish_timelock: u32,
+    refund_address: bitcoin::Address,
+    redeem_address: bitcoin::Address,
+    punish_address: bitcoin::Address,
+    tx_lock: bitcoin::TxLock,
+    tx_punish_sig_bob: bitcoin::Signature,
+    tx_cancel_sig_bob: bitcoin::Signature,
 }
 
 impl State3 {
@@ -411,9 +409,7 @@ pub struct State4 {
     redeem_address: bitcoin::Address,
     punish_address: bitcoin::Address,
     tx_lock: bitcoin::TxLock,
-    #[serde(with = "ecdsa_fun_signature")]
     tx_punish_sig_bob: bitcoin::Signature,
-    #[serde(with = "ecdsa_fun_signature")]
     tx_cancel_sig_bob: bitcoin::Signature,
 }
 
@@ -519,9 +515,9 @@ pub struct State5 {
     punish_address: bitcoin::Address,
     tx_lock: bitcoin::TxLock,
     tx_lock_proof: monero::TransferProof,
-    #[serde(with = "ecdsa_fun_signature")]
+
     tx_punish_sig_bob: bitcoin::Signature,
-    #[serde(with = "ecdsa_fun_signature")]
+
     tx_cancel_sig_bob: bitcoin::Signature,
     lock_xmr_fee: monero::Amount,
 }
@@ -613,7 +609,7 @@ pub struct State6 {
     redeem_address: bitcoin::Address,
     punish_address: bitcoin::Address,
     tx_lock: bitcoin::TxLock,
-    #[serde(with = "ecdsa_fun_signature")]
+
     tx_punish_sig_bob: bitcoin::Signature,
     tx_redeem_encsig: EncryptedSignature,
     lock_xmr_fee: monero::Amount,

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -3,7 +3,7 @@ use crate::{
     bitcoin::{BroadcastSignedTransaction, WatchForRawTransaction},
     bob, monero,
     monero::{CreateWalletForOutput, Transfer},
-    serde::{bitcoin_amount, cross_curve_dleq_scalar},
+    serde::bitcoin_amount,
     transport::{ReceiveMessage, SendMessage},
 };
 use anyhow::{anyhow, Result};
@@ -134,7 +134,7 @@ impl State {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct State0 {
     a: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
+    //#[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     v_a: monero::PrivateViewKey,
     #[serde(with = "bitcoin_amount")]
@@ -223,7 +223,6 @@ impl State0 {
 pub struct State1 {
     a: bitcoin::SecretKey,
     B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
@@ -263,7 +262,6 @@ impl State1 {
 pub struct State2 {
     a: bitcoin::SecretKey,
     B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
@@ -340,7 +338,6 @@ impl State2 {
 pub struct State3 {
     pub a: bitcoin::SecretKey,
     pub B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     pub s_a: cross_curve_dleq::Scalar,
     pub S_b_monero: monero::PublicKey,
     pub S_b_bitcoin: bitcoin::PublicKey,
@@ -395,7 +392,6 @@ impl State3 {
 pub struct State4 {
     a: bitcoin::SecretKey,
     B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
@@ -500,7 +496,6 @@ impl State4 {
 pub struct State5 {
     a: bitcoin::SecretKey,
     B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
@@ -595,7 +590,6 @@ impl State5 {
 pub struct State6 {
     a: bitcoin::SecretKey,
     B: bitcoin::PublicKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -82,7 +82,7 @@ pub async fn next_state<
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum State {
     State0(State0),
     State1(State1),

--- a/xmr-btc/src/bob.rs
+++ b/xmr-btc/src/bob.rs
@@ -82,7 +82,7 @@ pub async fn next_state<
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum State {
     State0(State0),
     State1(State1),

--- a/xmr-btc/src/bob.rs
+++ b/xmr-btc/src/bob.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     monero,
     monero::{CreateWalletForOutput, WatchForTransfer},
-    serde::{bitcoin_amount, cross_curve_dleq_scalar, monero_private_key},
+    serde::{bitcoin_amount, monero_private_key},
     transport::{ReceiveMessage, SendMessage},
 };
 use anyhow::{anyhow, Result};
@@ -109,7 +109,6 @@ impl_from_child_enum!(State5, State);
 #[derive(Debug, Deserialize, Serialize)]
 pub struct State0 {
     b: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_b: cross_curve_dleq::Scalar,
     v_b: monero::PrivateViewKey,
     #[serde(with = "bitcoin_amount")]
@@ -200,7 +199,6 @@ impl State0 {
 pub struct State1 {
     A: bitcoin::PublicKey,
     b: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_b: cross_curve_dleq::Scalar,
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
@@ -265,7 +263,6 @@ impl State1 {
 pub struct State2 {
     pub A: bitcoin::PublicKey,
     pub b: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     pub s_b: cross_curve_dleq::Scalar,
     pub S_a_monero: monero::PublicKey,
     pub S_a_bitcoin: bitcoin::PublicKey,
@@ -338,7 +335,6 @@ impl State2 {
 pub struct State3 {
     A: bitcoin::PublicKey,
     b: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_b: cross_curve_dleq::Scalar,
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
@@ -451,7 +447,6 @@ impl State3 {
 pub struct State4 {
     A: bitcoin::PublicKey,
     b: bitcoin::SecretKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_b: cross_curve_dleq::Scalar,
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
@@ -522,7 +517,6 @@ pub struct State5 {
     b: bitcoin::SecretKey,
     #[serde(with = "monero_private_key")]
     s_a: monero::PrivateKey,
-    #[serde(with = "cross_curve_dleq_scalar")]
     s_b: cross_curve_dleq::Scalar,
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,

--- a/xmr-btc/tests/e2e.rs
+++ b/xmr-btc/tests/e2e.rs
@@ -18,6 +18,7 @@ mod tests {
     use monero_harness::Monero;
     use rand::rngs::OsRng;
 
+    use crate::harness::storage::Database;
     use std::{convert::TryInto, path::Path};
     use testcontainers::clients::Cli;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -251,8 +252,10 @@ mod tests {
         let cli = Cli::default();
         let (monero, _container) = Monero::new(&cli);
         let bitcoind = init_bitcoind(&cli).await;
-        let alice_db = harness::storage::Database::open(Path::new(ALICE_TEST_DB_FOLDER)).unwrap();
-        let bob_db = harness::storage::Database::open(Path::new(BOB_TEST_DB_FOLDER)).unwrap();
+        let alice_db: Database<alice::State> =
+            harness::storage::Database::open(Path::new(ALICE_TEST_DB_FOLDER)).unwrap();
+        let bob_db: Database<bob::State> =
+            harness::storage::Database::open(Path::new(BOB_TEST_DB_FOLDER)).unwrap();
 
         let (
             alice_state0,
@@ -281,29 +284,26 @@ mod tests {
             .await
             .unwrap();
 
-            let alice_state5: alice::State5 = alice_state.try_into().unwrap();
-            let bob_state3: bob::State3 = bob_state.try_into().unwrap();
-
             // save state to db
-            alice_db.insert_latest_state(&alice_state5).await.unwrap();
-            bob_db.insert_latest_state(&bob_state3).await.unwrap();
+            alice_db.insert_latest_state(&alice_state).await.unwrap();
+            bob_db.insert_latest_state(&bob_state).await.unwrap();
         };
 
         let (alice_state6, bob_state5) = {
             // recover state from db
-            let alice_state5: alice::State5 = alice_db.get_latest_state().unwrap();
-            let bob_state3: bob::State3 = bob_db.get_latest_state().unwrap();
+            let alice_state = alice_db.get_latest_state().unwrap();
+            let bob_state = bob_db.get_latest_state().unwrap();
 
             let (alice_state, bob_state) = future::try_join(
                 run_alice_until(
                     &mut alice_node,
-                    alice_state5.into(),
+                    alice_state,
                     harness::alice::is_state6,
                     &mut OsRng,
                 ),
                 run_bob_until(
                     &mut bob_node,
-                    bob_state3.into(),
+                    bob_state,
                     harness::bob::is_state5,
                     &mut OsRng,
                 ),

--- a/xmr-btc/tests/e2e.rs
+++ b/xmr-btc/tests/e2e.rs
@@ -11,7 +11,6 @@ mod tests {
         harness::{
             init_bitcoind, init_test,
             node::{run_alice_until, run_bob_until},
-            ALICE_TEST_DB_FOLDER, BOB_TEST_DB_FOLDER,
         },
     };
     use futures::future;
@@ -19,7 +18,7 @@ mod tests {
     use rand::rngs::OsRng;
 
     use crate::harness::storage::Database;
-    use std::{convert::TryInto, path::Path};
+    use std::convert::TryInto;
     use testcontainers::clients::Cli;
     use tracing_subscriber::util::SubscriberInitExt;
     use xmr_btc::{
@@ -252,10 +251,13 @@ mod tests {
         let cli = Cli::default();
         let (monero, _container) = Monero::new(&cli);
         let bitcoind = init_bitcoind(&cli).await;
+
+        let alice_db_dir = tempfile::tempdir().unwrap();
         let alice_db: Database<alice::State> =
-            harness::storage::Database::open(Path::new(ALICE_TEST_DB_FOLDER)).unwrap();
+            harness::storage::Database::open(alice_db_dir.path()).unwrap();
+        let bob_db_dir = tempfile::tempdir().unwrap();
         let bob_db: Database<bob::State> =
-            harness::storage::Database::open(Path::new(BOB_TEST_DB_FOLDER)).unwrap();
+            harness::storage::Database::open(bob_db_dir.path()).unwrap();
 
         let (
             alice_state0,

--- a/xmr-btc/tests/harness/storage.rs
+++ b/xmr-btc/tests/harness/storage.rs
@@ -10,10 +10,8 @@ impl Database {
     const LAST_STATE_KEY: &'static str = "latest_state";
 
     pub fn open(path: &Path) -> Result<Self> {
-        let path = path
-            .to_str()
-            .ok_or_else(|| anyhow!("The path is not utf-8 valid: {:?}", path))?;
-        let db = sled::open(path).with_context(|| format!("Could not open the DB at {}", path))?;
+        let db =
+            sled::open(path).with_context(|| format!("Could not open the DB at {:?}", path))?;
 
         Ok(Database { db })
     }
@@ -30,7 +28,7 @@ impl Database {
         self.db
             .compare_and_swap(key, old_value, Some(new_value))
             .context("Could not write in the DB")?
-            .context("Stored swap somehow changed, aborting saving")?; // let _ =
+            .context("Stored swap somehow changed, aborting saving")?;
 
         self.db
             .flush_async()
@@ -77,9 +75,7 @@ mod tests {
     use curve25519_dalek::scalar::Scalar;
     use ecdsa_fun::fun::rand_core::OsRng;
     use std::str::FromStr;
-    use xmr_btc::serde::{
-        bitcoin_amount, cross_curve_dleq_scalar, ecdsa_fun_signature, monero_private_key,
-    };
+    use xmr_btc::serde::{bitcoin_amount, cross_curve_dleq_scalar, monero_private_key};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {
@@ -98,7 +94,6 @@ mod tests {
         refund_timelock: u32,
         refund_address: ::bitcoin::Address,
         transaction: ::bitcoin::Transaction,
-        #[serde(with = "ecdsa_fun_signature")]
         tx_punish_sig: xmr_btc::bitcoin::Signature,
     }
 

--- a/xmr-btc/tests/harness/storage.rs
+++ b/xmr-btc/tests/harness/storage.rs
@@ -81,13 +81,12 @@ mod tests {
     use curve25519_dalek::scalar::Scalar;
     use ecdsa_fun::fun::rand_core::OsRng;
     use std::str::FromStr;
-    use xmr_btc::serde::{bitcoin_amount, cross_curve_dleq_scalar, monero_private_key};
+    use xmr_btc::serde::{bitcoin_amount, monero_private_key};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {
         A: xmr_btc::bitcoin::PublicKey,
         a: xmr_btc::bitcoin::SecretKey,
-        #[serde(with = "cross_curve_dleq_scalar")]
         s_a: ::cross_curve_dleq::Scalar,
         #[serde(with = "monero_private_key")]
         s_b: monero::PrivateKey,

--- a/xmr-btc/tests/harness/storage.rs
+++ b/xmr-btc/tests/harness/storage.rs
@@ -14,6 +14,7 @@ impl<T> Database<T>
 where
     T: Serialize + DeserializeOwned,
 {
+    // TODO: serialize using lazy/one-time initlisation
     const LAST_STATE_KEY: &'static str = "latest_state";
 
     pub fn open(path: &Path) -> Result<Self> {
@@ -37,6 +38,7 @@ where
             .context("Could not write in the DB")?
             .context("Stored swap somehow changed, aborting saving")?;
 
+        // TODO: see if this can be done through sled config
         self.db
             .flush_async()
             .await

--- a/xmr-btc/tests/harness/storage.rs
+++ b/xmr-btc/tests/harness/storage.rs
@@ -105,7 +105,8 @@ mod tests {
 
     #[tokio::test]
     async fn recover_state_from_db() {
-        let db = Database::open(Path::new("../target/test_recover.db")).unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(db_dir.path()).unwrap();
 
         let a = xmr_btc::bitcoin::SecretKey::new_random(&mut OsRng);
         let s_a = cross_curve_dleq::Scalar::random(&mut OsRng);


### PR DESCRIPTION
NOTE: This implementation saves secrets to disk! It is not
secure.

The storage API allows the caller to atomically record the state
of the protocol. The user can retrieve this recorded state and
re-commence the protocol from that point. The state is recorded
using a hard coded key, causing it to overwrite the previously
recorded state. This limitation means that this recovery
mechanism should not be used in a program that simultaneously
manages the execution of multiple swaps.

An e2e test was added to show how to save, recover and resume
protocol execution. This logic could also be integrated into the
run_until functions to automate saving but was not included at
this stage as protocol execution is currently under development.

Serialisation and deserialisation was implemented on the states
to allow the to be stored using the database. Currently the
secret's are also being stored to disk but should be recovered
from a seed or wallets.