### PR TITLE
Adding peers manually could enhance privacy

### DIFF
--- a/docs/research/user-experience/xmr-btc-user-interface-validation.md
+++ b/docs/research/user-experience/xmr-btc-user-interface-validation.md
@@ -36,12 +36,12 @@ The questions are split between `M`aker (liquidity provider) and `T`aker (normal
 |   |  |  | configure Tor for trading | TM |
 |   |  | Do users care about P2P? | use a centralized service to find makers | TM |
 |   |  |  | user a decentralized service to find makers | TM |
+|   |  |  | add peers manually | TM |
 |  Software Setup | How does the user want to manage the swap software setup? | Is the user willing to download software? | download software (swap execution daemon) before being able to do a swap | T |
 |   |  | How does the user want to manage long-running tasks? | keep a GUI/CLI open for the whole length of the swap execution | T |
 |   |  |  | keep a computer running (that hosts the daemon) for the whole length of the swap execution | T |
 |   |  |  | keep the browser open for the whole length of a swap | T |
 |  Protocol | How important are protocol details to the user? | Does the user care about the incentives of each role? | have different steps (locking first vs second) depending on the direction of the swap | TM |
-
 ## Prototypes
 
 In the initial project description we distinguished product `A` a single market-maker product and product `B` a product including peer-to-peer discovery and multiple makers.
@@ -91,12 +91,12 @@ Example:
 |  configure Tor for trading | TM |  |  |  |  |
 |  use a centralized service to find makers | TM | T | T |  |  |
 |  user a decentralized service to find makers | TM |  |  |  |  |
+|  add peers manually | TM |  |  |  |  |
 |  download software (swap execution daemon) before being able to do a swap | T |  |  |  |  |
 |  keep a GUI/CLI open for the whole length of the swap execution | T |  |  | T | T |
 |  keep a computer running (that hosts the daemon) for the whole length of the swap execution | T | T | T | T | T |
 |  keep the browser open for the whole length of a swap | T |  |  |  |  |
 |  have different steps (locking first vs second) depending on the direction of the swap | TM |  |  | T (M) | T (M) |
-
 Legend:
 
 ```

--- a/docs/research/user-experience/xmr-btc-user-interface-validation.md
+++ b/docs/research/user-experience/xmr-btc-user-interface-validation.md
@@ -36,12 +36,15 @@ The questions are split between `M`aker (liquidity provider) and `T`aker (normal
 |   |  |  | configure Tor for trading | TM |
 |   |  | Do users care about P2P? | use a centralized service to find makers | TM |
 |   |  |  | user a decentralized service to find makers | TM |
+|   |  |  | discover peers automatically | TM |
 |   |  |  | add peers manually | TM |
 |  Software Setup | How does the user want to manage the swap software setup? | Is the user willing to download software? | download software (swap execution daemon) before being able to do a swap | T |
 |   |  | How does the user want to manage long-running tasks? | keep a GUI/CLI open for the whole length of the swap execution | T |
 |   |  |  | keep a computer running (that hosts the daemon) for the whole length of the swap execution | T |
 |   |  |  | keep the browser open for the whole length of a swap | T |
 |  Protocol | How important are protocol details to the user? | Does the user care about the incentives of each role? | have different steps (locking first vs second) depending on the direction of the swap | TM |
+
+
 ## Prototypes
 
 In the initial project description we distinguished product `A` a single market-maker product and product `B` a product including peer-to-peer discovery and multiple makers.
@@ -75,7 +78,7 @@ Example:
 |  run both his own Bitcoin and Monero node | TM | T | T |  |  |
 |  use a wallet that connects to third party nodes | TM |  |  |  |  |
 |  send signed transactions through third part nodes | TM |  |  |  |  |
-|  run his own blockchain full node | TM |  |  |  |  |
+|  run his own blockchain full node | TM | T | T |  |  |
 |  run an SPV node (Bitcoin) | TM |  |  |  |  |
 |  fund and redeem from existing wallets | TM | T | T |  |  |
 |  fund from existing Monero wallet, redeem to new Bitcoin wallet | TM |  |  |  |  |
@@ -91,12 +94,15 @@ Example:
 |  configure Tor for trading | TM |  |  |  |  |
 |  use a centralized service to find makers | TM | T | T |  |  |
 |  user a decentralized service to find makers | TM |  |  |  |  |
+|  discover peers automatically | TM |  |  |  |  |
 |  add peers manually | TM |  |  |  |  |
 |  download software (swap execution daemon) before being able to do a swap | T |  |  |  |  |
 |  keep a GUI/CLI open for the whole length of the swap execution | T |  |  | T | T |
 |  keep a computer running (that hosts the daemon) for the whole length of the swap execution | T | T | T | T | T |
 |  keep the browser open for the whole length of a swap | T |  |  |  |  |
 |  have different steps (locking first vs second) depending on the direction of the swap | TM |  |  | T (M) | T (M) |
+
+
 Legend:
 
 ```


### PR DESCRIPTION
This opens up different use cases and might preserve more privacy.
Validate if it is important for users to be able to control who to add (and how).