### PR TITLE
Do not re-export curve25519_dalek

### DIFF
--- a/swap/src/storage.rs
+++ b/swap/src/storage.rs
@@ -81,7 +81,7 @@ mod tests {
     use rand::rngs::OsRng;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
-    use xmr_btc::{cross_curve_dleq, curve25519_dalek, serde::monero_private_key};
+    use xmr_btc::{cross_curve_dleq, monero, serde::monero_private_key};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     pub struct TestState {
@@ -109,8 +109,7 @@ mod tests {
 
         let a = xmr_btc::bitcoin::SecretKey::new_random(&mut OsRng);
         let s_a = cross_curve_dleq::Scalar::random(&mut OsRng);
-        let s_b =
-            monero::PrivateKey::from_scalar(curve25519_dalek::scalar::Scalar::random(&mut OsRng));
+        let s_b = monero::PrivateKey::from_scalar(monero::Scalar::random(&mut OsRng));
         let v_a = xmr_btc::monero::PrivateViewKey::new_random(&mut OsRng);
         let S_a_monero = monero::PublicKey::from_private_key(&monero::PrivateKey {
             scalar: s_a.into_ed25519(),

--- a/xmr-btc/src/lib.rs
+++ b/xmr-btc/src/lib.rs
@@ -53,4 +53,3 @@ pub mod serde;
 pub mod transport;
 
 pub use cross_curve_dleq;
-pub use curve25519_dalek;

--- a/xmr-btc/src/serde.rs
+++ b/xmr-btc/src/serde.rs
@@ -70,7 +70,6 @@ pub mod monero_amount {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use curve25519_dalek::scalar::Scalar;
     use rand::rngs::OsRng;
     use serde::{Deserialize, Serialize};
 
@@ -82,7 +81,9 @@ mod tests {
 
     #[test]
     fn serde_monero_private_key() {
-        let key = MoneroPrivateKey(monero::PrivateKey::from_scalar(Scalar::random(&mut OsRng)));
+        let key = MoneroPrivateKey(monero::PrivateKey::from_scalar(
+            crate::monero::Scalar::random(&mut OsRng),
+        ));
         let encoded = serde_cbor::to_vec(&key).unwrap();
         let decoded: MoneroPrivateKey = serde_cbor::from_slice(&encoded).unwrap();
         assert_eq!(key, decoded);


### PR DESCRIPTION
Anything that needs to be re-exported by this crate from `curve25519_dalek` can be re-exported from the `monero` module. In
fact, the `Scalar` type was already being re-exported.

What do you think, @rishflab?