### PR TITLE
Add CLI config and remove conditional compile flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           cargo tomlfmt -d -p Cargo.toml
           cargo tomlfmt -d -p xmr-btc/Cargo.toml
           cargo tomlfmt -d -p monero-harness/Cargo.toml
+          cargo tomlfmt -d -p swap/Cargo.toml
 
       - name: Check code formatting
         run: cargo fmt --all -- --check

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -32,7 +32,8 @@ structopt = "0.3"
 tempfile = "3"
 time = "0.2"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "sync"] }
-torut = { version = "0.1", optional = true }
+#torut = { version = "0.1", optional = true }
+torut = { version = "0.1"}
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-core = "0.1"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }
@@ -49,6 +50,6 @@ spectral = "0.6"
 tempfile = "3"
 testcontainers = "0.10"
 
-[features]
-default = []
-tor = ["torut"]
+#[features]
+#default = []
+#tor = ["torut"]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -32,8 +32,7 @@ structopt = "0.3"
 tempfile = "3"
 time = "0.2"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "sync"] }
-#torut = { version = "0.1", optional = true }
-torut = { version = "0.1"}
+torut = { version = "0.1" }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-core = "0.1"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }
@@ -49,7 +48,3 @@ port_check = "0.1"
 spectral = "0.6"
 tempfile = "3"
 testcontainers = "0.10"
-
-#[features]
-#default = []
-#tor = ["torut"]

--- a/swap/src/alice.rs
+++ b/swap/src/alice.rs
@@ -44,8 +44,6 @@ pub async fn swap(
     bitcoin_wallet: Arc<bitcoin::Wallet>,
     monero_wallet: Arc<monero::Wallet>,
     listen: Multiaddr,
-    redeem_address: ::bitcoin::Address,
-    punish_address: ::bitcoin::Address,
     transport: SwapTransport,
     behaviour: Alice,
 ) -> Result<()> {
@@ -71,7 +69,6 @@ pub async fn swap(
 
     // TODO: For retry, use `backoff::ExponentialBackoff` in production as opposed
     // to `ConstantBackoff`.
-
     #[async_trait]
     impl ReceiveBitcoinRedeemEncsig for Network {
         async fn receive_bitcoin_redeem_encsig(&mut self) -> xmr_btc::bitcoin::EncryptedSignature {

--- a/swap/src/alice.rs
+++ b/swap/src/alice.rs
@@ -28,7 +28,6 @@ use crate::{
     network::{
         peer_tracker::{self, PeerTracker},
         request_response::AliceToBob,
-        transport,
         transport::SwapTransport,
         TokioExecutor,
     },

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use backoff::{backoff::Constant as ConstantBackoff, future::FutureOperation as _};
 use bitcoin::{util::psbt::PartiallySignedTransaction, Address, Transaction};
-use bitcoin_harness::{bitcoind_rpc::PsbtBase64, Bitcoind};
+use bitcoin_harness::bitcoind_rpc::PsbtBase64;
 use reqwest::Url;
 use tokio::time;
 use xmr_btc::bitcoin::{
@@ -20,8 +20,8 @@ pub const TX_LOCK_MINE_TIMEOUT: u64 = 3600;
 pub struct Wallet(pub bitcoin_harness::Wallet);
 
 impl Wallet {
-    pub async fn new(name: &str, url: &Url) -> Result<Self> {
-        let wallet = bitcoin_harness::Wallet::new(name, url.clone()).await?;
+    pub async fn new(name: &str, url: Url) -> Result<Self> {
+        let wallet = bitcoin_harness::Wallet::new(name, url).await?;
 
         Ok(Self(wallet))
     }
@@ -44,22 +44,6 @@ impl Wallet {
 
         Ok(fee)
     }
-}
-
-pub async fn make_wallet(
-    name: &str,
-    bitcoind: &Bitcoind<'_>,
-    fund_amount: Amount,
-) -> Result<Wallet> {
-    let wallet = Wallet::new(name, &bitcoind.node_url).await?;
-    let buffer = Amount::from_btc(1.0).unwrap();
-    let amount = fund_amount + buffer;
-
-    let address = wallet.0.new_address().await.unwrap();
-
-    bitcoind.mint(address, amount).await.unwrap();
-
-    Ok(wallet)
 }
 
 #[async_trait]

--- a/swap/src/bob.rs
+++ b/swap/src/bob.rs
@@ -27,7 +27,6 @@ use crate::{
     monero,
     network::{
         peer_tracker::{self, PeerTracker},
-        transport,
         transport::SwapTransport,
         TokioExecutor,
     },

--- a/swap/src/bob.rs
+++ b/swap/src/bob.rs
@@ -39,6 +39,7 @@ use xmr_btc::{
     monero::CreateWalletForOutput,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub async fn swap(
     bitcoin_wallet: Arc<bitcoin::Wallet>,
     monero_wallet: Arc<monero::Wallet>,

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -4,41 +4,32 @@ use url::Url;
 #[derive(structopt::StructOpt, Debug)]
 pub enum Options {
     Alice {
-        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
-        #[structopt(long = "sats")]
-        satoshis: u64,
-
         // /// Run the swap as Bob and try to swap this many XMR (in piconero).
         // #[structopt(long = "picos", conflicts_with = "sats"))]
         // pub piconeros: u64,
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
-        #[structopt(default_value = "127.0.0.1", long = "listen_addr")]
-        listen_addr: String,
+        #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "listen-addr")]
+        listen_addr: Multiaddr,
 
-        #[structopt(default_value = 9876, long = "list_port")]
-        listen_port: u16,
+        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
+        // #[cfg(feature = "tor")]
+        #[structopt(long = "tor-port")]
+        tor_port: Option<u16>,
     },
     Bob {
-        /// Alice's multitaddr (only required for Bob, Alice will autogenerate
-        /// one)
-        #[structopt(long = "alice_addr")]
-        alice_addr: Multiaddr,
-
         /// Run the swap as Bob and try to swap this many BTC (in satoshi).
         #[structopt(long = "sats")]
         satoshis: u64,
+
+        #[structopt(long = "alice-addr")]
+        alice_addr: Multiaddr,
 
         // /// Run the swap as Bob and try to swap this many XMR (in piconero).
         // #[structopt(long = "picos", conflicts_with = "sats"))]
         // pub piconeros: u64,
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
-        // #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "dial")]
-        // alice_addr: String,
-        #[cfg(feature = "tor")]
-        #[structopt(long = "tor")]
-        tor_port: u16,
     },
 }

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -8,6 +8,9 @@ pub enum Options {
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
+        #[structopt(default_value = "http://127.0.0.1:18083", long = "monerod")]
+        monerod_url: Url,
+
         #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "listen-addr")]
         listen_addr: Multiaddr,
 
@@ -23,6 +26,9 @@ pub enum Options {
 
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
+
+        #[structopt(default_value = "http://127.0.0.1:18083", long = "monerod")]
+        monerod_url: Url,
 
         #[structopt(long = "tor")]
         tor: bool,

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -2,6 +2,7 @@ use libp2p::core::Multiaddr;
 use url::Url;
 
 #[derive(structopt::StructOpt, Debug)]
+#[structopt(name = "xmr-btc-swap", about = "Trustless XMR BTC swaps")]
 pub enum Options {
     Alice {
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
@@ -22,5 +23,8 @@ pub enum Options {
 
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
+
+        #[structopt(long = "tor")]
+        tor: bool,
     },
 }

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -4,31 +4,22 @@ use url::Url;
 #[derive(structopt::StructOpt, Debug)]
 pub enum Options {
     Alice {
-        // /// Run the swap as Bob and try to swap this many XMR (in piconero).
-        // #[structopt(long = "picos", conflicts_with = "sats"))]
-        // pub piconeros: u64,
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
         #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "listen-addr")]
         listen_addr: Multiaddr,
 
-        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
-        // #[cfg(feature = "tor")]
         #[structopt(long = "tor-port")]
         tor_port: Option<u16>,
     },
     Bob {
-        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
         #[structopt(long = "sats")]
         satoshis: u64,
 
         #[structopt(long = "alice-addr")]
         alice_addr: Multiaddr,
 
-        // /// Run the swap as Bob and try to swap this many XMR (in piconero).
-        // #[structopt(long = "picos", conflicts_with = "sats"))]
-        // pub piconeros: u64,
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
     },

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -1,19 +1,44 @@
+use libp2p::core::Multiaddr;
+use url::Url;
+
 #[derive(structopt::StructOpt, Debug)]
-pub struct Options {
-    /// Run the swap as Alice.
-    #[structopt(long = "as-alice")]
-    pub as_alice: bool,
+pub enum Options {
+    Alice {
+        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
+        #[structopt(long = "sats")]
+        satoshis: u64,
 
-    /// Run the swap as Bob and try to swap this many XMR (in piconero).
-    #[structopt(long = "picos")]
-    pub piconeros: Option<u64>,
+        // /// Run the swap as Bob and try to swap this many XMR (in piconero).
+        // #[structopt(long = "picos", conflicts_with = "sats"))]
+        // pub piconeros: u64,
+        #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
+        bitcoind_url: Url,
 
-    /// Run the swap as Bob and try to swap this many BTC (in satoshi).
-    #[structopt(long = "sats")]
-    pub satoshis: Option<u64>,
+        #[structopt(default_value = "127.0.0.1", long = "listen_addr")]
+        listen_addr: String,
 
-    /// Alice's onion multitaddr (only required for Bob, Alice will autogenerate
-    /// one)
-    #[structopt(long)]
-    pub alice_address: Option<String>,
+        #[structopt(default_value = 9876, long = "list_port")]
+        listen_port: u16,
+    },
+    Bob {
+        /// Alice's multitaddr (only required for Bob, Alice will autogenerate
+        /// one)
+        #[structopt(long = "alice_addr")]
+        alice_addr: Multiaddr,
+
+        /// Run the swap as Bob and try to swap this many BTC (in satoshi).
+        #[structopt(long = "sats")]
+        satoshis: u64,
+
+        // /// Run the swap as Bob and try to swap this many XMR (in piconero).
+        // #[structopt(long = "picos", conflicts_with = "sats"))]
+        // pub piconeros: u64,
+        #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
+        bitcoind_url: Url,
+        // #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "dial")]
+        // alice_addr: String,
+        #[cfg(feature = "tor")]
+        #[structopt(long = "tor")]
+        tor_port: u16,
+    },
 }

--- a/swap/src/lib.rs
+++ b/swap/src/lib.rs
@@ -7,7 +7,6 @@ pub mod bob;
 pub mod monero;
 pub mod network;
 pub mod storage;
-//#[cfg(feature = "tor")]
 pub mod tor;
 
 const REFUND_TIMELOCK: u32 = 10; // Relative timelock, this is number of blocks. TODO: What should it be?

--- a/swap/src/lib.rs
+++ b/swap/src/lib.rs
@@ -7,7 +7,7 @@ pub mod bob;
 pub mod monero;
 pub mod network;
 pub mod storage;
-#[cfg(feature = "tor")]
+//#[cfg(feature = "tor")]
 pub mod tor;
 
 const REFUND_TIMELOCK: u32 = 10; // Relative timelock, this is number of blocks. TODO: What should it be?

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
                     let onion_address_string = format!("/onion3/{}:{}", onion_address, tor_port);
                     let addr: Multiaddr = onion_address_string.parse()?;
                     let ac = create_tor_service(tor_secret_key, tor_port).await?;
-                    let transport = build_tor(local_key_pair, addr.clone(), tor_port)?;
+                    let transport = build_tor(local_key_pair, Some((addr.clone(), tor_port)))?;
                     (addr, Some(ac), transport)
                 }
                 None => {
@@ -88,13 +88,17 @@ async fn main() -> Result<()> {
             alice_addr,
             satoshis,
             bitcoind_url: url,
+            tor,
         } => {
             info!("running swap node as Bob ...");
 
             let behaviour = Bob::default();
             let local_key_pair = behaviour.identity();
 
-            let transport = build(local_key_pair)?;
+            let transport = match tor {
+                true => build_tor(local_key_pair, None)?,
+                false => build(local_key_pair)?,
+            };
 
             let bitcoin_wallet = Wallet::new("bob", &url)
                 .await

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -14,7 +14,7 @@
 
 use anyhow::Result;
 use futures::{channel::mpsc, StreamExt};
-use libp2p::core::Multiaddr;
+use libp2p::Multiaddr;
 use log::LevelFilter;
 use std::{io, io::Write, process, sync::Arc};
 use structopt::StructOpt;

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -41,7 +41,7 @@ use swap::{alice, bitcoin, bob, monero, Cmd, Rsp, SwapAmounts};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opt: Options = Options::from_args();
+    let opt = Options::from_args();
 
     trace::init_tracing(LevelFilter::Debug)?;
 
@@ -50,7 +50,6 @@ async fn main() -> Result<()> {
             bitcoind_url: url,
             listen_addr,
             tor_port,
-            ..
         } => {
             info!("running swap node as Alice ...");
 

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
             let behaviour = Alice::default();
             let local_key_pair = behaviour.identity();
 
-            let (listen_addr, ac, transport) = match tor_port {
+            let (listen_addr, _ac, transport) = match tor_port {
                 Some(tor_port) => {
                     let tor_secret_key = torut::onion::TorSecretKeyV3::generate();
                     let onion_address = tor_secret_key

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -5,6 +5,7 @@ use monero::{Address, Network, PrivateKey};
 use monero_harness::rpc::wallet;
 use std::{str::FromStr, time::Duration};
 
+use url::Url;
 pub use xmr_btc::monero::{
     Amount, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicKey, PublicViewKey,
     Transfer, TransferProof, TxHash, WatchForTransfer, *,
@@ -13,8 +14,8 @@ pub use xmr_btc::monero::{
 pub struct Wallet(pub wallet::Client);
 
 impl Wallet {
-    pub fn localhost(port: u16) -> Self {
-        Self(wallet::Client::localhost(port))
+    pub fn new(url: Url) -> Self {
+        Self(wallet::Client::new(url))
     }
 
     /// Get the balance of the primary account.

--- a/swap/src/network/transport.rs
+++ b/swap/src/network/transport.rs
@@ -5,7 +5,7 @@ use libp2p::{
         muxing::StreamMuxerBox,
         transport::Boxed,
         upgrade::{SelectUpgrade, Version},
-        Multiaddr, Transport,
+        Transport,
     },
     dns::DnsConfig,
     mplex::MplexConfig,
@@ -46,13 +46,15 @@ pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
 /// - multiplexing via yamux or mplex
 pub fn build_tor(
     id_keys: identity::Keypair,
-    addr: libp2p::core::Multiaddr,
-    port: u16,
+    address_port_pair: Option<(libp2p::core::Multiaddr, u16)>,
 ) -> Result<SwapTransport> {
     use libp2p_tokio_socks5::Socks5TokioTcpConfig;
     use std::collections::HashMap;
 
-    let map: HashMap<Multiaddr, u16> = [(addr, port)].iter().cloned().collect();
+    let mut map = HashMap::new();
+    if let Some((addr, port)) = address_port_pair {
+        map.insert(addr, port);
+    }
 
     let dh_keys = noise::Keypair::<X25519Spec>::new().into_authentic(&id_keys)?;
     let noise = NoiseConfig::xx(dh_keys).into_authenticated();

--- a/swap/src/network/transport.rs
+++ b/swap/src/network/transport.rs
@@ -18,7 +18,6 @@ use libp2p::{
 /// - DNS name resolution
 /// - authentication via noise
 /// - multiplexing via yamux or mplex
-/// #[cfg(not(feature = "tor"))]
 pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
     use libp2p::tcp::TokioTcpConfig;
 
@@ -45,7 +44,6 @@ pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
 /// - DNS name resolution
 /// - authentication via noise
 /// - multiplexing via yamux or mplex
-// #[cfg(feature = "tor")]
 pub fn build_tor(
     id_keys: identity::Keypair,
     addr: libp2p::core::Multiaddr,

--- a/swap/src/network/transport.rs
+++ b/swap/src/network/transport.rs
@@ -5,7 +5,7 @@ use libp2p::{
         muxing::StreamMuxerBox,
         transport::Boxed,
         upgrade::{SelectUpgrade, Version},
-        Transport,
+        Multiaddr, Transport,
     },
     dns::DnsConfig,
     mplex::MplexConfig,
@@ -18,7 +18,7 @@ use libp2p::{
 /// - DNS name resolution
 /// - authentication via noise
 /// - multiplexing via yamux or mplex
-#[cfg(not(feature = "tor"))]
+/// #[cfg(not(feature = "tor"))]
 pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
     use libp2p::tcp::TokioTcpConfig;
 
@@ -40,24 +40,21 @@ pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
 
     Ok(transport)
 }
-
 /// Builds a libp2p transport with Tor and with the following features:
 /// - TCP connection over the Tor network
 /// - DNS name resolution
 /// - authentication via noise
 /// - multiplexing via yamux or mplex
-#[cfg(feature = "tor")]
-pub fn build(
+// #[cfg(feature = "tor")]
+pub fn build_tor(
     id_keys: identity::Keypair,
-    address_port_pair: Option<(libp2p::core::Multiaddr, u16)>,
+    addr: libp2p::core::Multiaddr,
+    port: u16,
 ) -> Result<SwapTransport> {
     use libp2p_tokio_socks5::Socks5TokioTcpConfig;
     use std::collections::HashMap;
 
-    let mut map = HashMap::new();
-    if let Some((addr, port)) = address_port_pair {
-        map.insert(addr, port);
-    }
+    let map: HashMap<Multiaddr, u16> = [(addr, port)].iter().cloned().collect();
 
     let dh_keys = noise::Keypair::<X25519Spec>::new().into_authentic(&id_keys)?;
     let noise = NoiseConfig::xx(dh_keys).into_authenticated();


### PR DESCRIPTION
The hardcoded configuration was replaced with CLI
configuration options. CLI based config was chosen
over a config file as it does not access and clutter
the user's file system. By CLI options depend on whether
the program is run in Alice or Bob mode.

The tor conditional compile flags were removed by
extracting transport creation to the main statement. A tor
transport is created if Alice specifies a tor port using the CLI.