### PR TITLE
Attach binaries when doing CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,23 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   build_test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            skip_tests: true # Most likely do not work due to docker usage, TODO: add feature flag to allow unit tests
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Install and stop tor in case it was running
+        if: (matrix.os == 'ubuntu-latest' && !matrix.skip_tests)
         run: |
           sudo apt install software-properties-common
           sudo curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | sudo gpg --import
@@ -72,15 +82,16 @@ jobs:
 
       - name: Cache target directory
         uses: actions/cache@v1
+        if: matrix.os == 'ubuntu-latest'
         with:
           path: target
-          key: rust-${{ matrix.rust_toolchain }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cache ~/.cargo/registry directory
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: rust-${{ matrix.rust_toolchain }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cargo check release code with default features
         run: cargo check --workspace
@@ -89,6 +100,17 @@ jobs:
         run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
+        if: (!matrix.skip_tests)
         run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
+
+      - name: Build binary
+        run: |
+          cargo build -p swap --target ${{ matrix.target }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: swap-${{ matrix.target }}
+          path: target/${{ matrix.target }}/debug/swap


### PR DESCRIPTION
To make it easier to deploy the binary on a less powerful machine when
doing mainnet try outs.

Also add CI for mac os.