### PR TITLE
Improve serde implementations

### DIFF
--- a/swap/src/storage.rs
+++ b/swap/src/storage.rs
@@ -82,6 +82,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
     use xmr_btc::serde::monero_private_key;
+    use xmr_btc::{CrossCurveScalar, Curve25519Scalar};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {

--- a/swap/src/storage.rs
+++ b/swap/src/storage.rs
@@ -81,10 +81,7 @@ mod tests {
     use rand::rngs::OsRng;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
-    use xmr_btc::{
-        serde::{bitcoin_amount, monero_private_key},
-        CrossCurveScalar, Curve25519Scalar,
-    };
+    use xmr_btc::serde::monero_private_key;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {
@@ -96,7 +93,7 @@ mod tests {
         S_a_monero: ::monero::PublicKey,
         S_a_bitcoin: xmr_btc::bitcoin::PublicKey,
         v: xmr_btc::monero::PrivateViewKey,
-        #[serde(with = "bitcoin_amount")]
+        #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
         btc: ::bitcoin::Amount,
         xmr: xmr_btc::monero::Amount,
         refund_timelock: u32,

--- a/swap/src/storage.rs
+++ b/swap/src/storage.rs
@@ -81,14 +81,13 @@ mod tests {
     use rand::rngs::OsRng;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
-    use xmr_btc::serde::monero_private_key;
-    use xmr_btc::{CrossCurveScalar, Curve25519Scalar};
+    use xmr_btc::{cross_curve_dleq, curve25519_dalek, serde::monero_private_key};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {
         A: xmr_btc::bitcoin::PublicKey,
         a: xmr_btc::bitcoin::SecretKey,
-        s_a: CrossCurveScalar,
+        s_a: cross_curve_dleq::Scalar,
         #[serde(with = "monero_private_key")]
         s_b: monero::PrivateKey,
         S_a_monero: ::monero::PublicKey,
@@ -109,8 +108,9 @@ mod tests {
         let db = Database::open(db_dir.path()).unwrap();
 
         let a = xmr_btc::bitcoin::SecretKey::new_random(&mut OsRng);
-        let s_a = CrossCurveScalar::random(&mut OsRng);
-        let s_b = monero::PrivateKey::from_scalar(Curve25519Scalar::random(&mut OsRng));
+        let s_a = cross_curve_dleq::Scalar::random(&mut OsRng);
+        let s_b =
+            monero::PrivateKey::from_scalar(curve25519_dalek::scalar::Scalar::random(&mut OsRng));
         let v_a = xmr_btc::monero::PrivateViewKey::new_random(&mut OsRng);
         let S_a_monero = monero::PublicKey::from_private_key(&monero::PrivateKey {
             scalar: s_a.into_ed25519(),

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -133,7 +133,6 @@ impl State {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct State0 {
     a: bitcoin::SecretKey,
-    //#[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     v_a: monero::PrivateViewKey,
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -3,7 +3,6 @@ use crate::{
     bitcoin::{BroadcastSignedTransaction, WatchForRawTransaction},
     bob, monero,
     monero::{CreateWalletForOutput, Transfer},
-    serde::bitcoin_amount,
     transport::{ReceiveMessage, SendMessage},
 };
 use anyhow::{anyhow, Result};
@@ -137,7 +136,7 @@ pub struct State0 {
     //#[serde(with = "cross_curve_dleq_scalar")]
     s_a: cross_curve_dleq::Scalar,
     v_a: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -227,7 +226,7 @@ pub struct State1 {
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -266,7 +265,7 @@ pub struct State2 {
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -342,7 +341,7 @@ pub struct State3 {
     pub S_b_monero: monero::PublicKey,
     pub S_b_bitcoin: bitcoin::PublicKey,
     pub v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     pub btc: bitcoin::Amount,
     pub xmr: monero::Amount,
     pub refund_timelock: u32,
@@ -396,7 +395,7 @@ pub struct State4 {
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -500,7 +499,7 @@ pub struct State5 {
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -594,7 +593,7 @@ pub struct State6 {
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,

--- a/xmr-btc/src/bob.rs
+++ b/xmr-btc/src/bob.rs
@@ -5,8 +5,7 @@ use crate::{
         WatchForRawTransaction,
     },
     monero,
-    monero::{CreateWalletForOutput, WatchForTransfer},
-    serde::{bitcoin_amount, monero_private_key},
+    serde::monero_private_key,
     transport::{ReceiveMessage, SendMessage},
 };
 use anyhow::{anyhow, Result};
@@ -21,6 +20,7 @@ use sha2::Sha256;
 use std::convert::{TryFrom, TryInto};
 
 pub mod message;
+use crate::monero::{CreateWalletForOutput, WatchForTransfer};
 pub use message::{Message, Message0, Message1, Message2, Message3};
 
 // There are no guarantees that send_message and receive_massage do not block
@@ -111,7 +111,7 @@ pub struct State0 {
     b: bitcoin::SecretKey,
     s_b: cross_curve_dleq::Scalar,
     v_b: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -203,7 +203,7 @@ pub struct State1 {
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -267,7 +267,7 @@ pub struct State2 {
     pub S_a_monero: monero::PublicKey,
     pub S_a_bitcoin: bitcoin::PublicKey,
     pub v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     pub xmr: monero::Amount,
     pub refund_timelock: u32,
@@ -339,7 +339,7 @@ pub struct State3 {
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -451,7 +451,7 @@ pub struct State4 {
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,
@@ -521,7 +521,7 @@ pub struct State5 {
     S_a_monero: monero::PublicKey,
     S_a_bitcoin: bitcoin::PublicKey,
     v: monero::PrivateViewKey,
-    #[serde(with = "bitcoin_amount")]
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
     refund_timelock: u32,

--- a/xmr-btc/src/lib.rs
+++ b/xmr-btc/src/lib.rs
@@ -52,8 +52,8 @@ pub mod monero;
 pub mod serde;
 pub mod transport;
 
-pub use cross_curve_dleq::Scalar as CrossCurveScalar;
-pub use curve25519_dalek::scalar::Scalar as Curve25519Scalar;
+pub use cross_curve_dleq;
+pub use curve25519_dalek;
 
 use async_trait::async_trait;
 use ecdsa_fun::{adaptor::Adaptor, nonce::Deterministic};

--- a/xmr-btc/src/serde.rs
+++ b/xmr-btc/src/serde.rs
@@ -41,28 +41,6 @@ pub mod monero_private_key {
     }
 }
 
-pub mod bitcoin_amount {
-    use bitcoin::Amount;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(x: &Amount, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        s.serialize_u64(x.as_sat())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Amount, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let sats = u64::deserialize(deserializer)?;
-        let amount = Amount::from_sat(sats);
-
-        Ok(amount)
-    }
-}
-
 pub mod monero_amount {
     use crate::monero::Amount;
     use serde::{Deserialize, Deserializer, Serializer};
@@ -95,21 +73,11 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct MoneroPrivateKey(#[serde(with = "monero_private_key")] crate::monero::PrivateKey);
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    pub struct BitcoinAmount(#[serde(with = "bitcoin_amount")] ::bitcoin::Amount);
-
     #[test]
     fn serde_monero_private_key() {
         let key = MoneroPrivateKey(monero::PrivateKey::from_scalar(Scalar::random(&mut OsRng)));
         let encoded = serde_cbor::to_vec(&key).unwrap();
         let decoded: MoneroPrivateKey = serde_cbor::from_slice(&encoded).unwrap();
         assert_eq!(key, decoded);
-    }
-    #[test]
-    fn serde_bitcoin_amount() {
-        let amount = BitcoinAmount(::bitcoin::Amount::from_sat(100));
-        let encoded = serde_cbor::to_vec(&amount).unwrap();
-        let decoded: BitcoinAmount = serde_cbor::from_slice(&encoded).unwrap();
-        assert_eq!(amount, decoded);
     }
 }

--- a/xmr-btc/src/serde.rs
+++ b/xmr-btc/src/serde.rs
@@ -77,11 +77,22 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct MoneroPrivateKey(#[serde(with = "monero_private_key")] crate::monero::PrivateKey);
 
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    pub struct MoneroAmount(#[serde(with = "monero_amount")] crate::monero::Amount);
+
     #[test]
     fn serde_monero_private_key() {
         let key = MoneroPrivateKey(monero::PrivateKey::from_scalar(Scalar::random(&mut OsRng)));
         let encoded = serde_cbor::to_vec(&key).unwrap();
         let decoded: MoneroPrivateKey = serde_cbor::from_slice(&encoded).unwrap();
         assert_eq!(key, decoded);
+    }
+
+    #[test]
+    fn serde_monero_amount() {
+        let amount = MoneroAmount(crate::monero::Amount::from_piconero(1000));
+        let encoded = serde_cbor::to_vec(&amount).unwrap();
+        let decoded: MoneroAmount = serde_cbor::from_slice(&encoded).unwrap();
+        assert_eq!(amount, decoded);
     }
 }


### PR DESCRIPTION
- Remove bitcoin custom implementation as rust-bitcoin provides it.
- Use consensus encoding to serialize monero private key