### PR TITLE
Bugfix: Remove fragile assertions

### DIFF
--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -66,11 +66,6 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         )
         .await;
 
-    // TODO: we are making a clone of Bob's wallets here to keep them in scope after
-    // Bob's wallets are moved into an async task.
-    let bob_btc_wallet_clone = bob_btc_wallet.clone();
-    let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
-
     let _ = tokio::spawn(async move {
         bob::swap::swap(
             bob_state,
@@ -133,18 +128,14 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     assert!(matches!(alice_state, AliceState::BtcRedeemed {..}));
 
     let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet_clone.as_ref().balance().await.unwrap();
 
     assert_eq!(
         btc_alice_final,
         btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
     );
-    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
 
+    alice_xmr_wallet.as_ref().0.refresh().await.unwrap();
     let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-    bob_xmr_wallet_clone.as_ref().0.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
 
     assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
-    assert_eq!(xmr_bob_final, xmr_to_swap);
 }

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -67,16 +67,6 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         )
         .await;
 
-    // TODO: we are making a clone of Alices's wallets here to keep them in scope
-    // after Alices's wallets are moved into an async task.
-    let alice_btc_wallet_clone = alice_btc_wallet.clone();
-    let alice_xmr_wallet_clone = alice_xmr_wallet.clone();
-
-    // TODO: we are making a clone of Bob's wallets here to keep them in scope after
-    // Bob's wallets are moved into an async task.
-    let bob_btc_wallet_clone = bob_btc_wallet.clone();
-    let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
-
     let _ = tokio::spawn(async move {
         alice::swap::swap(
             alice_state,
@@ -124,32 +114,25 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         testutils::init_bob_event_loop();
     let _alice_swarm_fut = tokio::spawn(async move { event_loop_after_restart.run().await });
 
-    let alice_state = bob::swap::resume_from_database(
+    let bob_state = bob::swap::resume_from_database(
         event_loop_handle_after_restart,
         bob_db,
-        bob_btc_wallet,
-        bob_xmr_wallet,
+        bob_btc_wallet.clone(),
+        bob_xmr_wallet.clone(),
         OsRng,
         bob_swap_id,
     )
     .await
     .unwrap();
 
-    assert!(matches!(alice_state, BobState::XmrRedeemed {..}));
+    assert!(matches!(bob_state, BobState::XmrRedeemed {..}));
 
-    let btc_alice_final = alice_btc_wallet_clone.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet_clone.as_ref().balance().await.unwrap();
+    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
 
-    assert_eq!(
-        btc_alice_final,
-        btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
     assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
 
-    let xmr_alice_final = alice_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
-    bob_xmr_wallet_clone.as_ref().0.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
+    bob_xmr_wallet.as_ref().0.refresh().await.unwrap();
+    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
 
-    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
     assert_eq!(xmr_bob_final, xmr_to_swap);
 }


### PR DESCRIPTION
The the Alice and Bob restart tests we were asserting that both
Alice's and Bob's balances were correct. This was problematic
because we are not waiting for both parties to complete causing
the test to fail (sometimes). This issue is resolved by removing
the assertions for the party that is moved into an async task as
we do not what state they have reached when we check their
balances.

I am not sure whether we should merge this commit or change the tests so that we wait (join) until both parties have hit redeemed? 