### PR TITLE
Punish Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
+          RUST_MIN_STACK: 100000000000
 
       - name: Build binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
-          RUST_MIN_STACK: 100000000000
+          RUST_MIN_STACK: 10000000
 
       - name: Build binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "bitcoin",
  "bitcoin-harness",
  "conquer-once",
+ "conquer-once",
  "derivative",
  "ecdsa_fun",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,7 +3369,6 @@ dependencies = [
  "bitcoin",
  "bitcoin-harness",
  "conquer-once",
- "conquer-once",
  "derivative",
  "ecdsa_fun",
  "futures",

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -24,7 +24,8 @@ use futures::{
 };
 use libp2p::request_response::ResponseChannel;
 use rand::{CryptoRng, RngCore};
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
+use tracing::info;
 use xmr_btc::{
     alice::State3,
     bitcoin::{TransactionBlockHeight, TxCancel, TxRefund, WatchForRawTransaction},
@@ -86,328 +87,377 @@ pub enum AliceState {
     SafelyAborted,
 }
 
-pub async fn swap<R>(
+impl fmt::Display for AliceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AliceState::Started { .. } => write!(f, "started"),
+            AliceState::Negotiated { .. } => write!(f, "negotiated"),
+            AliceState::BtcLocked { .. } => write!(f, "btc_locked"),
+            AliceState::XmrLocked { .. } => write!(f, "xmr_locked"),
+            AliceState::EncSignLearned { .. } => write!(f, "encsig_sent"),
+            AliceState::BtcRedeemed => write!(f, "btc_redeemed"),
+            AliceState::BtcCancelled { .. } => write!(f, "btc_cancelled"),
+            AliceState::BtcRefunded { .. } => write!(f, "btc_refunded"),
+            AliceState::Punished => write!(f, "punished"),
+            AliceState::SafelyAborted => write!(f, "safely_aborted"),
+            AliceState::BtcPunishable { .. } => write!(f, "btc_punishable"),
+            AliceState::XmrRefunded => write!(f, "xmr_refunded"),
+            AliceState::WaitingToCancel { .. } => write!(f, "waiting_to_cancel"),
+        }
+    }
+}
+
+pub async fn swap(
     state: AliceState,
     swarm: Swarm,
     bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
     monero_wallet: Arc<crate::monero::Wallet>,
-) -> Result<AliceState>
-    where
-        R: RngCore + CryptoRng + Send,
-{
-    run_until(state, is_complete, swarm, bitcoin_wallet, monero_wallet).await
+    config: Config,
+) -> Result<(AliceState, Swarm)> {
+    run_until(
+        state,
+        is_complete,
+        swarm,
+        bitcoin_wallet,
+        monero_wallet,
+        config,
+    )
+    .await
 }
 
 // TODO: use macro or generics
 pub fn is_complete(state: &AliceState) -> bool {
-    matches!(state,  AliceState::XmrRefunded| AliceState::BtcRedeemed | AliceState::Punished | AliceState::SafelyAborted)
+    matches!(
+        state,
+        AliceState::XmrRefunded
+            | AliceState::BtcRedeemed
+            | AliceState::Punished
+            | AliceState::SafelyAborted
+    )
 }
 
+pub fn is_xmr_locked(state: &AliceState) -> bool {
+    matches!(
+        state,
+        AliceState::XmrLocked{..}
+    )
+}
 
 // State machine driver for swap execution
 #[async_recursion]
 pub async fn run_until(
     state: AliceState,
-    is_state: fn(&AliceState) -> bool,
+    is_target_state: fn(&AliceState) -> bool,
     mut swarm: Swarm,
     bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
     monero_wallet: Arc<crate::monero::Wallet>,
     config: Config,
-) -> Result<AliceState> {
-    if is_state(&state) {
-        Ok(state)
+) -> Result<(AliceState, Swarm)> {
+    info!("{}", state);
+    if is_target_state(&state) {
+        Ok((state, swarm))
     } else {
         match state {
-        AliceState::Started {
-            amounts,
-            a,
-            s_a,
-            v_a,
-        } => {
-            let (channel, state3) = negotiate(
+            AliceState::Started {
                 amounts,
                 a,
                 s_a,
                 v_a,
-                &mut swarm,
-                bitcoin_wallet.clone(),
-                config,
-            )
-            .await?;
-
-            run_until(
-                AliceState::Negotiated {
-                    channel,
+            } => {
+                let (channel, state3) = negotiate(
                     amounts,
-                    state3,
-                },
-                is_state,
-                swarm,
-                bitcoin_wallet,
-                monero_wallet,
-                config,
-            )
-            .await
-        }
-        AliceState::Negotiated {
-            state3,
-            channel,
-            amounts,
-        } => {
-            let _ = wait_for_locked_bitcoin(state3.tx_lock.txid(), bitcoin_wallet.clone(), config)
+                    a,
+                    s_a,
+                    v_a,
+                    &mut swarm,
+                    bitcoin_wallet.clone(),
+                    config,
+                )
                 .await?;
 
-            run_until(
-                AliceState::BtcLocked {
-                    channel,
-                    amounts,
-                    state3,
-                },
-                is_state,
-                swarm,
-                bitcoin_wallet,
-                monero_wallet,
-                config,
-            )
-            .await
-        }
-        AliceState::BtcLocked {
-            channel,
-            amounts,
-            state3,
-        } => {
-            lock_xmr(
+                run_until(
+                    AliceState::Negotiated {
+                        channel,
+                        amounts,
+                        state3,
+                    },
+                    is_target_state,
+                    swarm,
+                    bitcoin_wallet,
+                    monero_wallet,
+                    config,
+                )
+                .await
+            }
+            AliceState::Negotiated {
+                state3,
                 channel,
                 amounts,
-                state3.clone(),
-                &mut swarm,
-                monero_wallet.clone(),
-            )
-            .await?;
+            } => {
+                let _ =
+                    wait_for_locked_bitcoin(state3.tx_lock.txid(), bitcoin_wallet.clone(), config)
+                        .await?;
 
-            run_until(
-                AliceState::XmrLocked { state3 },
-                is_state,
-                swarm,
-                bitcoin_wallet,
-                monero_wallet,
-                config,
-            )
-            .await
-        }
-        AliceState::XmrLocked { state3 } => {
-            // Our Monero is locked, we need to go through the cancellation process if this
-            // step fails
-            match wait_for_bitcoin_encrypted_signature(&mut swarm).await {
-                Ok(encrypted_signature) => {
-                    run_until(
-                        AliceState::EncSignLearned {
-                            state3,
-                            encrypted_signature,
-                        },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet,
-                        monero_wallet,
-                        config,
-                    )
-                    .await
-                }
-                Err(_) => {
-                    run_until(
-                        AliceState::WaitingToCancel { state3 },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet,
-                        monero_wallet,
-                        config,
-                    )
-                    .await
+                run_until(
+                    AliceState::BtcLocked {
+                        channel,
+                        amounts,
+                        state3,
+                    },
+                    is_target_state,
+                    swarm,
+                    bitcoin_wallet,
+                    monero_wallet,
+                    config,
+                )
+                .await
+            }
+            AliceState::BtcLocked {
+                channel,
+                amounts,
+                state3,
+            } => {
+                lock_xmr(
+                    channel,
+                    amounts,
+                    state3.clone(),
+                    &mut swarm,
+                    monero_wallet.clone(),
+                )
+                .await?;
+
+                run_until(
+                    AliceState::XmrLocked { state3 },
+                    is_target_state,
+                    swarm,
+                    bitcoin_wallet,
+                    monero_wallet,
+                    config,
+                )
+                .await
+            }
+            AliceState::XmrLocked { state3 } => {
+                // Our Monero is locked, we need to go through the cancellation process if this
+                // step fails
+                match wait_for_bitcoin_encrypted_signature(
+                    &mut swarm,
+                    config.monero_max_finality_time,
+                )
+                .await
+                {
+                    Ok(encrypted_signature) => {
+                        run_until(
+                            AliceState::EncSignLearned {
+                                state3,
+                                encrypted_signature,
+                            },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet,
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
+                    Err(_) => {
+                        run_until(
+                            AliceState::WaitingToCancel { state3 },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet,
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
                 }
             }
-        }
-        AliceState::EncSignLearned {
-            state3,
-            encrypted_signature,
-        } => {
-            let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+            AliceState::EncSignLearned {
+                state3,
                 encrypted_signature,
-                &state3.tx_lock,
-                state3.a.clone(),
-                state3.s_a,
-                state3.B,
-                &state3.redeem_address,
-            ) {
-                Ok(tx) => tx,
-                Err(_) => {
-                    return run_until(
-                        AliceState::WaitingToCancel { state3 },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet,
-                        monero_wallet,
-                        config,
-                    )
+            } => {
+                let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+                    encrypted_signature,
+                    &state3.tx_lock,
+                    state3.a.clone(),
+                    state3.s_a,
+                    state3.B,
+                    &state3.redeem_address,
+                ) {
+                    Ok(tx) => tx,
+                    Err(_) => {
+                        return run_until(
+                            AliceState::WaitingToCancel { state3 },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet,
+                            monero_wallet,
+                            config,
+                        )
+                        .await;
+                    }
+                };
+
+                // TODO(Franck): Error handling is delicate here.
+                // If Bob sees this transaction he can redeem Monero
+                // e.g. If the Bitcoin node is down then the user needs to take action.
+                publish_bitcoin_redeem_transaction(
+                    signed_tx_redeem,
+                    bitcoin_wallet.clone(),
+                    config,
+                )
+                .await?;
+
+                run_until(
+                    AliceState::BtcRedeemed,
+                    is_target_state,
+                    swarm,
+                    bitcoin_wallet,
+                    monero_wallet,
+                    config,
+                )
+                .await
+            }
+            AliceState::WaitingToCancel { state3 } => {
+                let tx_cancel = publish_cancel_transaction(
+                    state3.tx_lock.clone(),
+                    state3.a.clone(),
+                    state3.B,
+                    state3.refund_timelock,
+                    state3.tx_cancel_sig_bob.clone(),
+                    bitcoin_wallet.clone(),
+                )
+                .await?;
+
+                run_until(
+                    AliceState::BtcCancelled { state3, tx_cancel },
+                    is_target_state,
+                    swarm,
+                    bitcoin_wallet,
+                    monero_wallet,
+                    config,
+                )
+                .await
+            }
+            AliceState::BtcCancelled { state3, tx_cancel } => {
+                let tx_cancel_height = bitcoin_wallet
+                    .transaction_block_height(tx_cancel.txid())
                     .await;
-                }
-            };
 
-            // TODO(Franck): Error handling is delicate here.
-            // If Bob sees this transaction he can redeem Monero
-            // e.g. If the Bitcoin node is down then the user needs to take action.
-            publish_bitcoin_redeem_transaction(signed_tx_redeem, bitcoin_wallet.clone(), config)
+                let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
+                    &tx_cancel,
+                    tx_cancel_height,
+                    state3.punish_timelock,
+                    &state3.refund_address,
+                    bitcoin_wallet.clone(),
+                )
                 .await?;
 
-            run_until(
-                AliceState::BtcRedeemed,
-                is_state,
-                swarm,
-                bitcoin_wallet,
-                monero_wallet,
-                config,
-            )
-            .await
-        }
-        AliceState::WaitingToCancel { state3 } => {
-            let tx_cancel = publish_cancel_transaction(
-                state3.tx_lock.clone(),
-                state3.a.clone(),
-                state3.B,
-                state3.refund_timelock,
-                state3.tx_cancel_sig_bob.clone(),
-                bitcoin_wallet.clone(),
-            )
-            .await?;
-
-            run_until(
-                AliceState::BtcCancelled { state3, tx_cancel },
-                is_state,
-                swarm,
-                bitcoin_wallet,
-                monero_wallet,
-                config,
-            )
-            .await
-        }
-        AliceState::BtcCancelled { state3, tx_cancel } => {
-            let tx_cancel_height = bitcoin_wallet
-                .transaction_block_height(tx_cancel.txid())
-                .await;
-
-            let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
-                &tx_cancel,
-                tx_cancel_height,
-                state3.punish_timelock,
-                &state3.refund_address,
-                bitcoin_wallet.clone(),
-            )
-            .await?;
-
-            // TODO(Franck): Review error handling
-            match published_refund_tx {
-                None => {
-                    run_until(
-                        AliceState::BtcPunishable { tx_refund, state3 },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet.clone(),
-                        monero_wallet,
-                        config,
-                    )
-                    .await
-                }
-                Some(published_refund_tx) => {
-                    run_until(
-                        AliceState::BtcRefunded {
-                            tx_refund,
-                            published_refund_tx,
-                            state3,
-                        },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet.clone(),
-                        monero_wallet,
-                        config,
-                    )
-                    .await
+                // TODO(Franck): Review error handling
+                match published_refund_tx {
+                    None => {
+                        run_until(
+                            AliceState::BtcPunishable { tx_refund, state3 },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet.clone(),
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
+                    Some(published_refund_tx) => {
+                        run_until(
+                            AliceState::BtcRefunded {
+                                tx_refund,
+                                published_refund_tx,
+                                state3,
+                            },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet.clone(),
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
                 }
             }
-        }
-        AliceState::BtcRefunded {
-            tx_refund,
-            published_refund_tx,
-            state3,
-        } => {
-            let spend_key = extract_monero_private_key(
-                published_refund_tx,
+            AliceState::BtcRefunded {
                 tx_refund,
-                state3.s_a,
-                state3.a.clone(),
-                state3.S_b_bitcoin,
-            )?;
-            let view_key = state3.v;
+                published_refund_tx,
+                state3,
+            } => {
+                let spend_key = extract_monero_private_key(
+                    published_refund_tx,
+                    tx_refund,
+                    state3.s_a,
+                    state3.a.clone(),
+                    state3.S_b_bitcoin,
+                )?;
+                let view_key = state3.v;
 
-            monero_wallet
-                .create_and_load_wallet_for_output(spend_key, view_key)
-                .await?;
+                monero_wallet
+                    .create_and_load_wallet_for_output(spend_key, view_key)
+                    .await?;
 
-            Ok(AliceState::XmrRefunded)
-        }
-        AliceState::BtcPunishable { tx_refund, state3 } => {
-            let signed_tx_punish = build_bitcoin_punish_transaction(
-                &state3.tx_lock,
-                state3.refund_timelock,
-                &state3.punish_address,
-                state3.punish_timelock,
-                state3.tx_punish_sig_bob.clone(),
-                state3.a.clone(),
-                state3.B,
-            )?;
+                Ok((AliceState::XmrRefunded, swarm))
+            }
+            AliceState::BtcPunishable { tx_refund, state3 } => {
+                let signed_tx_punish = build_bitcoin_punish_transaction(
+                    &state3.tx_lock,
+                    state3.refund_timelock,
+                    &state3.punish_address,
+                    state3.punish_timelock,
+                    state3.tx_punish_sig_bob.clone(),
+                    state3.a.clone(),
+                    state3.B,
+                )?;
 
-            let punish_tx_finalised = publish_bitcoin_punish_transaction(
-                signed_tx_punish,
-                bitcoin_wallet.clone(),
-                config,
-            );
+                let punish_tx_finalised = publish_bitcoin_punish_transaction(
+                    signed_tx_punish,
+                    bitcoin_wallet.clone(),
+                    config,
+                );
 
-            let refund_tx_seen = bitcoin_wallet.watch_for_raw_transaction(tx_refund.txid());
+                let refund_tx_seen = bitcoin_wallet.watch_for_raw_transaction(tx_refund.txid());
 
-            pin_mut!(punish_tx_finalised);
-            pin_mut!(refund_tx_seen);
+                pin_mut!(punish_tx_finalised);
+                pin_mut!(refund_tx_seen);
 
-            match select(punish_tx_finalised, refund_tx_seen).await {
-                Either::Left(_) => {
-                    run_until(
-                        AliceState::Punished,
-                        is_state,
-                        swarm,
-                        bitcoin_wallet.clone(),
-                        monero_wallet,
-                        config,
-                    )
-                    .await
-                }
-                Either::Right((published_refund_tx, _)) => {
-                    run_until(
-                        AliceState::BtcRefunded {
-                            tx_refund,
-                            published_refund_tx,
-                            state3,
-                        },
-                        is_state,
-                        swarm,
-                        bitcoin_wallet.clone(),
-                        monero_wallet,
-                        config,
-                    )
-                    .await
+                match select(punish_tx_finalised, refund_tx_seen).await {
+                    Either::Left(_) => {
+                        run_until(
+                            AliceState::Punished,
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet.clone(),
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
+                    Either::Right((published_refund_tx, _)) => {
+                        run_until(
+                            AliceState::BtcRefunded {
+                                tx_refund,
+                                published_refund_tx,
+                                state3,
+                            },
+                            is_target_state,
+                            swarm,
+                            bitcoin_wallet.clone(),
+                            monero_wallet,
+                            config,
+                        )
+                        .await
+                    }
                 }
             }
+            AliceState::XmrRefunded => Ok((AliceState::XmrRefunded, swarm)),
+            AliceState::BtcRedeemed => Ok((AliceState::BtcRedeemed, swarm)),
+            AliceState::Punished => Ok((AliceState::Punished, swarm)),
+            AliceState::SafelyAborted => Ok((AliceState::SafelyAborted, swarm)),
         }
-        AliceState::XmrRefunded => Ok(AliceState::XmrRefunded),
-        AliceState::BtcRedeemed => Ok(AliceState::BtcRedeemed),
-        AliceState::Punished => Ok(AliceState::Punished),
-        AliceState::SafelyAborted => Ok(AliceState::SafelyAborted),
-    }
     }
 }

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -125,7 +125,6 @@ pub async fn swap(
     .await
 }
 
-// TODO: use macro or generics
 pub fn is_complete(state: &AliceState) -> bool {
     matches!(
         state,
@@ -153,7 +152,7 @@ pub async fn run_until(
     monero_wallet: Arc<crate::monero::Wallet>,
     config: Config,
 ) -> Result<(AliceState, Swarm)> {
-    info!("{}", state);
+    info!("Current state:{}", state);
     if is_target_state(&state) {
         Ok((state, swarm))
     } else {

--- a/swap/src/bob/swap.rs
+++ b/swap/src/bob/swap.rs
@@ -76,7 +76,6 @@ where
     .await
 }
 
-// TODO: use macro or generics
 pub fn is_complete(state: &BobState) -> bool {
     matches!(
         state,
@@ -111,7 +110,7 @@ pub async fn run_until<R>(
 where
     R: RngCore + CryptoRng + Send,
 {
-    info!("{}", state);
+    info!("Current state: {}", state);
     if is_target_state(&state) {
         Ok(state)
     } else {
@@ -303,62 +302,3 @@ where
         }
     }
 }
-
-// // State machine driver for recovery execution
-// #[async_recursion]
-// pub async fn abort(state: BobState, io: Io) -> Result<BobState> {
-//     match state {
-//         BobState::Started => {
-//             // Nothing has been commited by either party, abort swap.
-//             abort(BobState::SafelyAborted, io).await
-//         }
-//         BobState::Negotiated => {
-//             // Nothing has been commited by either party, abort swap.
-//             abort(BobState::SafelyAborted, io).await
-//         }
-//         BobState::BtcLocked => {
-//             // Bob has locked BTC and must refund it
-//             // Bob waits for alice to publish TxRedeem or t1
-//             if unimplemented!("TxRedeemSeen") {
-//                 // Alice has redeemed revealing s_a
-//                 abort(BobState::BtcRedeemed, io).await
-//             } else if unimplemented!("T1Elapsed") {
-//                 // publish TxCancel or see if it has been published
-//                 abort(BobState::Cancelled, io).await
-//             } else {
-//                 Err(unimplemented!())
-//             }
-//         }
-//         BobState::XmrLocked => {
-//             // Alice has locked Xmr
-//             // Wait until t1
-//             if unimplemented!(">t1 and <t2") {
-//                 // Bob publishes TxCancel
-//                 abort(BobState::Cancelled, io).await
-//             } else {
-//                 // >t2
-//                 // submit TxCancel
-//                 abort(BobState::Punished, io).await
-//             }
-//         }
-//         BobState::Cancelled => {
-//             // Bob has cancelled the swap
-//             // If <t2 Bob refunds
-//             if unimplemented!("<t2") {
-//                 // Submit TxRefund
-//                 abort(BobState::BtcRefunded, io).await
-//             } else {
-//                 // Bob failed to refund in time and has been punished
-//                 abort(BobState::Punished, io).await
-//             }
-//         }
-//         BobState::BtcRedeemed => {
-//             // Bob uses revealed s_a to redeem XMR
-//             abort(BobState::XmrRedeemed, io).await
-//         }
-//         BobState::BtcRefunded => Ok(BobState::BtcRefunded),
-//         BobState::Punished => Ok(BobState::Punished),
-//         BobState::SafelyAborted => Ok(BobState::SafelyAborted),
-//         BobState::XmrRedeemed => Ok(BobState::XmrRedeemed),
-//     }
-// }

--- a/swap/tests/e2e.rs
+++ b/swap/tests/e2e.rs
@@ -161,32 +161,18 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         Uuid::new_v4(),
     );
 
-    let alice_xmr_locked_fut = alice::swap::run_until(
+    let alice_fut = alice::swap::swap(
         alice_state,
-        alice::swap::is_xmr_locked,
         alice_swarm,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),
         Config::regtest(),
     );
 
-    // Wait until alice has locked xmr and bob has locked btc
-    let ((alice_state, alice_swarm), _bob_state) =
-        try_join(alice_xmr_locked_fut, bob_xmr_locked_fut)
-            .await
-            .unwrap();
+    // Wait until alice has locked xmr and bob h  as locked btc
+    let ((alice_state, _), _bob_state) = try_join(alice_fut, bob_xmr_locked_fut).await.unwrap();
 
-    let (punished, _) = alice::swap::swap(
-        alice_state,
-        alice_swarm,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        Config::regtest(),
-    )
-    .await
-    .unwrap();
-
-    assert!(matches!(punished, AliceState::Punished));
+    assert!(matches!(alice_state, AliceState::Punished));
 
     // todo: Add balance assertions
 }

--- a/swap/tests/e2e.rs
+++ b/swap/tests/e2e.rs
@@ -10,9 +10,9 @@ use swap::{
 };
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
+use tracing_subscriber::util::SubscriberInitExt as _;
 use uuid::Uuid;
 use xmr_btc::{bitcoin, config::Config, cross_curve_dleq};
-use tracing_subscriber::util::SubscriberInitExt as _;
 
 /// Run the following tests with RUST_MIN_STACK=10000000
 
@@ -109,7 +109,6 @@ async fn happy_path() {
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-
     let _guard = tracing_subscriber::fmt()
         .with_env_filter("trace,hyper=warn")
         .set_default();

--- a/swap/tests/e2e.rs
+++ b/swap/tests/e2e.rs
@@ -36,14 +36,20 @@ async fn happy_path() {
     let xmr_alice = xmr * 10;
     let xmr_bob = 0;
 
-    let (
-        alice_state,
-        alice_swarm,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_peer_id,
-        alice_multiaddr,
-    ) = init_alice(&bitcoind, &monero, btc, btc_alice, xmr, xmr_alice).await;
+    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9876"
+        .parse()
+        .expect("failed to parse Alice's address");
+
+    let (alice_state, alice_swarm, alice_btc_wallet, alice_xmr_wallet, alice_peer_id) = init_alice(
+        &bitcoind,
+        &monero,
+        btc,
+        btc_alice,
+        xmr,
+        xmr_alice,
+        alice_multiaddr.clone(),
+    )
+    .await;
 
     let (bob_state, bob_swarm, bob_btc_wallet, bob_xmr_wallet, bob_db) = init_bob(
         alice_multiaddr,
@@ -117,20 +123,18 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
     let alice_btc_starting_balance = bitcoin::Amount::ZERO;
     let alice_xmr_starting_balance = xmr_to_swap * 10;
 
-    let (
-        alice_state,
-        alice_swarm,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_peer_id,
-        alice_multiaddr,
-    ) = init_alice(
+    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9877"
+        .parse()
+        .expect("failed to parse Alice's address");
+
+    let (alice_state, alice_swarm, alice_btc_wallet, alice_xmr_wallet, alice_peer_id) = init_alice(
         &bitcoind,
         &monero,
         btc_to_swap,
         alice_btc_starting_balance,
         xmr_to_swap,
         alice_xmr_starting_balance,
+        alice_multiaddr.clone(),
     )
     .await;
 
@@ -195,13 +199,13 @@ async fn init_alice(
     _btc_starting_balance: bitcoin::Amount,
     xmr_to_swap: u64,
     xmr_starting_balance: u64,
+    alice_multiaddr: Multiaddr,
 ) -> (
     AliceState,
     alice::Swarm,
     Arc<swap::bitcoin::Wallet>,
     Arc<swap::monero::Wallet>,
     PeerId,
-    Multiaddr,
 ) {
     monero
         .init(vec![("alice", xmr_starting_balance)])
@@ -239,12 +243,7 @@ async fn init_alice(
         }
     };
 
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9876"
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let alice_swarm =
-        alice::new_swarm(alice_multiaddr.clone(), alice_transport, alice_behaviour).unwrap();
+    let alice_swarm = alice::new_swarm(alice_multiaddr, alice_transport, alice_behaviour).unwrap();
 
     (
         alice_state,
@@ -252,7 +251,6 @@ async fn init_alice(
         alice_btc_wallet,
         alice_xmr_wallet,
         alice_peer_id,
-        alice_multiaddr,
     )
 }
 

--- a/swap/tests/e2e.rs
+++ b/swap/tests/e2e.rs
@@ -33,7 +33,7 @@ async fn happy_path() {
     // this xmr value matches the logic of alice::calculate_amounts i.e. btc *
     // 10_000 * 100
     let xmr_to_swap = xmr_btc::monero::Amount::from_piconero(1_000_000_000_000);
-    let xmr_alice = xmr_to_swap * xmr_btc::monero::Amount::from_piconero(10);
+    let xmr_alice = xmr_to_swap * 10;
     let xmr_bob = xmr_btc::monero::Amount::from_piconero(0);
 
     let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9876"
@@ -121,7 +121,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
     let bob_xmr_starting_balance = xmr_btc::monero::Amount::from_piconero(0);
 
     let alice_btc_starting_balance = bitcoin::Amount::ZERO;
-    let alice_xmr_starting_balance = xmr_to_swap * xmr_btc::monero::Amount::from_piconero(10);
+    let alice_xmr_starting_balance = xmr_to_swap * 10;
 
     let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9877"
         .parse()

--- a/swap/tests/e2e.rs
+++ b/swap/tests/e2e.rs
@@ -13,7 +13,7 @@ use testcontainers::clients::Cli;
 use uuid::Uuid;
 use xmr_btc::{bitcoin, config::Config, cross_curve_dleq};
 
-/// Run the following tests with RUST_MIN_STACK=100000000000
+/// Run the following tests with RUST_MIN_STACK=10000000
 
 #[tokio::test]
 async fn happy_path() {

--- a/xmr-btc/src/bob.rs
+++ b/xmr-btc/src/bob.rs
@@ -799,6 +799,9 @@ impl State4 {
         t1_timeout.await;
         Ok(())
     }
+    pub fn tx_lock_id(&self) -> bitcoin::Txid {
+        self.tx_lock.txid()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/xmr-btc/src/config.rs
+++ b/xmr-btc/src/config.rs
@@ -15,7 +15,9 @@ impl Config {
             bob_time_to_act: *mainnet::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: mainnet::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *mainnet::BITCOIN_AVG_BLOCK_TIME,
-            monero_max_finality_time: *mainnet::MONERO_AVG_BLOCK_TIME
+            // We apply a scaling factor (1.5) so that the swap is not aborted when the
+            // blockchain is slow
+            monero_max_finality_time: (*mainnet::MONERO_AVG_BLOCK_TIME).mul_f64(1.5)
                 * mainnet::MONERO_FINALITY_CONFIRMATIONS,
         }
     }
@@ -25,7 +27,9 @@ impl Config {
             bob_time_to_act: *regtest::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: regtest::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *regtest::BITCOIN_AVG_BLOCK_TIME,
-            monero_max_finality_time: *regtest::MONERO_AVG_BLOCK_TIME
+            // We apply a scaling factor (1.5) so that the swap is not aborted when the
+            // blockchain is slow
+            monero_max_finality_time: (*regtest::MONERO_AVG_BLOCK_TIME).mul_f64(1.5)
                 * regtest::MONERO_FINALITY_CONFIRMATIONS,
         }
     }
@@ -41,7 +45,7 @@ mod mainnet {
 
     pub static BITCOIN_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(10 * 60));
 
-    pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 10;
+    pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 15;
 
     pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(2 * 60));
 }
@@ -58,5 +62,5 @@ mod regtest {
 
     pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 1;
 
-    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(5));
+    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(60));
 }

--- a/xmr-btc/src/config.rs
+++ b/xmr-btc/src/config.rs
@@ -15,7 +15,8 @@ impl Config {
             bob_time_to_act: *mainnet::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: mainnet::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *mainnet::BITCOIN_AVG_BLOCK_TIME,
-            monero_max_finality_time: *mainnet::MONERO_MAX_FINALITY_TIME,
+            monero_max_finality_time: *mainnet::MONERO_AVG_BLOCK_TIME
+                * mainnet::MONERO_FINALITY_CONFIRMATIONS,
         }
     }
 
@@ -24,7 +25,8 @@ impl Config {
             bob_time_to_act: *regtest::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: regtest::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *regtest::BITCOIN_AVG_BLOCK_TIME,
-            monero_max_finality_time: *regtest::MONERO_MAX_FINALITY_TIME,
+            monero_max_finality_time: *regtest::MONERO_AVG_BLOCK_TIME
+                * regtest::MONERO_FINALITY_CONFIRMATIONS,
         }
     }
 }
@@ -39,20 +41,22 @@ mod mainnet {
 
     pub static BITCOIN_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(10 * 60));
 
-    pub static MONERO_MAX_FINALITY_TIME: Lazy<Duration> =
-        Lazy::new(|| Duration::from_secs_f64(15f64 * 1.5 * 2f64 * 60f64));
+    pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 10;
+
+    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(2 * 60));
 }
 
 mod regtest {
     use super::*;
 
-    // In test, set to 5 seconds to fail fast
+    // In test, we set a shorter time to fail fast
     pub static BOB_TIME_TO_ACT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(30));
 
     pub static BITCOIN_FINALITY_CONFIRMATIONS: u32 = 1;
 
     pub static BITCOIN_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(5));
 
-    pub static MONERO_MAX_FINALITY_TIME: Lazy<Duration> =
-        Lazy::new(|| Duration::from_secs_f64(60f64));
+    pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 1;
+
+    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(5));
 }

--- a/xmr-btc/src/config.rs
+++ b/xmr-btc/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub bob_time_to_act: Duration,
     pub bitcoin_finality_confirmations: u32,
     pub bitcoin_avg_block_time: Duration,
+    pub monero_max_finality_time: Duration,
 }
 
 impl Config {
@@ -14,6 +15,7 @@ impl Config {
             bob_time_to_act: *mainnet::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: mainnet::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *mainnet::BITCOIN_AVG_BLOCK_TIME,
+            monero_max_finality_time: *mainnet::MONERO_MAX_FINALITY_TIME,
         }
     }
 
@@ -22,6 +24,7 @@ impl Config {
             bob_time_to_act: *regtest::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: regtest::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *regtest::BITCOIN_AVG_BLOCK_TIME,
+            monero_max_finality_time: *regtest::MONERO_MAX_FINALITY_TIME,
         }
     }
 }
@@ -35,15 +38,21 @@ mod mainnet {
     pub static BITCOIN_FINALITY_CONFIRMATIONS: u32 = 3;
 
     pub static BITCOIN_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(10 * 60));
+
+    pub static MONERO_MAX_FINALITY_TIME: Lazy<Duration> =
+        Lazy::new(|| Duration::from_secs_f64(15f64 * 1.5 * 2f64 * 60f64));
 }
 
 mod regtest {
     use super::*;
 
     // In test, set to 5 seconds to fail fast
-    pub static BOB_TIME_TO_ACT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(10));
+    pub static BOB_TIME_TO_ACT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(30));
 
     pub static BITCOIN_FINALITY_CONFIRMATIONS: u32 = 1;
 
     pub static BITCOIN_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(5));
+
+    pub static MONERO_MAX_FINALITY_TIME: Lazy<Duration> =
+        Lazy::new(|| Duration::from_secs_f64(60f64));
 }

--- a/xmr-btc/src/monero.rs
+++ b/xmr-btc/src/monero.rs
@@ -97,11 +97,11 @@ impl Sub for Amount {
     }
 }
 
-impl Mul for Amount {
+impl Mul<u64> for Amount {
     type Output = Amount;
 
-    fn mul(self, rhs: Self) -> Self::Output {
-        Self(self.0 * rhs.0)
+    fn mul(self, rhs: u64) -> Self::Output {
+        Self(self.0 * rhs)
     }
 }
 

--- a/xmr-btc/src/monero.rs
+++ b/xmr-btc/src/monero.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Mul, Sub};
 
 pub use curve25519_dalek::scalar::Scalar;
 pub use monero::*;
@@ -94,6 +94,14 @@ impl Sub for Amount {
 
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0 - rhs.0)
+    }
+}
+
+impl Mul for Amount {
+    type Output = Amount;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0 * rhs.0)
     }
 }
 


### PR DESCRIPTION
Add unhappy path test for `alice_punishes` scenario. There is a todo to assert on balances as the rest of team needs the changes to the executor function asap and I am stuck on trying to get Alice's bitcoin balance to update. Alice successfully exit on the Punish state however.

Added functionality to allow the execution to exit and restart at a specified state to allow for such tests. The public API remains unchanged.