### PR TITLE
Revert "No need to send Monero transfer proof from Alice to Bob"

### DIFF
--- a/monero-harness/Cargo.toml
+++ b/monero-harness/Cargo.toml
@@ -18,7 +18,3 @@ testcontainers = "0.11"
 tokio = { version = "0.2", default-features = false, features = ["blocking", "macros", "rt-core", "time"] }
 tracing = "0.1"
 url = "2"
-
-[dev-dependencies]
-curve25519-dalek = "2"
-monero = "0.9"

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -136,7 +136,11 @@ impl<'c> Monero {
         monerod.start_miner(&miner_address).await?;
 
         tracing::info!("Waiting for miner wallet to catch up...");
-        miner_wallet.refresh().await?;
+        let block_height = monerod.client().get_block_count().await?;
+        miner_wallet
+            .wait_for_wallet_height(block_height)
+            .await
+            .unwrap();
 
         Ok(())
     }

--- a/monero-harness/src/rpc/wallet.rs
+++ b/monero-harness/src/rpc/wallet.rs
@@ -236,14 +236,14 @@ impl Client {
     pub async fn generate_from_keys(
         &self,
         address: &str,
-        spend_key: Option<&str>,
+        spend_key: &str,
         view_key: &str,
     ) -> Result<GenerateFromKeys> {
         let params = GenerateFromKeysParams {
             restore_height: 0,
             filename: view_key.into(),
             address: address.into(),
-            spendkey: spend_key.map(|sk| sk.into()),
+            spendkey: spend_key.into(),
             viewkey: view_key.into(),
             password: "".into(),
             autosave_current: true,
@@ -400,8 +400,7 @@ pub struct GenerateFromKeysParams {
     pub restore_height: u32,
     pub filename: String,
     pub address: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub spendkey: Option<String>,
+    pub spendkey: String,
     pub viewkey: String,
     pub password: String,
     pub autosave_current: bool,

--- a/monero-harness/tests/wallet.rs
+++ b/monero-harness/tests/wallet.rs
@@ -1,7 +1,4 @@
-use curve25519_dalek::scalar::Scalar;
-use monero::{Address, Network, PrivateKey, PublicKey};
 use monero_harness::Monero;
-use rand::rngs::OsRng;
 use spectral::prelude::*;
 use testcontainers::clients::Cli;
 
@@ -63,52 +60,4 @@ async fn fund_transfer_and_check_tx_key() {
         .expect("failed to check tx by key");
 
     assert_that!(res.received).is_equal_to(send_to_bob);
-}
-
-#[tokio::test]
-async fn load_watch_only_wallet() {
-    let tc = Cli::default();
-    let (monero, _containers) = Monero::new(&tc, None, vec!["watch-only".into()])
-        .await
-        .unwrap();
-    let miner_wallet = monero.wallet("miner").unwrap();
-
-    let (_spend_sk, spend_pk) = {
-        let scalar = Scalar::random(&mut OsRng);
-        let sk = PrivateKey::from_scalar(scalar);
-        let pk = PublicKey::from_private_key(&sk);
-
-        (sk, pk)
-    };
-    let (view_sk, view_pk) = {
-        let scalar = Scalar::random(&mut OsRng);
-        let sk = PrivateKey::from_scalar(scalar);
-        let pk = PublicKey::from_private_key(&sk);
-
-        (sk, pk)
-    };
-    let address = Address::standard(Network::Mainnet, spend_pk, view_pk);
-
-    let one_xmr = 1_000_000_000_000;
-
-    monero.init(Vec::new()).await.unwrap();
-
-    miner_wallet
-        .client()
-        .transfer(0, one_xmr, &address.to_string())
-        .await
-        .unwrap();
-
-    let watch_only_wallet = monero.wallet("watch-only").unwrap();
-
-    watch_only_wallet
-        .client()
-        .generate_from_keys(&address.to_string(), None, &view_sk.to_string())
-        .await
-        .unwrap();
-    watch_only_wallet.client().refresh().await.unwrap();
-
-    let balance = watch_only_wallet.client().get_balance(0).await.unwrap();
-
-    assert_eq!(balance, one_xmr);
 }

--- a/swap/src/alice.rs
+++ b/swap/src/alice.rs
@@ -45,13 +45,31 @@ use xmr_btc::{
 
 pub async fn swap(
     bitcoin_wallet: Arc<bitcoin::Wallet>,
-    monero_wallet: Arc<monero::Facade>,
+    monero_wallet: Arc<monero::Wallet>,
     db: Database,
     listen: Multiaddr,
     transport: SwapTransport,
     behaviour: Alice,
 ) -> Result<()> {
-    struct Network(Arc<Mutex<Swarm>>);
+    struct Network {
+        swarm: Arc<Mutex<Swarm>>,
+        channel: Option<ResponseChannel<AliceToBob>>,
+    }
+
+    impl Network {
+        pub async fn send_message2(&mut self, proof: monero::TransferProof) {
+            match self.channel.take() {
+                None => warn!("Channel not found, did you call this twice?"),
+                Some(channel) => {
+                    let mut guard = self.swarm.lock().await;
+                    guard.send_message2(channel, alice::Message2 {
+                        tx_lock_proof: proof,
+                    });
+                    info!("Sent transfer proof");
+                }
+            }
+        }
+    }
 
     // TODO: For retry, use `backoff::ExponentialBackoff` in production as opposed
     // to `ConstantBackoff`.
@@ -62,7 +80,7 @@ pub async fn swap(
             struct UnexpectedMessage;
 
             let encsig = (|| async {
-                let mut guard = self.0.lock().await;
+                let mut guard = self.swarm.lock().await;
                 let encsig = match guard.next().await {
                     OutEvent::Message3(msg) => msg.tx_redeem_encsig,
                     other => {
@@ -151,8 +169,11 @@ pub async fn swap(
     let msg = state2.next_message();
     swarm.send_message1(channel, msg);
 
-    let state3 = match swarm.next().await {
-        OutEvent::Message2(msg) => state2.receive(msg)?,
+    let (state3, channel) = match swarm.next().await {
+        OutEvent::Message2 { msg, channel } => {
+            let state3 = state2.receive(msg)?;
+            (state3, channel)
+        }
         other => panic!("Unexpected event: {:?}", other),
     };
 
@@ -162,12 +183,14 @@ pub async fn swap(
 
     info!("Handshake complete, we now have State3 for Alice.");
 
-    let network = Network(Arc::new(Mutex::new(swarm)));
+    let network = Arc::new(Mutex::new(Network {
+        swarm: Arc::new(Mutex::new(swarm)),
+        channel: Some(channel),
+    }));
 
     let mut action_generator = action_generator(
-        network,
+        network.clone(),
         bitcoin_wallet.clone(),
-        monero_wallet.clone(),
         state3.clone(),
         TX_LOCK_MINE_TIMEOUT,
     );
@@ -186,12 +209,16 @@ pub async fn swap(
                 db.insert_latest_state(swap_id, state::Alice::BtcLocked(state3.clone()).into())
                     .await?;
 
-                let _ = monero_wallet
+                let (transfer_proof, _) = monero_wallet
                     .transfer(public_spend_key, public_view_key, amount)
                     .await?;
 
                 db.insert_latest_state(swap_id, state::Alice::XmrLocked(state3.clone()).into())
                     .await?;
+
+                let mut guard = network.as_ref().lock().await;
+                guard.send_message2(transfer_proof).await;
+                info!("Sent transfer proof");
             }
 
             GeneratorState::Yielded(Action::RedeemBtc(tx)) => {
@@ -276,7 +303,10 @@ pub enum OutEvent {
         msg: bob::Message1,
         channel: ResponseChannel<AliceToBob>,
     },
-    Message2(bob::Message2),
+    Message2 {
+        msg: bob::Message2,
+        channel: ResponseChannel<AliceToBob>,
+    },
     Message3(bob::Message3),
 }
 
@@ -315,7 +345,7 @@ impl From<message1::OutEvent> for OutEvent {
 impl From<message2::OutEvent> for OutEvent {
     fn from(event: message2::OutEvent) -> Self {
         match event {
-            message2::OutEvent::Msg(msg) => OutEvent::Message2(msg),
+            message2::OutEvent::Msg { msg, channel } => OutEvent::Message2 { msg, channel },
         }
     }
 }
@@ -373,6 +403,16 @@ impl Alice {
     ) {
         self.message1.send(channel, msg);
         debug!("Sent Message1");
+    }
+
+    /// Send Message2 to Bob in response to receiving his Message2.
+    pub fn send_message2(
+        &mut self,
+        channel: ResponseChannel<AliceToBob>,
+        msg: xmr_btc::alice::Message2,
+    ) {
+        self.message2.send(channel, msg);
+        debug!("Sent Message2");
     }
 }
 

--- a/swap/src/bob.rs
+++ b/swap/src/bob.rs
@@ -1,15 +1,18 @@
 //! Run an XMR/BTC swap in the role of Bob.
 //! Bob holds BTC and wishes receive XMR.
 use anyhow::Result;
+use async_trait::async_trait;
+use backoff::{backoff::Constant as ConstantBackoff, future::FutureOperation as _};
 use futures::{
     channel::mpsc::{Receiver, Sender},
-    StreamExt,
+    FutureExt, StreamExt,
 };
 use genawaiter::GeneratorState;
 use libp2p::{core::identity::Keypair, Multiaddr, NetworkBehaviour, PeerId};
 use rand::rngs::OsRng;
-use std::{process, sync::Arc};
-use tracing::{debug, info};
+use std::{process, sync::Arc, time::Duration};
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 mod amounts;
@@ -34,14 +37,14 @@ use crate::{
 use xmr_btc::{
     alice,
     bitcoin::{BroadcastSignedTransaction, EncryptedSignature, SignTxLock},
-    bob::{self, action_generator, State0},
+    bob::{self, action_generator, ReceiveTransferProof, State0},
     monero::CreateWalletForOutput,
 };
 
 #[allow(clippy::too_many_arguments)]
 pub async fn swap(
     bitcoin_wallet: Arc<bitcoin::Wallet>,
-    monero_wallet: Arc<monero::Facade>,
+    monero_wallet: Arc<monero::Wallet>,
     db: Database,
     btc: u64,
     addr: Multiaddr,
@@ -50,6 +53,40 @@ pub async fn swap(
     transport: SwapTransport,
     behaviour: Bob,
 ) -> Result<()> {
+    struct Network(Swarm);
+
+    // TODO: For retry, use `backoff::ExponentialBackoff` in production as opposed
+    // to `ConstantBackoff`.
+
+    #[async_trait]
+    impl ReceiveTransferProof for Network {
+        async fn receive_transfer_proof(&mut self) -> monero::TransferProof {
+            #[derive(Debug)]
+            struct UnexpectedMessage;
+
+            let future = self.0.next().shared();
+
+            let proof = (|| async {
+                let proof = match future.clone().await {
+                    OutEvent::Message2(msg) => msg.tx_lock_proof,
+                    other => {
+                        warn!("Expected transfer proof, got: {:?}", other);
+                        return Err(backoff::Error::Transient(UnexpectedMessage));
+                    }
+                };
+
+                Result::<_, backoff::Error<UnexpectedMessage>>::Ok(proof)
+            })
+            .retry(ConstantBackoff::new(Duration::from_secs(1)))
+            .await
+            .expect("transient errors to be retried");
+
+            info!("Received transfer proof");
+
+            proof
+        }
+    }
+
     let mut swarm = new_swarm(transport, behaviour)?;
 
     libp2p::Swarm::dial_addr(&mut swarm, addr)?;
@@ -112,19 +149,13 @@ pub async fn swap(
         .await?;
 
     swarm.send_message2(alice.clone(), state2.next_message());
-    // NOTE: We must poll the swarm after `send_messageX` to actually trigger
-    // sending the message. This is really weird to me and has been a constant
-    // source of bugs. Is this the only way?
-    match swarm.next().await {
-        OutEvent::Message2 => {
-            debug!("Got message 3 response from Alice");
-        }
-        other => panic!("unexpected event: {:?}", other),
-    };
 
     info!("Handshake complete");
 
+    let network = Arc::new(Mutex::new(Network(swarm)));
+
     let mut action_generator = action_generator(
+        network.clone(),
         monero_wallet.clone(),
         bitcoin_wallet.clone(),
         state2.clone(),
@@ -151,14 +182,20 @@ pub async fn swap(
             GeneratorState::Yielded(bob::Action::SendBtcRedeemEncsig(tx_redeem_encsig)) => {
                 db.insert_latest_state(swap_id, state::Bob::XmrLocked(state2.clone()).into())
                     .await?;
-                swarm.send_message3(alice.clone(), tx_redeem_encsig);
-                match swarm.next().await {
+
+                let mut guard = network.as_ref().lock().await;
+                guard.0.send_message3(alice.clone(), tx_redeem_encsig);
+                info!("Sent Bitcoin redeem encsig");
+
+                // FIXME: Having to wait for Alice's response here is a big problem, because
+                // we're stuck if she doesn't send her response back. I believe this is
+                // currently necessary, so we may have to rework this and/or how we use libp2p
+                match guard.0.next().shared().await {
                     OutEvent::Message3 => {
-                        debug!("Got message 3 response from Alice");
+                        debug!("Got Message3 empty response");
                     }
                     other => panic!("unexpected event: {:?}", other),
                 };
-                info!("Sent Bitcoin redeem encsig");
             }
             GeneratorState::Yielded(bob::Action::CreateXmrWalletForOutput {
                 spend_key,
@@ -220,7 +257,7 @@ pub enum OutEvent {
     Amounts(SwapAmounts),
     Message0(alice::Message0),
     Message1(alice::Message1),
-    Message2,
+    Message2(alice::Message2),
     Message3,
 }
 
@@ -261,7 +298,7 @@ impl From<message1::OutEvent> for OutEvent {
 impl From<message2::OutEvent> for OutEvent {
     fn from(event: message2::OutEvent) -> Self {
         match event {
-            message2::OutEvent::Msg => OutEvent::Message2,
+            message2::OutEvent::Msg(msg) => OutEvent::Message2(msg),
         }
     }
 }

--- a/swap/src/bob/message2.rs
+++ b/swap/src/bob/message2.rs
@@ -11,14 +11,14 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::network::request_response::{AliceToBob, BobToAlice, Codec, Message2Protocol, TIMEOUT};
-use xmr_btc::bob;
+use xmr_btc::{alice, bob};
 
 #[derive(Debug)]
 pub enum OutEvent {
-    Msg,
+    Msg(alice::Message2),
 }
 
 /// A `NetworkBehaviour` that represents sending message 2 to Alice.
@@ -78,8 +78,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
                 message: RequestResponseMessage::Response { response, .. },
                 ..
             } => {
-                if let AliceToBob::Message2 = response {
-                    self.events.push_back(OutEvent::Msg);
+                if let AliceToBob::Message2(msg) = response {
+                    debug!("Received Message2");
+                    self.events.push_back(OutEvent::Msg(msg));
                 }
             }
             RequestResponseEvent::InboundFailure { error, .. } => {

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -2,15 +2,6 @@ use libp2p::core::Multiaddr;
 use url::Url;
 use uuid::Uuid;
 
-// TODO: Remove monero_watch_only_wallet_rpc_url options.
-//
-// We need an extra `monero-wallet-rpc` to monitor the shared output without
-// unloading the user's Monero wallet. A better approach than passing in an
-// extra argument (and requiring the user to start up 2 `monero-wallet-rpc`
-// instances), may be to start up another `monero-wallet-rpc` instance as
-// part of executing this binary (i.e. requiring `monero-wallet-rpc` to be in
-// the path).
-
 #[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "xmr-btc-swap", about = "Trustless XMR BTC swaps")]
 pub enum Options {
@@ -18,17 +9,8 @@ pub enum Options {
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
-        #[structopt(
-            default_value = "http://127.0.0.1:18083/json_rpc",
-            long = "monero_wallet_rpc"
-        )]
-        monero_wallet_rpc_url: Url,
-
-        #[structopt(
-            default_value = "http://127.0.0.1:18084",
-            long = "monero_watch_only_wallet_rpc"
-        )]
-        monero_watch_only_wallet_rpc_url: Url,
+        #[structopt(default_value = "http://127.0.0.1:18083/json_rpc", long = "monerod")]
+        monerod_url: Url,
 
         #[structopt(default_value = "/ip4/127.0.0.1/tcp/9876", long = "listen-addr")]
         listen_addr: Multiaddr,
@@ -46,17 +28,8 @@ pub enum Options {
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
-        #[structopt(
-            default_value = "http://127.0.0.1:18083/json_rpc",
-            long = "monero_wallet_rpc"
-        )]
-        monero_wallet_rpc_url: Url,
-
-        #[structopt(
-            default_value = "http://127.0.0.1:18084",
-            long = "monero_watch_only_wallet_rpc"
-        )]
-        monero_watch_only_wallet_rpc_url: Url,
+        #[structopt(default_value = "http://127.0.0.1:18083/json_rpc", long = "monerod")]
+        monerod_url: Url,
 
         #[structopt(long = "tor")]
         tor: bool,
@@ -69,16 +42,7 @@ pub enum Options {
         #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
         bitcoind_url: Url,
 
-        #[structopt(
-            default_value = "http://127.0.0.1:18083/json_rpc",
-            long = "monero_wallet_rpc"
-        )]
-        monero_wallet_rpc_url: Url,
-
-        #[structopt(
-            default_value = "http://127.0.0.1:18084",
-            long = "monero_watch_only_wallet_rpc"
-        )]
-        monero_watch_only_wallet_rpc_url: Url,
+        #[structopt(default_value = "http://127.0.0.1:18083/json_rpc", long = "monerod")]
+        monerod_url: Url,
     },
 }

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -53,8 +53,7 @@ async fn main() -> Result<()> {
     match opt {
         Options::Alice {
             bitcoind_url,
-            monero_wallet_rpc_url,
-            monero_watch_only_wallet_rpc_url,
+            monerod_url,
             listen_addr,
             tor_port,
         } => {
@@ -87,10 +86,7 @@ async fn main() -> Result<()> {
                 .expect("failed to create bitcoin wallet");
             let bitcoin_wallet = Arc::new(bitcoin_wallet);
 
-            let monero_wallet = Arc::new(monero::Facade::new(
-                monero_wallet_rpc_url,
-                monero_watch_only_wallet_rpc_url,
-            ));
+            let monero_wallet = Arc::new(monero::Wallet::new(monerod_url));
 
             swap_as_alice(
                 bitcoin_wallet,
@@ -106,8 +102,7 @@ async fn main() -> Result<()> {
             alice_addr,
             satoshis,
             bitcoind_url,
-            monero_wallet_rpc_url,
-            monero_watch_only_wallet_rpc_url,
+            monerod_url,
             tor,
         } => {
             info!("running swap node as Bob ...");
@@ -125,10 +120,7 @@ async fn main() -> Result<()> {
                 .expect("failed to create bitcoin wallet");
             let bitcoin_wallet = Arc::new(bitcoin_wallet);
 
-            let monero_wallet = Arc::new(monero::Facade::new(
-                monero_wallet_rpc_url,
-                monero_watch_only_wallet_rpc_url,
-            ));
+            let monero_wallet = Arc::new(monero::Wallet::new(monerod_url));
 
             swap_as_bob(
                 bitcoin_wallet,
@@ -156,15 +148,13 @@ async fn main() -> Result<()> {
         Options::Recover {
             swap_id,
             bitcoind_url,
-            monero_wallet_rpc_url,
-            monero_watch_only_wallet_rpc_url,
+            monerod_url,
         } => {
             let state = db.get_state(swap_id)?;
             let bitcoin_wallet = bitcoin::Wallet::new("bob", bitcoind_url)
                 .await
                 .expect("failed to create bitcoin wallet");
-            let monero_wallet =
-                monero::Facade::new(monero_wallet_rpc_url, monero_watch_only_wallet_rpc_url);
+            let monero_wallet = monero::Wallet::new(monerod_url);
 
             recover(bitcoin_wallet, monero_wallet, state).await?;
         }
@@ -193,7 +183,7 @@ async fn create_tor_service(
 
 async fn swap_as_alice(
     bitcoin_wallet: Arc<swap::bitcoin::Wallet>,
-    monero_wallet: Arc<swap::monero::Facade>,
+    monero_wallet: Arc<swap::monero::Wallet>,
     db: Database,
     addr: Multiaddr,
     transport: SwapTransport,
@@ -212,7 +202,7 @@ async fn swap_as_alice(
 
 async fn swap_as_bob(
     bitcoin_wallet: Arc<swap::bitcoin::Wallet>,
-    monero_wallet: Arc<swap::monero::Facade>,
+    monero_wallet: Arc<swap::monero::Wallet>,
     db: Database,
     sats: u64,
     alice: Multiaddr,

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -1,59 +1,54 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use backoff::{backoff::Constant as ConstantBackoff, future::FutureOperation as _};
-use futures::TryFutureExt;
-use monero::{Address, Network};
 use monero_harness::rpc::wallet;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 use url::Url;
-pub use xmr_btc::monero::{
-    Amount, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicKey, PublicViewKey,
-    Transfer, *,
-};
 
-pub struct Facade {
-    pub user_wallet: wallet::Client,
-    pub watch_only_wallet: wallet::Client,
-}
+pub use xmr_btc::monero::*;
 
-impl Facade {
-    pub fn new(user_url: Url, watch_only_url: Url) -> Self {
-        Self {
-            user_wallet: wallet::Client::new(user_url),
-            watch_only_wallet: wallet::Client::new(watch_only_url),
-        }
+pub struct Wallet(pub wallet::Client);
+
+impl Wallet {
+    pub fn new(url: Url) -> Self {
+        Self(wallet::Client::new(url))
     }
 
     /// Get the balance of the primary account.
     pub async fn get_balance(&self) -> Result<Amount> {
-        let amount = self.user_wallet.get_balance(0).await?;
+        let amount = self.0.get_balance(0).await?;
 
         Ok(Amount::from_piconero(amount))
     }
 }
 
 #[async_trait]
-impl Transfer for Facade {
+impl Transfer for Wallet {
     async fn transfer(
         &self,
         public_spend_key: PublicKey,
         public_view_key: PublicViewKey,
         amount: Amount,
-    ) -> Result<Amount> {
+    ) -> Result<(TransferProof, Amount)> {
         let destination_address =
             Address::standard(Network::Mainnet, public_spend_key, public_view_key.into());
 
         let res = self
-            .user_wallet
+            .0
             .transfer(0, amount.as_piconero(), &destination_address.to_string())
             .await?;
 
-        Ok(Amount::from_piconero(res.fee))
+        let tx_hash = TxHash(res.tx_hash);
+        let tx_key = PrivateKey::from_str(&res.tx_key)?;
+
+        let fee = Amount::from_piconero(res.fee);
+
+        Ok((TransferProof::new(tx_hash, tx_key), fee))
     }
 }
 
 #[async_trait]
-impl CreateWalletForOutput for Facade {
+impl CreateWalletForOutput for Wallet {
     async fn create_and_load_wallet_for_output(
         &self,
         private_spend_key: PrivateKey,
@@ -65,10 +60,10 @@ impl CreateWalletForOutput for Facade {
         let address = Address::standard(Network::Mainnet, public_spend_key, public_view_key);
 
         let _ = self
-            .user_wallet
+            .0
             .generate_from_keys(
                 &address.to_string(),
-                Some(&private_spend_key.to_string()),
+                &private_spend_key.to_string(),
                 &PrivateKey::from(private_view_key).to_string(),
             )
             .await?;
@@ -81,57 +76,57 @@ impl CreateWalletForOutput for Facade {
 // to `ConstantBackoff`.
 
 #[async_trait]
-impl WatchForTransfer for Facade {
+impl WatchForTransfer for Wallet {
     async fn watch_for_transfer(
         &self,
-        address: Address,
+        public_spend_key: PublicKey,
+        public_view_key: PublicViewKey,
+        transfer_proof: TransferProof,
         expected_amount: Amount,
-        private_view_key: PrivateViewKey,
-    ) {
-        let address = address.to_string();
-        let private_view_key = PrivateKey::from(private_view_key).to_string();
-        let load_address = || {
-            self.watch_only_wallet
-                .generate_from_keys(&address, None, &private_view_key)
-                .map_err(backoff::Error::Transient)
-        };
+        expected_confirmations: u32,
+    ) -> Result<(), InsufficientFunds> {
+        enum Error {
+            TxNotFound,
+            InsufficientConfirmations,
+            InsufficientFunds { expected: Amount, actual: Amount },
+        }
 
-        // QUESTION: Should we really retry every error?
-        load_address
-            .retry(ConstantBackoff::new(Duration::from_secs(1)))
-            .await
-            .expect("transient error is never returned");
+        let address = Address::standard(Network::Mainnet, public_spend_key, public_view_key.into());
 
-        // QUESTION: Should we retry this error at all?
-        let refresh = || {
-            self.watch_only_wallet
-                .refresh()
-                .map_err(backoff::Error::Transient)
-        };
-
-        refresh
-            .retry(ConstantBackoff::new(Duration::from_secs(1)))
-            .await
-            .expect("transient error is never returned");
-
-        let check_balance = || async {
-            let balance = self
-                .watch_only_wallet
-                .get_balance(0)
+        let res = (|| async {
+            // NOTE: Currently, this is conflating IO errors with the transaction not being
+            // in the blockchain yet, or not having enough confirmations on it. All these
+            // errors warrant a retry, but the strategy should probably differ per case
+            let proof = self
+                .0
+                .check_tx_key(
+                    &String::from(transfer_proof.tx_hash()),
+                    &transfer_proof.tx_key().to_string(),
+                    &address.to_string(),
+                )
                 .await
-                .map_err(|_| backoff::Error::Transient("io"))?;
-            let balance = Amount::from_piconero(balance);
+                .map_err(|_| backoff::Error::Transient(Error::TxNotFound))?;
 
-            if balance != expected_amount {
-                return Err(backoff::Error::Transient("insufficient funds"));
+            if proof.received != expected_amount.as_piconero() {
+                return Err(backoff::Error::Permanent(Error::InsufficientFunds {
+                    expected: expected_amount,
+                    actual: Amount::from_piconero(proof.received),
+                }));
             }
 
-            Ok(())
+            if proof.confirmations < expected_confirmations {
+                return Err(backoff::Error::Transient(Error::InsufficientConfirmations));
+            }
+
+            Ok(proof)
+        })
+        .retry(ConstantBackoff::new(Duration::from_secs(1)))
+        .await;
+
+        if let Err(Error::InsufficientFunds { expected, actual }) = res {
+            return Err(InsufficientFunds { expected, actual });
         };
 
-        check_balance
-            .retry(ConstantBackoff::new(Duration::from_secs(1)))
-            .await
-            .expect("transient error is never returned");
+        Ok(())
     }
 }

--- a/swap/src/network/request_response.rs
+++ b/swap/src/network/request_response.rs
@@ -40,7 +40,7 @@ pub enum AliceToBob {
     Amounts(SwapAmounts),
     Message0(alice::Message0),
     Message1(alice::Message1),
-    Message2, // empty response
+    Message2(alice::Message2),
     Message3, // empty response
 }
 

--- a/swap/src/recover.rs
+++ b/swap/src/recover.rs
@@ -29,8 +29,8 @@ use xmr_btc::bitcoin::{
 };
 
 pub async fn recover(
-    bitcoin_wallet: crate::bitcoin::Wallet,
-    monero_wallet: crate::monero::Facade,
+    bitcoin_wallet: bitcoin::Wallet,
+    monero_wallet: monero::Wallet,
     state: Swap,
 ) -> Result<()> {
     match state {
@@ -40,8 +40,8 @@ pub async fn recover(
 }
 
 pub async fn alice_recover(
-    bitcoin_wallet: crate::bitcoin::Wallet,
-    monero_wallet: crate::monero::Facade,
+    bitcoin_wallet: bitcoin::Wallet,
+    monero_wallet: monero::Wallet,
     state: Alice,
 ) -> Result<()> {
     match state {
@@ -368,7 +368,7 @@ pub async fn alice_recover(
 
 pub async fn bob_recover(
     bitcoin_wallet: crate::bitcoin::Wallet,
-    monero_wallet: crate::monero::Facade,
+    monero_wallet: crate::monero::Wallet,
     state: Bob,
 ) -> Result<()> {
     match state {

--- a/xmr-btc/src/alice/message.rs
+++ b/xmr-btc/src/alice/message.rs
@@ -9,6 +9,7 @@ use crate::{bitcoin, monero};
 pub enum Message {
     Message0(Message0),
     Message1(Message1),
+    Message2(Message2),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -28,8 +29,15 @@ pub struct Message1 {
     pub(crate) tx_refund_encsig: EncryptedSignature,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Message2 {
+    pub tx_lock_proof: monero::TransferProof,
+}
+
 impl_try_from_parent_enum!(Message0, Message);
 impl_try_from_parent_enum!(Message1, Message);
+impl_try_from_parent_enum!(Message2, Message);
 
 impl_from_child_enum!(Message0, Message);
 impl_from_child_enum!(Message1, Message);
+impl_from_child_enum!(Message2, Message);

--- a/xmr-btc/src/monero.rs
+++ b/xmr-btc/src/monero.rs
@@ -1,11 +1,14 @@
 use crate::serde::monero_private_key;
+use anyhow::Result;
 use async_trait::async_trait;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
 
 pub use curve25519_dalek::scalar::Scalar;
-pub use monero::{Address, Network, PrivateKey, PublicKey};
+pub use monero::*;
+
+pub const MIN_CONFIRMATIONS: u32 = 10;
 
 pub fn random_private_key<R: RngCore + CryptoRng>(rng: &mut R) -> PrivateKey {
     let scalar = Scalar::random(rng);
@@ -100,6 +103,35 @@ impl From<Amount> for u64 {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransferProof {
+    tx_hash: TxHash,
+    #[serde(with = "monero_private_key")]
+    tx_key: PrivateKey,
+}
+
+impl TransferProof {
+    pub fn new(tx_hash: TxHash, tx_key: PrivateKey) -> Self {
+        Self { tx_hash, tx_key }
+    }
+    pub fn tx_hash(&self) -> TxHash {
+        self.tx_hash.clone()
+    }
+    pub fn tx_key(&self) -> PrivateKey {
+        self.tx_key
+    }
+}
+
+// TODO: add constructor/ change String to fixed length byte array
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TxHash(pub String);
+
+impl From<TxHash> for String {
+    fn from(from: TxHash) -> Self {
+        from.0
+    }
+}
+
 #[async_trait]
 pub trait Transfer {
     async fn transfer(
@@ -107,17 +139,19 @@ pub trait Transfer {
         public_spend_key: PublicKey,
         public_view_key: PublicViewKey,
         amount: Amount,
-    ) -> anyhow::Result<Amount>;
+    ) -> anyhow::Result<(TransferProof, Amount)>;
 }
 
 #[async_trait]
 pub trait WatchForTransfer {
     async fn watch_for_transfer(
         &self,
-        address: Address,
+        public_spend_key: PublicKey,
+        public_view_key: PublicViewKey,
+        transfer_proof: TransferProof,
         amount: Amount,
-        private_view_key: PrivateViewKey,
-    );
+        expected_confirmations: u32,
+    ) -> Result<(), InsufficientFunds>;
 }
 
 #[derive(Debug, Clone, Copy, thiserror::Error)]

--- a/xmr-btc/tests/e2e.rs
+++ b/xmr-btc/tests/e2e.rs
@@ -22,11 +22,9 @@ mod tests {
     #[tokio::test]
     async fn happy_path() {
         let cli = Cli::default();
-        let (monero, _container) = Monero::new(&cli, None, vec![
+        let (monero, _container) = Monero::new(&cli, Some("hp".to_string()), vec![
             "alice".to_string(),
-            "alice-watch-only".to_string(),
             "bob".to_string(),
-            "bob-watch-only".to_string(),
         ])
         .await
         .unwrap();
@@ -99,11 +97,9 @@ mod tests {
     #[tokio::test]
     async fn both_refund() {
         let cli = Cli::default();
-        let (monero, _container) = Monero::new(&cli, None, vec![
+        let (monero, _container) = Monero::new(&cli, Some("br".to_string()), vec![
             "alice".to_string(),
-            "alice-watch-only".to_string(),
             "bob".to_string(),
-            "bob-watch-only".to_string(),
         ])
         .await
         .unwrap();
@@ -178,11 +174,9 @@ mod tests {
     #[tokio::test]
     async fn alice_punishes() {
         let cli = Cli::default();
-        let (monero, _container) = Monero::new(&cli, None, vec![
+        let (monero, _containers) = Monero::new(&cli, Some("ap".to_string()), vec![
             "alice".to_string(),
-            "alice-watch-only".to_string(),
             "bob".to_string(),
-            "bob-watch-only".to_string(),
         ])
         .await
         .unwrap();

--- a/xmr-btc/tests/harness/mod.rs
+++ b/xmr-btc/tests/harness/mod.rs
@@ -135,14 +135,8 @@ pub async fn init_test(
         .await
         .unwrap();
 
-    let alice_monero_wallet = wallet::monero::Wallet {
-        inner: monero.wallet("alice").unwrap().client(),
-        watch_only: monero.wallet("alice-watch-only").unwrap().client(),
-    };
-    let bob_monero_wallet = wallet::monero::Wallet {
-        inner: monero.wallet("bob").unwrap().client(),
-        watch_only: monero.wallet("bob-watch-only").unwrap().client(),
-    };
+    let alice_monero_wallet = wallet::monero::Wallet(monero.wallet("alice").unwrap().client());
+    let bob_monero_wallet = wallet::monero::Wallet(monero.wallet("bob").unwrap().client());
 
     let alice_btc_wallet = wallet::bitcoin::Wallet::new("alice", &bitcoind.node_url)
         .await


### PR DESCRIPTION
The original PR replaced the transfer proof message from Alice to Bob with a watch-only Monero wallet to watch for Alice's Xmr transfer (I am not sure about the details).

I merged this PR but forgot to update my fork (still getting used to fork based dev..). We ended up developing https://github.com/comit-network/xmr-btc-swap/pull/41 without this PR. I think it will be easier to revert this PR for now and reintroduce it once https://github.com/comit-network/xmr-btc-swap/pull/41 is merged instead of rebasing that PR. 

Additionally, this PR requires 2 XMR wallets to function which might be a bit more complicated that sending a message containing the transfer.