### PR TITLE
Resume command and global database cl-parameter

### DIFF
--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -3,8 +3,17 @@ use url::Url;
 use uuid::Uuid;
 
 #[derive(structopt::StructOpt, Debug)]
+pub struct Options {
+    #[structopt(short = "db", long = "database", default_value = "./.swap-db/")]
+    pub db_path: String,
+
+    #[structopt(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "xmr-btc-swap", about = "Trustless XMR BTC swaps")]
-pub enum Options {
+pub enum Command {
     SellXmr {
         #[structopt(
             short = "b",
@@ -65,17 +74,34 @@ pub enum Options {
     },
     History,
     Resume {
-        #[structopt(required = true)]
+        #[structopt(short = "id", long = "swap-id")]
         swap_id: Uuid,
 
-        #[structopt(default_value = "http://127.0.0.1:8332", long = "bitcoind")]
+        #[structopt(
+            short = "b",
+            long = "bitcoind",
+            default_value = "http://127.0.0.1:8332"
+        )]
         bitcoind_url: Url,
-
-        #[structopt(default_value = "http://127.0.0.1:18083/json_rpc", long = "monerod")]
-        monerod_url: Url,
 
         #[structopt(short = "n", long = "bitcoin-wallet-name")]
         bitcoin_wallet_name: String,
+
+        #[structopt(
+            short = "m",
+            long = "monero-wallet-rpc",
+            default_value = "http://127.0.0.1:18083/json_rpc"
+        )]
+        monero_wallet_rpc_url: Url,
+
+        // TODO: The listen address is only relevant for Alice, but should be role independent
+        //  see: https://github.com/comit-network/xmr-btc-swap/issues/77
+        #[structopt(
+            short = "a",
+            long = "listen-addr",
+            default_value = "/ip4/127.0.0.1/tcp/9876"
+        )]
+        listen_addr: Multiaddr,
     },
 }
 

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 #[derive(structopt::StructOpt, Debug)]
 pub struct Options {
+    // TODO: Default value should points to proper configuration folder in home folder
     #[structopt(short = "db", long = "database", default_value = "./.swap-db/")]
     pub db_path: String,
 
@@ -12,12 +13,12 @@ pub struct Options {
 }
 
 #[derive(structopt::StructOpt, Debug)]
-#[structopt(name = "xmr-btc-swap", about = "Trustless XMR BTC swaps")]
+#[structopt(name = "xmr-btc-swap", about = "XMR BTC atomic swap")]
 pub enum Command {
     SellXmr {
         #[structopt(
             short = "b",
-            long = "bitcoind",
+            long = "bitcoind-rpc",
             default_value = "http://127.0.0.1:8332"
         )]
         bitcoind_url: Url,
@@ -34,7 +35,7 @@ pub enum Command {
 
         #[structopt(
             short = "a",
-            long = "listen-addr",
+            long = "p2p-address",
             default_value = "/ip4/127.0.0.1/tcp/9876"
         )]
         listen_addr: Multiaddr,
@@ -51,7 +52,7 @@ pub enum Command {
 
         #[structopt(
             short = "b",
-            long = "bitcoind",
+            long = "bitcoind-rpc",
             default_value = "http://127.0.0.1:8332"
         )]
         bitcoind_url: Url,
@@ -79,7 +80,7 @@ pub enum Command {
 
         #[structopt(
             short = "b",
-            long = "bitcoind",
+            long = "bitcoind-rpc",
             default_value = "http://127.0.0.1:8332"
         )]
         bitcoind_url: Url,
@@ -98,7 +99,7 @@ pub enum Command {
         //  see: https://github.com/comit-network/xmr-btc-swap/issues/77
         #[structopt(
             short = "a",
-            long = "listen-addr",
+            long = "p2p-address",
             default_value = "/ip4/127.0.0.1/tcp/9876"
         )]
         listen_addr: Multiaddr,

--- a/swap/src/storage.rs
+++ b/swap/src/storage.rs
@@ -39,7 +39,7 @@ impl Database {
         let encoded = self
             .0
             .get(&key)?
-            .ok_or_else(|| anyhow!("State does not exist {:?}", key))?;
+            .ok_or_else(|| anyhow!("Swap with id {} not found in database", swap_id))?;
 
         let state = deserialize(&encoded).context("Could not deserialize state")?;
         Ok(state)


### PR DESCRIPTION
Since the database is relevant for all commands available, specifying a database path was added as a global parameter to be defined before the subcommand. If not specified currently defaults to `./.swap-db/`.

Example usage of `resume` with specifying a database path (and defaults for bitcoind and moerod urls):

```
swap --database /path/to/database/ resume --swap-id 4b1c1265-a801-4741-9a11-0bcf841e93d5 --bitcoin-wallet-name my-wallet-name
```

The PR includes a small refactoring in `main` to be able to re-use code for starting the swap.

Note that in production we are actually not using the `resume_from_database` functions because we would load from the db twice. I was probably a bit hasty to add those before. We might want to remove them and add loading the swap to the `testutils` so we can use them in the `e2e` tests. Not sure what is nicer.