### PR TITLE
Allow returning XMR from monero::Amount as decimal-string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4192,7 @@ dependencies = [
  "monero-harness",
  "rand 0.7.3",
  "reqwest",
+ "rust_decimal",
  "serde",
  "serde_cbor",
  "sha2 0.9.2",

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -113,9 +113,8 @@ async fn main() -> Result<()> {
 
             let monero_wallet = monero::Wallet::new(monero_wallet_rpc_url);
             let monero_balance = monero_wallet.get_balance().await?;
-            // TODO: impl Display for monero wallet to display proper monero balance
             info!(
-                "Connection to Monero wallet succeeded, balance: {:?}",
+                "Connection to Monero wallet succeeded, balance: {}",
                 monero_balance
             );
             let monero_wallet = Arc::new(monero_wallet);
@@ -184,7 +183,7 @@ async fn main() -> Result<()> {
             let monero_wallet = monero::Wallet::new(monero_wallet_rpc_url);
             let monero_balance = monero_wallet.get_balance().await?;
             info!(
-                "Connection to Monero wallet succeeded, balance: {:?}",
+                "Connection to Monero wallet succeeded, balance: {}",
                 monero_balance
             );
             let monero_wallet = Arc::new(monero_wallet);

--- a/xmr-btc/Cargo.toml
+++ b/xmr-btc/Cargo.toml
@@ -20,6 +20,7 @@ genawaiter = "0.99.1"
 miniscript = { version = "4", features = ["serde"] }
 monero = { version = "0.9", features = ["serde_support"] }
 rand = "0.7"
+rust_decimal = "1.8"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.9"
 thiserror = "1"


### PR DESCRIPTION
This allows us to implement `Display` on `monero::Amount` that shows `XMR`.
We use `rust_decimal` to convert from piconeros to decimal-string.
`rust_decimal` uses `i64` internally, so only values within `i64` can be returned by `as_monero()`.
For `Display` either the result of `as_monero()` is returned, or the piconeros if `as_monero()` errors.

In the long run we could add `Denomination` similar to [rust bitcoin](https://docs.rs/bitcoin/0.25.2/src/bitcoin/util/amount.rs.html#209-244), but that is quite complex to add so I decided to go with this first implementation of `Display`. It will only fail for very large amounts larger than `9223372.036854775807` XMR, which should be rare...