### PR TITLE
Remove breaks and continues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: cargo +nightly test --workspace --all-features -- -Z unstable-options --report-time
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
-          RUST_MIN_STACK: 10000000
+          RUST_MIN_STACK: 20000000
 
       - name: Build binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           profile: minimal
           override: true
 
@@ -95,14 +94,14 @@ jobs:
           key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cargo check release code with default features
-        run: cargo +nightly check --workspace
+        run: cargo check --workspace
 
       - name: Cargo check all features
-        run: cargo +nightly check --workspace --all-targets --all-features
+        run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
         if: (!matrix.skip_tests)
-        run: cargo +nightly test --workspace --all-features -- -Z unstable-options --report-time
+        run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
           RUST_MIN_STACK: 20000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
         run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
-          RUST_MIN_STACK: 20000000
 
       - name: Build binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,17 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5444eec77a9ec2bfe4524139e09195862e981400c4358d3b760cae634e4c4ee"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.48",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,7 +3371,6 @@ name = "swap"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "async-trait",
  "atty",
  "backoff",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -7,7 +7,6 @@ description = "XMR/BTC trustless atomic swaps."
 
 [dependencies]
 anyhow = "1"
-async-recursion = "0.3.1"
 async-trait = "0.1"
 atty = "0.2"
 backoff = { version = "0.2", features = ["tokio"] }

--- a/swap/src/alice.rs
+++ b/swap/src/alice.rs
@@ -190,13 +190,8 @@ impl Default for Behaviour {
         let identity = Keypair::generate_ed25519();
 
         Self {
-            pt: PeerTracker::default(),
-            amounts: Amounts::default(),
-            message0: Message0::default(),
-            message1: Message1::default(),
-            message2: Message2::default(),
-            message3: Message3::default(),
             identity,
+            ..Default::default()
         }
     }
 }

--- a/swap/src/alice/message0.rs
+++ b/swap/src/alice/message0.rs
@@ -1,7 +1,8 @@
+use crate::network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
-        RequestResponseEvent, RequestResponseMessage,
+        RequestResponseEvent, RequestResponseMessage, ResponseChannel,
     },
     swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
     NetworkBehaviour,
@@ -12,9 +13,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT};
-use libp2p::request_response::ResponseChannel;
 use xmr_btc::bob;
 
 #[derive(Debug)]

--- a/swap/src/alice/steps.rs
+++ b/swap/src/alice/steps.rs
@@ -9,7 +9,6 @@ use futures::{
     pin_mut,
 };
 use libp2p::request_response::ResponseChannel;
-
 use rand::rngs::OsRng;
 use sha2::Sha256;
 use std::{sync::Arc, time::Duration};

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -19,7 +19,6 @@ use crate::{
     SwapAmounts,
 };
 use anyhow::{bail, Result};
-use async_recursion::async_recursion;
 use futures::{
     future::{select, Either},
     pin_mut,
@@ -254,290 +253,288 @@ impl Swap {
         }
     }
 
-    pub async fn save_and_run_until(
-        self,
-        state: AliceState,
-        is_target_state: fn(&AliceState) -> bool,
-    ) -> Result<AliceState> {
-        let db_state = (&state).into();
-        self.db
-            .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
-            .await?;
-        self.run_until(state, is_target_state).await
-    }
-
     // State machine driver for swap execution
-    #[async_recursion]
     pub async fn run_until(
         mut self,
-        state: AliceState,
+        mut state: AliceState,
         is_target_state: fn(&AliceState) -> bool,
     ) -> Result<AliceState> {
-        info!("Current state:{}", state);
-        if is_target_state(&state) {
-            Ok(state)
-        } else {
-            match state {
-                AliceState::Started { amounts, state0 } => {
-                    let (channel, state3) =
-                        negotiate(state0, amounts, &mut self.event_loop_handle, self.config)
-                            .await?;
-
-                    self.save_and_run_until(
-                        AliceState::Negotiated {
+        loop {
+            info!("Current state:{}", state);
+            if is_target_state(&state) {
+                break Ok(state);
+            } else {
+                match state {
+                    AliceState::Started { amounts, state0 } => {
+                        let (channel, state3) =
+                            negotiate(state0, amounts, &mut self.event_loop_handle, self.config)
+                                .await?;
+                        state = AliceState::Negotiated {
                             channel: Some(channel),
                             amounts,
                             state3,
-                        },
-                        is_target_state,
-                    )
-                    .await
-                }
-                AliceState::Negotiated {
-                    state3,
-                    channel,
-                    amounts,
-                } => {
-                    let state = match channel {
-                        Some(channel) => {
-                            let _ = wait_for_locked_bitcoin(
-                                state3.tx_lock.txid(),
-                                self.bitcoin_wallet.clone(),
-                                self.config,
-                            )
+                        };
+
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
                             .await?;
-
-                            AliceState::BtcLocked {
-                                channel: Some(channel),
-                                amounts,
-                                state3,
-                            }
-                        }
-                        None => {
-                            tracing::info!("Cannot resume swap from negotiated state, aborting");
-
-                            // Alice did not lock Xmr yet
-                            AliceState::SafelyAborted
-                        }
-                    };
-
-                    self.save_and_run_until(state, is_target_state).await
-                }
-                AliceState::BtcLocked {
-                    channel,
-                    amounts,
-                    state3,
-                } => {
-                    let state = match channel {
-                        Some(channel) => {
-                            lock_xmr(
-                                channel,
-                                amounts,
-                                state3.clone(),
-                                &mut self.event_loop_handle,
-                                self.monero_wallet.clone(),
-                            )
-                            .await?;
-
-                            AliceState::XmrLocked { state3 }
-                        }
-                        None => {
-                            tracing::info!("Cannot resume swap from BTC locked state, aborting");
-
-                            // Alice did not lock Xmr yet
-                            AliceState::SafelyAborted
-                        }
-                    };
-
-                    self.save_and_run_until(state, is_target_state).await
-                }
-                AliceState::XmrLocked { state3 } => {
-                    // todo: match statement and wait for t1 can probably be expressed more cleanly
-                    let state = match state3.current_epoch(self.bitcoin_wallet.as_ref()).await? {
-                        Epoch::T0 => {
-                            let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
-                                &mut self.event_loop_handle,
-                                self.config.monero_max_finality_time,
-                            );
-                            let state3_clone = state3.clone();
-                            let t1_timeout = state3_clone.wait_for_t1(self.bitcoin_wallet.as_ref());
-
-                            pin_mut!(wait_for_enc_sig);
-                            pin_mut!(t1_timeout);
-
-                            match select(t1_timeout, wait_for_enc_sig).await {
-                                Either::Left(_) => AliceState::T1Expired { state3 },
-                                Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
-                                    state3,
-                                    encrypted_signature: enc_sig?,
-                                },
-                            }
-                        }
-                        _ => AliceState::T1Expired { state3 },
-                    };
-
-                    self.save_and_run_until(state, is_target_state).await
-                }
-                AliceState::EncSignLearned {
-                    state3,
-                    encrypted_signature,
-                } => {
-                    let signed_tx_redeem = match build_bitcoin_redeem_transaction(
-                        encrypted_signature,
-                        &state3.tx_lock,
-                        state3.a.clone(),
-                        state3.s_a,
-                        state3.B,
-                        &state3.redeem_address,
-                    ) {
-                        Ok(tx) => tx,
-                        Err(_) => {
-                            state3.wait_for_t1(self.bitcoin_wallet.as_ref()).await?;
-                            return self
-                                .save_and_run_until(
-                                    AliceState::T1Expired { state3 },
-                                    is_target_state,
+                    }
+                    AliceState::Negotiated {
+                        state3,
+                        channel,
+                        amounts,
+                    } => {
+                        state = match channel {
+                            Some(channel) => {
+                                let _ = wait_for_locked_bitcoin(
+                                    state3.tx_lock.txid(),
+                                    self.bitcoin_wallet.clone(),
+                                    self.config,
                                 )
-                                .await;
-                        }
-                    };
+                                .await?;
 
-                    // TODO(Franck): Error handling is delicate here.
-                    // If Bob sees this transaction he can redeem Monero
-                    // e.g. If the Bitcoin node is down then the user needs to take action.
-                    publish_bitcoin_redeem_transaction(
-                        signed_tx_redeem,
-                        self.bitcoin_wallet.clone(),
-                        self.config,
-                    )
-                    .await?;
+                                AliceState::BtcLocked {
+                                    channel: Some(channel),
+                                    amounts,
+                                    state3,
+                                }
+                            }
+                            None => {
+                                tracing::info!(
+                                    "Cannot resume swap from negotiated state, aborting"
+                                );
 
-                    self.save_and_run_until(AliceState::BtcRedeemed, is_target_state)
-                        .await
-                }
-                AliceState::T1Expired { state3 } => {
-                    let tx_cancel = publish_cancel_transaction(
-                        state3.tx_lock.clone(),
-                        state3.a.clone(),
-                        state3.B,
-                        state3.refund_timelock,
-                        state3.tx_cancel_sig_bob.clone(),
-                        self.bitcoin_wallet.clone(),
-                    )
-                    .await?;
+                                // Alice did not lock Xmr yet
+                                AliceState::SafelyAborted
+                            }
+                        };
 
-                    self.save_and_run_until(
-                        AliceState::BtcCancelled { state3, tx_cancel },
-                        is_target_state,
-                    )
-                    .await
-                }
-                AliceState::BtcCancelled { state3, tx_cancel } => {
-                    let tx_cancel_height = self
-                        .bitcoin_wallet
-                        .transaction_block_height(tx_cancel.txid())
-                        .await;
-
-                    let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
-                        &tx_cancel,
-                        tx_cancel_height,
-                        state3.punish_timelock,
-                        &state3.refund_address,
-                        self.bitcoin_wallet.clone(),
-                    )
-                    .await?;
-
-                    // TODO(Franck): Review error handling
-                    match published_refund_tx {
-                        None => {
-                            self.save_and_run_until(
-                                AliceState::BtcPunishable { tx_refund, state3 },
-                                is_target_state,
-                            )
-                            .await
-                        }
-                        Some(published_refund_tx) => {
-                            let spend_key = extract_monero_private_key(
-                                published_refund_tx,
-                                tx_refund,
-                                state3.s_a,
-                                state3.a.clone(),
-                                state3.S_b_bitcoin,
-                            )?;
-
-                            self.save_and_run_until(
-                                AliceState::BtcRefunded { spend_key, state3 },
-                                is_target_state,
-                            )
-                            .await
-                        }
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
                     }
-                }
-                AliceState::BtcRefunded { spend_key, state3 } => {
-                    let view_key = state3.v;
+                    AliceState::BtcLocked {
+                        channel,
+                        amounts,
+                        state3,
+                    } => {
+                        state = match channel {
+                            Some(channel) => {
+                                lock_xmr(
+                                    channel,
+                                    amounts,
+                                    state3.clone(),
+                                    &mut self.event_loop_handle,
+                                    self.monero_wallet.clone(),
+                                )
+                                .await?;
 
-                    self.monero_wallet
-                        .create_and_load_wallet_for_output(spend_key, view_key)
+                                AliceState::XmrLocked { state3 }
+                            }
+                            None => {
+                                tracing::info!(
+                                    "Cannot resume swap from BTC locked state, aborting"
+                                );
+
+                                // Alice did not lock Xmr yet
+                                AliceState::SafelyAborted
+                            }
+                        };
+
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::XmrLocked { state3 } => {
+                        state = match state3.current_epoch(self.bitcoin_wallet.as_ref()).await? {
+                            Epoch::T0 => {
+                                let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
+                                    &mut self.event_loop_handle,
+                                    self.config.monero_max_finality_time,
+                                );
+                                let state3_clone = state3.clone();
+                                let t1_timeout =
+                                    state3_clone.wait_for_t1(self.bitcoin_wallet.as_ref());
+
+                                pin_mut!(wait_for_enc_sig);
+                                pin_mut!(t1_timeout);
+
+                                match select(t1_timeout, wait_for_enc_sig).await {
+                                    Either::Left(_) => AliceState::T1Expired { state3 },
+                                    Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
+                                        state3,
+                                        encrypted_signature: enc_sig?,
+                                    },
+                                }
+                            }
+                            _ => AliceState::T1Expired { state3 },
+                        };
+
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::EncSignLearned {
+                        state3,
+                        encrypted_signature,
+                    } => {
+                        let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+                            encrypted_signature,
+                            &state3.tx_lock,
+                            state3.a.clone(),
+                            state3.s_a,
+                            state3.B,
+                            &state3.redeem_address,
+                        ) {
+                            Ok(tx) => tx,
+                            Err(_) => {
+                                state3.wait_for_t1(self.bitcoin_wallet.as_ref()).await?;
+
+                                state = AliceState::T1Expired { state3 };
+                                self.db
+                                    .insert_latest_state(
+                                        self.swap_id,
+                                        state::Swap::Alice((&state).into()),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+                        };
+
+                        // TODO(Franck): Error handling is delicate here.
+                        // If Bob sees this transaction he can redeem Monero
+                        // e.g. If the Bitcoin node is down then the user needs to take action.
+                        publish_bitcoin_redeem_transaction(
+                            signed_tx_redeem,
+                            self.bitcoin_wallet.clone(),
+                            self.config,
+                        )
                         .await?;
 
-                    let state = AliceState::XmrRefunded;
-                    let db_state = (&state).into();
-                    self.db
-                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        state = AliceState::BtcRedeemed;
+
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::T1Expired { state3 } => {
+                        let tx_cancel = publish_cancel_transaction(
+                            state3.tx_lock.clone(),
+                            state3.a.clone(),
+                            state3.B,
+                            state3.refund_timelock,
+                            state3.tx_cancel_sig_bob.clone(),
+                            self.bitcoin_wallet.clone(),
+                        )
                         .await?;
-                    // TODO: This is inconsistent as we are not calling `run_until`.
-                    Ok(state)
-                }
-                AliceState::BtcPunishable { tx_refund, state3 } => {
-                    let signed_tx_punish = build_bitcoin_punish_transaction(
-                        &state3.tx_lock,
-                        state3.refund_timelock,
-                        &state3.punish_address,
-                        state3.punish_timelock,
-                        state3.tx_punish_sig_bob.clone(),
-                        state3.a.clone(),
-                        state3.B,
-                    )?;
 
-                    let punish_tx_finalised = publish_bitcoin_punish_transaction(
-                        signed_tx_punish,
-                        self.bitcoin_wallet.clone(),
-                        self.config,
-                    );
+                        state = AliceState::BtcCancelled { state3, tx_cancel };
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::BtcCancelled { state3, tx_cancel } => {
+                        let tx_cancel_height = self
+                            .bitcoin_wallet
+                            .transaction_block_height(tx_cancel.txid())
+                            .await;
 
-                    let bitcoin_wallet_clone = self.bitcoin_wallet.clone();
+                        let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
+                            &tx_cancel,
+                            tx_cancel_height,
+                            state3.punish_timelock,
+                            &state3.refund_address,
+                            self.bitcoin_wallet.clone(),
+                        )
+                        .await?;
 
-                    let refund_tx_seen =
-                        bitcoin_wallet_clone.watch_for_raw_transaction(tx_refund.txid());
+                        // TODO(Franck): Review error handling
+                        state = match published_refund_tx {
+                            None => AliceState::BtcPunishable { tx_refund, state3 },
+                            Some(published_refund_tx) => {
+                                let spend_key = extract_monero_private_key(
+                                    published_refund_tx,
+                                    tx_refund,
+                                    state3.s_a,
+                                    state3.a.clone(),
+                                    state3.S_b_bitcoin,
+                                )?;
 
-                    pin_mut!(punish_tx_finalised);
-                    pin_mut!(refund_tx_seen);
+                                AliceState::BtcRefunded { spend_key, state3 }
+                            }
+                        };
 
-                    match select(punish_tx_finalised, refund_tx_seen).await {
-                        Either::Left(_) => {
-                            self.save_and_run_until(AliceState::Punished, is_target_state)
-                                .await
-                        }
-                        Either::Right((published_refund_tx, _)) => {
-                            let spend_key = extract_monero_private_key(
-                                published_refund_tx,
-                                tx_refund,
-                                state3.s_a,
-                                state3.a.clone(),
-                                state3.S_b_bitcoin,
-                            )?;
-                            self.save_and_run_until(
-                                AliceState::BtcRefunded { spend_key, state3 },
-                                is_target_state,
-                            )
-                            .await
-                        }
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::BtcRefunded { spend_key, state3 } => {
+                        let view_key = state3.v;
+
+                        self.monero_wallet
+                            .create_and_load_wallet_for_output(spend_key, view_key)
+                            .await?;
+
+                        state = AliceState::XmrRefunded;
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::BtcPunishable { tx_refund, state3 } => {
+                        let signed_tx_punish = build_bitcoin_punish_transaction(
+                            &state3.tx_lock,
+                            state3.refund_timelock,
+                            &state3.punish_address,
+                            state3.punish_timelock,
+                            state3.tx_punish_sig_bob.clone(),
+                            state3.a.clone(),
+                            state3.B,
+                        )?;
+
+                        let punish_tx_finalised = publish_bitcoin_punish_transaction(
+                            signed_tx_punish,
+                            self.bitcoin_wallet.clone(),
+                            self.config,
+                        );
+
+                        let bitcoin_wallet_clone = self.bitcoin_wallet.clone();
+
+                        let refund_tx_seen =
+                            bitcoin_wallet_clone.watch_for_raw_transaction(tx_refund.txid());
+
+                        pin_mut!(punish_tx_finalised);
+                        pin_mut!(refund_tx_seen);
+
+                        state = match select(punish_tx_finalised, refund_tx_seen).await {
+                            Either::Left(_) => AliceState::Punished,
+                            Either::Right((published_refund_tx, _)) => {
+                                let spend_key = extract_monero_private_key(
+                                    published_refund_tx,
+                                    tx_refund,
+                                    state3.s_a,
+                                    state3.a.clone(),
+                                    state3.S_b_bitcoin,
+                                )?;
+                                AliceState::BtcRefunded { spend_key, state3 }
+                            }
+                        };
+                        self.db
+                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                            .await?;
+                    }
+                    AliceState::XmrRefunded => {
+                        break Ok(AliceState::XmrRefunded);
+                    }
+                    AliceState::BtcRedeemed => {
+                        break Ok(AliceState::BtcRedeemed);
+                    }
+                    AliceState::Punished => {
+                        break Ok(AliceState::Punished);
+                    }
+                    AliceState::SafelyAborted => {
+                        break Ok(AliceState::SafelyAborted);
                     }
                 }
-                AliceState::XmrRefunded => Ok(AliceState::XmrRefunded),
-                AliceState::BtcRedeemed => Ok(AliceState::BtcRedeemed),
-                AliceState::Punished => Ok(AliceState::Punished),
-                AliceState::SafelyAborted => Ok(AliceState::SafelyAborted),
             }
         }
     }

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -536,8 +536,9 @@ pub async fn run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
-                        swap(
+                        run_until(
                             state,
+                            is_target_state,
                             event_loop_handle,
                             bitcoin_wallet.clone(),
                             monero_wallet,

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -260,20 +260,6 @@ pub fn is_complete(state: &AliceState) -> bool {
     )
 }
 
-pub fn is_xmr_locked(state: &AliceState) -> bool {
-    matches!(
-        state,
-        AliceState::XmrLocked{..}
-    )
-}
-
-pub fn is_encsig_learned(state: &AliceState) -> bool {
-    matches!(
-        state,
-        AliceState::EncSignLearned{..}
-    )
-}
-
 // State machine driver for swap execution
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -253,288 +253,292 @@ impl Swap {
         }
     }
 
-    // State machine driver for swap execution
-    pub async fn run_until(
-        mut self,
-        mut state: AliceState,
-        is_target_state: fn(&AliceState) -> bool,
-    ) -> Result<AliceState> {
-        loop {
-            info!("Current state:{}", state);
-            if is_target_state(&state) {
-                break Ok(state);
-            } else {
-                match state {
-                    AliceState::Started { amounts, state0 } => {
-                        let (channel, state3) =
-                            negotiate(state0, amounts, &mut self.event_loop_handle, self.config)
-                                .await?;
-                        state = AliceState::Negotiated {
+    pub async fn next_state(&mut self, initial_state: AliceState) -> Result<AliceState> {
+        match initial_state {
+            AliceState::Started { amounts, state0 } => {
+                let (channel, state3) =
+                    negotiate(state0, amounts, &mut self.event_loop_handle, self.config).await?;
+                let state = AliceState::Negotiated {
+                    channel: Some(channel),
+                    amounts,
+                    state3,
+                };
+
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+                Ok(state)
+            }
+            AliceState::Negotiated {
+                state3,
+                channel,
+                amounts,
+            } => {
+                let state = match channel {
+                    Some(channel) => {
+                        let _ = wait_for_locked_bitcoin(
+                            state3.tx_lock.txid(),
+                            self.bitcoin_wallet.clone(),
+                            self.config,
+                        )
+                        .await?;
+
+                        AliceState::BtcLocked {
                             channel: Some(channel),
                             amounts,
                             state3,
-                        };
+                        }
+                    }
+                    None => {
+                        tracing::info!("Cannot resume swap from negotiated state, aborting");
 
+                        // Alice did not lock Xmr yet
+                        AliceState::SafelyAborted
+                    }
+                };
+
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+                Ok(state)
+            }
+            AliceState::BtcLocked {
+                channel,
+                amounts,
+                state3,
+            } => {
+                let state = match channel {
+                    Some(channel) => {
+                        lock_xmr(
+                            channel,
+                            amounts,
+                            state3.clone(),
+                            &mut self.event_loop_handle,
+                            self.monero_wallet.clone(),
+                        )
+                        .await?;
+
+                        AliceState::XmrLocked { state3 }
+                    }
+                    None => {
+                        tracing::info!("Cannot resume swap from BTC locked state, aborting");
+
+                        // Alice did not lock Xmr yet
+                        AliceState::SafelyAborted
+                    }
+                };
+
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+                Ok(state)
+            }
+            AliceState::XmrLocked { state3 } => {
+                let state = match state3.current_epoch(self.bitcoin_wallet.as_ref()).await? {
+                    Epoch::T0 => {
+                        let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
+                            &mut self.event_loop_handle,
+                            self.config.monero_max_finality_time,
+                        );
+                        let state3_clone = state3.clone();
+                        let t1_timeout = state3_clone.wait_for_t1(self.bitcoin_wallet.as_ref());
+
+                        pin_mut!(wait_for_enc_sig);
+                        pin_mut!(t1_timeout);
+
+                        match select(t1_timeout, wait_for_enc_sig).await {
+                            Either::Left(_) => AliceState::T1Expired { state3 },
+                            Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
+                                state3,
+                                encrypted_signature: enc_sig?,
+                            },
+                        }
+                    }
+                    _ => AliceState::T1Expired { state3 },
+                };
+
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+
+                Ok(state)
+            }
+            AliceState::EncSignLearned {
+                state3,
+                encrypted_signature,
+            } => {
+                let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+                    encrypted_signature,
+                    &state3.tx_lock,
+                    state3.a.clone(),
+                    state3.s_a,
+                    state3.B,
+                    &state3.redeem_address,
+                ) {
+                    Ok(tx) => tx,
+                    Err(_) => {
+                        state3.wait_for_t1(self.bitcoin_wallet.as_ref()).await?;
+
+                        let state = AliceState::T1Expired { state3 };
                         self.db
                             .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
                             .await?;
+                        return Ok(state);
                     }
-                    AliceState::Negotiated {
-                        state3,
-                        channel,
-                        amounts,
-                    } => {
-                        state = match channel {
-                            Some(channel) => {
-                                let _ = wait_for_locked_bitcoin(
-                                    state3.tx_lock.txid(),
-                                    self.bitcoin_wallet.clone(),
-                                    self.config,
-                                )
-                                .await?;
+                };
 
-                                AliceState::BtcLocked {
-                                    channel: Some(channel),
-                                    amounts,
-                                    state3,
-                                }
-                            }
-                            None => {
-                                tracing::info!(
-                                    "Cannot resume swap from negotiated state, aborting"
-                                );
+                // TODO(Franck): Error handling is delicate here.
+                // If Bob sees this transaction he can redeem Monero
+                // e.g. If the Bitcoin node is down then the user needs to take action.
+                publish_bitcoin_redeem_transaction(
+                    signed_tx_redeem,
+                    self.bitcoin_wallet.clone(),
+                    self.config,
+                )
+                .await?;
 
-                                // Alice did not lock Xmr yet
-                                AliceState::SafelyAborted
-                            }
-                        };
+                let state = AliceState::BtcRedeemed;
 
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::BtcLocked {
-                        channel,
-                        amounts,
-                        state3,
-                    } => {
-                        state = match channel {
-                            Some(channel) => {
-                                lock_xmr(
-                                    channel,
-                                    amounts,
-                                    state3.clone(),
-                                    &mut self.event_loop_handle,
-                                    self.monero_wallet.clone(),
-                                )
-                                .await?;
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
 
-                                AliceState::XmrLocked { state3 }
-                            }
-                            None => {
-                                tracing::info!(
-                                    "Cannot resume swap from BTC locked state, aborting"
-                                );
+                Ok(state)
+            }
+            AliceState::T1Expired { state3 } => {
+                let tx_cancel = publish_cancel_transaction(
+                    state3.tx_lock.clone(),
+                    state3.a.clone(),
+                    state3.B,
+                    state3.refund_timelock,
+                    state3.tx_cancel_sig_bob.clone(),
+                    self.bitcoin_wallet.clone(),
+                )
+                .await?;
 
-                                // Alice did not lock Xmr yet
-                                AliceState::SafelyAborted
-                            }
-                        };
+                let state = AliceState::BtcCancelled { state3, tx_cancel };
 
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::XmrLocked { state3 } => {
-                        state = match state3.current_epoch(self.bitcoin_wallet.as_ref()).await? {
-                            Epoch::T0 => {
-                                let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
-                                    &mut self.event_loop_handle,
-                                    self.config.monero_max_finality_time,
-                                );
-                                let state3_clone = state3.clone();
-                                let t1_timeout =
-                                    state3_clone.wait_for_t1(self.bitcoin_wallet.as_ref());
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
 
-                                pin_mut!(wait_for_enc_sig);
-                                pin_mut!(t1_timeout);
+                Ok(state)
+            }
+            AliceState::BtcCancelled { state3, tx_cancel } => {
+                let tx_cancel_height = self
+                    .bitcoin_wallet
+                    .transaction_block_height(tx_cancel.txid())
+                    .await;
 
-                                match select(t1_timeout, wait_for_enc_sig).await {
-                                    Either::Left(_) => AliceState::T1Expired { state3 },
-                                    Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
-                                        state3,
-                                        encrypted_signature: enc_sig?,
-                                    },
-                                }
-                            }
-                            _ => AliceState::T1Expired { state3 },
-                        };
+                let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
+                    &tx_cancel,
+                    tx_cancel_height,
+                    state3.punish_timelock,
+                    &state3.refund_address,
+                    self.bitcoin_wallet.clone(),
+                )
+                .await?;
 
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::EncSignLearned {
-                        state3,
-                        encrypted_signature,
-                    } => {
-                        let signed_tx_redeem = match build_bitcoin_redeem_transaction(
-                            encrypted_signature,
-                            &state3.tx_lock,
-                            state3.a.clone(),
+                // TODO(Franck): Review error handling
+                let state = match published_refund_tx {
+                    None => AliceState::BtcPunishable { tx_refund, state3 },
+                    Some(published_refund_tx) => {
+                        let spend_key = extract_monero_private_key(
+                            published_refund_tx,
+                            tx_refund,
                             state3.s_a,
-                            state3.B,
-                            &state3.redeem_address,
-                        ) {
-                            Ok(tx) => tx,
-                            Err(_) => {
-                                state3.wait_for_t1(self.bitcoin_wallet.as_ref()).await?;
-
-                                state = AliceState::T1Expired { state3 };
-                                self.db
-                                    .insert_latest_state(
-                                        self.swap_id,
-                                        state::Swap::Alice((&state).into()),
-                                    )
-                                    .await?;
-                                continue;
-                            }
-                        };
-
-                        // TODO(Franck): Error handling is delicate here.
-                        // If Bob sees this transaction he can redeem Monero
-                        // e.g. If the Bitcoin node is down then the user needs to take action.
-                        publish_bitcoin_redeem_transaction(
-                            signed_tx_redeem,
-                            self.bitcoin_wallet.clone(),
-                            self.config,
-                        )
-                        .await?;
-
-                        state = AliceState::BtcRedeemed;
-
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::T1Expired { state3 } => {
-                        let tx_cancel = publish_cancel_transaction(
-                            state3.tx_lock.clone(),
                             state3.a.clone(),
-                            state3.B,
-                            state3.refund_timelock,
-                            state3.tx_cancel_sig_bob.clone(),
-                            self.bitcoin_wallet.clone(),
-                        )
-                        .await?;
-
-                        state = AliceState::BtcCancelled { state3, tx_cancel };
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::BtcCancelled { state3, tx_cancel } => {
-                        let tx_cancel_height = self
-                            .bitcoin_wallet
-                            .transaction_block_height(tx_cancel.txid())
-                            .await;
-
-                        let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
-                            &tx_cancel,
-                            tx_cancel_height,
-                            state3.punish_timelock,
-                            &state3.refund_address,
-                            self.bitcoin_wallet.clone(),
-                        )
-                        .await?;
-
-                        // TODO(Franck): Review error handling
-                        state = match published_refund_tx {
-                            None => AliceState::BtcPunishable { tx_refund, state3 },
-                            Some(published_refund_tx) => {
-                                let spend_key = extract_monero_private_key(
-                                    published_refund_tx,
-                                    tx_refund,
-                                    state3.s_a,
-                                    state3.a.clone(),
-                                    state3.S_b_bitcoin,
-                                )?;
-
-                                AliceState::BtcRefunded { spend_key, state3 }
-                            }
-                        };
-
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::BtcRefunded { spend_key, state3 } => {
-                        let view_key = state3.v;
-
-                        self.monero_wallet
-                            .create_and_load_wallet_for_output(spend_key, view_key)
-                            .await?;
-
-                        state = AliceState::XmrRefunded;
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
-                    }
-                    AliceState::BtcPunishable { tx_refund, state3 } => {
-                        let signed_tx_punish = build_bitcoin_punish_transaction(
-                            &state3.tx_lock,
-                            state3.refund_timelock,
-                            &state3.punish_address,
-                            state3.punish_timelock,
-                            state3.tx_punish_sig_bob.clone(),
-                            state3.a.clone(),
-                            state3.B,
+                            state3.S_b_bitcoin,
                         )?;
 
-                        let punish_tx_finalised = publish_bitcoin_punish_transaction(
-                            signed_tx_punish,
-                            self.bitcoin_wallet.clone(),
-                            self.config,
-                        );
+                        AliceState::BtcRefunded { spend_key, state3 }
+                    }
+                };
 
-                        let bitcoin_wallet_clone = self.bitcoin_wallet.clone();
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
 
-                        let refund_tx_seen =
-                            bitcoin_wallet_clone.watch_for_raw_transaction(tx_refund.txid());
+                Ok(state)
+            }
+            AliceState::BtcRefunded { spend_key, state3 } => {
+                let view_key = state3.v;
 
-                        pin_mut!(punish_tx_finalised);
-                        pin_mut!(refund_tx_seen);
+                self.monero_wallet
+                    .create_and_load_wallet_for_output(spend_key, view_key)
+                    .await?;
 
-                        state = match select(punish_tx_finalised, refund_tx_seen).await {
-                            Either::Left(_) => AliceState::Punished,
-                            Either::Right((published_refund_tx, _)) => {
-                                let spend_key = extract_monero_private_key(
-                                    published_refund_tx,
-                                    tx_refund,
-                                    state3.s_a,
-                                    state3.a.clone(),
-                                    state3.S_b_bitcoin,
-                                )?;
-                                AliceState::BtcRefunded { spend_key, state3 }
-                            }
-                        };
-                        self.db
-                            .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
-                            .await?;
+                let state = AliceState::XmrRefunded;
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+
+                Ok(state)
+            }
+            AliceState::BtcPunishable { tx_refund, state3 } => {
+                let signed_tx_punish = build_bitcoin_punish_transaction(
+                    &state3.tx_lock,
+                    state3.refund_timelock,
+                    &state3.punish_address,
+                    state3.punish_timelock,
+                    state3.tx_punish_sig_bob.clone(),
+                    state3.a.clone(),
+                    state3.B,
+                )?;
+
+                let punish_tx_finalised = publish_bitcoin_punish_transaction(
+                    signed_tx_punish,
+                    self.bitcoin_wallet.clone(),
+                    self.config,
+                );
+
+                let bitcoin_wallet_clone = self.bitcoin_wallet.clone();
+
+                let refund_tx_seen =
+                    bitcoin_wallet_clone.watch_for_raw_transaction(tx_refund.txid());
+
+                pin_mut!(punish_tx_finalised);
+                pin_mut!(refund_tx_seen);
+
+                let state = match select(punish_tx_finalised, refund_tx_seen).await {
+                    Either::Left(_) => AliceState::Punished,
+                    Either::Right((published_refund_tx, _)) => {
+                        let spend_key = extract_monero_private_key(
+                            published_refund_tx,
+                            tx_refund,
+                            state3.s_a,
+                            state3.a.clone(),
+                            state3.S_b_bitcoin,
+                        )?;
+                        AliceState::BtcRefunded { spend_key, state3 }
                     }
-                    AliceState::XmrRefunded => {
-                        break Ok(AliceState::XmrRefunded);
-                    }
-                    AliceState::BtcRedeemed => {
-                        break Ok(AliceState::BtcRedeemed);
-                    }
-                    AliceState::Punished => {
-                        break Ok(AliceState::Punished);
-                    }
-                    AliceState::SafelyAborted => {
-                        break Ok(AliceState::SafelyAborted);
-                    }
-                }
+                };
+
+                self.db
+                    .insert_latest_state(self.swap_id, state::Swap::Alice((&state).into()))
+                    .await?;
+
+                Ok(state)
+            }
+            AliceState::XmrRefunded => Ok(AliceState::XmrRefunded),
+            AliceState::BtcRedeemed => Ok(AliceState::BtcRedeemed),
+            AliceState::Punished => Ok(AliceState::Punished),
+            AliceState::SafelyAborted => Ok(AliceState::SafelyAborted),
+        }
+    }
+
+    // State machine driver for swap execution
+    pub async fn run_until(
+        mut self,
+        state: AliceState,
+        is_target_state: fn(&AliceState) -> bool,
+    ) -> Result<AliceState> {
+        let mut result = state;
+        loop {
+            info!("Current state: {}", result);
+            result = self.next_state(result).await?;
+            if is_target_state(&result) {
+                return Ok(result);
             }
         }
     }

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -204,52 +204,6 @@ impl From<state::Alice> for AliceState {
     }
 }
 
-pub async fn swap(
-    state: AliceState,
-    event_loop_handle: EventLoopHandle,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    monero_wallet: Arc<crate::monero::Wallet>,
-    config: Config,
-    swap_id: Uuid,
-    db: Database,
-) -> Result<AliceState> {
-    run_until(
-        state,
-        is_complete,
-        event_loop_handle,
-        bitcoin_wallet,
-        monero_wallet,
-        config,
-        swap_id,
-        db,
-    )
-    .await
-}
-
-pub async fn resume_from_database(
-    event_loop_handle: EventLoopHandle,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    monero_wallet: Arc<crate::monero::Wallet>,
-    config: Config,
-    swap_id: Uuid,
-    db: Database,
-) -> Result<AliceState> {
-    if let state::Swap::Alice(db_state) = db.get_state(swap_id)? {
-        swap(
-            db_state.into(),
-            event_loop_handle,
-            bitcoin_wallet,
-            monero_wallet,
-            config,
-            swap_id,
-            db,
-        )
-        .await
-    } else {
-        bail!("Alice state expected.")
-    }
-}
-
 pub fn is_complete(state: &AliceState) -> bool {
     matches!(
         state,
@@ -260,404 +214,345 @@ pub fn is_complete(state: &AliceState) -> bool {
     )
 }
 
-// State machine driver for swap execution
-#[async_recursion]
-#[allow(clippy::too_many_arguments)]
-pub async fn run_until(
-    state: AliceState,
-    is_target_state: fn(&AliceState) -> bool,
-    mut event_loop_handle: EventLoopHandle,
+pub struct Swap {
+    event_loop_handle: EventLoopHandle,
     bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
     monero_wallet: Arc<crate::monero::Wallet>,
     config: Config,
     swap_id: Uuid,
     db: Database,
-    // TODO: Remove EventLoopHandle!
-) -> Result<AliceState> {
-    info!("Current state:{}", state);
-    if is_target_state(&state) {
-        Ok(state)
-    } else {
-        match state {
-            AliceState::Started { amounts, state0 } => {
-                let (channel, state3) =
-                    negotiate(state0, amounts, &mut event_loop_handle, config).await?;
+}
 
-                let state = AliceState::Negotiated {
-                    channel: Some(channel),
+impl Swap {
+    pub fn new(
+        event_loop_handle: EventLoopHandle,
+        bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
+        monero_wallet: Arc<crate::monero::Wallet>,
+        config: Config,
+        swap_id: Uuid,
+        db: Database,
+    ) -> Self {
+        Self {
+            event_loop_handle,
+            bitcoin_wallet,
+            monero_wallet,
+            config,
+            swap_id,
+            db,
+        }
+    }
+
+    pub async fn swap(self, state: AliceState) -> Result<AliceState> {
+        self.run_until(state, is_complete).await
+    }
+
+    pub async fn resume_from_database(self) -> Result<AliceState> {
+        if let state::Swap::Alice(db_state) = self.db.get_state(self.swap_id)? {
+            self.swap(db_state.into()).await
+        } else {
+            bail!("Alice state expected.")
+        }
+    }
+
+    // State machine driver for swap execution
+    #[async_recursion]
+    pub async fn run_until(
+        mut self,
+        state: AliceState,
+        is_target_state: fn(&AliceState) -> bool,
+    ) -> Result<AliceState> {
+        info!("Current state:{}", state);
+        if is_target_state(&state) {
+            Ok(state)
+        } else {
+            match state {
+                AliceState::Started { amounts, state0 } => {
+                    let (channel, state3) =
+                        negotiate(state0, amounts, &mut self.event_loop_handle, self.config)
+                            .await?;
+
+                    let state = AliceState::Negotiated {
+                        channel: Some(channel),
+                        amounts,
+                        state3,
+                    };
+
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::Negotiated {
+                    state3,
+                    channel,
+                    amounts,
+                } => {
+                    let state = match channel {
+                        Some(channel) => {
+                            let _ = wait_for_locked_bitcoin(
+                                state3.tx_lock.txid(),
+                                self.bitcoin_wallet.clone(),
+                                self.config,
+                            )
+                            .await?;
+
+                            AliceState::BtcLocked {
+                                channel: Some(channel),
+                                amounts,
+                                state3,
+                            }
+                        }
+                        None => {
+                            tracing::info!("Cannot resume swap from negotiated state, aborting");
+
+                            // Alice did not lock Xmr yet
+                            AliceState::SafelyAborted
+                        }
+                    };
+
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::BtcLocked {
+                    channel,
                     amounts,
                     state3,
-                };
+                } => {
+                    let state = match channel {
+                        Some(channel) => {
+                            lock_xmr(
+                                channel,
+                                amounts,
+                                state3.clone(),
+                                &mut self.event_loop_handle,
+                                self.monero_wallet.clone(),
+                            )
+                            .await?;
 
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet,
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::Negotiated {
-                state3,
-                channel,
-                amounts,
-            } => {
-                let state = match channel {
-                    Some(channel) => {
-                        let _ = wait_for_locked_bitcoin(
-                            state3.tx_lock.txid(),
-                            bitcoin_wallet.clone(),
-                            config,
-                        )
-                        .await?;
-
-                        AliceState::BtcLocked {
-                            channel: Some(channel),
-                            amounts,
-                            state3,
+                            AliceState::XmrLocked { state3 }
                         }
-                    }
-                    None => {
-                        tracing::info!("Cannot resume swap from negotiated state, aborting");
+                        None => {
+                            tracing::info!("Cannot resume swap from BTC locked state, aborting");
 
-                        // Alice did not lock Xmr yet
-                        AliceState::SafelyAborted
-                    }
-                };
-
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet,
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::BtcLocked {
-                channel,
-                amounts,
-                state3,
-            } => {
-                let state = match channel {
-                    Some(channel) => {
-                        lock_xmr(
-                            channel,
-                            amounts,
-                            state3.clone(),
-                            &mut event_loop_handle,
-                            monero_wallet.clone(),
-                        )
-                        .await?;
-
-                        AliceState::XmrLocked { state3 }
-                    }
-                    None => {
-                        tracing::info!("Cannot resume swap from BTC locked state, aborting");
-
-                        // Alice did not lock Xmr yet
-                        AliceState::SafelyAborted
-                    }
-                };
-
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet,
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::XmrLocked { state3 } => {
-                // todo: match statement and wait for t1 can probably be expressed more cleanly
-                let state = match state3.current_epoch(bitcoin_wallet.as_ref()).await? {
-                    Epoch::T0 => {
-                        let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
-                            &mut event_loop_handle,
-                            config.monero_max_finality_time,
-                        );
-                        let state3_clone = state3.clone();
-                        let t1_timeout = state3_clone.wait_for_t1(bitcoin_wallet.as_ref());
-
-                        pin_mut!(wait_for_enc_sig);
-                        pin_mut!(t1_timeout);
-
-                        match select(t1_timeout, wait_for_enc_sig).await {
-                            Either::Left(_) => AliceState::T1Expired { state3 },
-                            Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
-                                state3,
-                                encrypted_signature: enc_sig?,
-                            },
+                            // Alice did not lock Xmr yet
+                            AliceState::SafelyAborted
                         }
-                    }
-                    _ => AliceState::T1Expired { state3 },
-                };
+                    };
 
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet.clone(),
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::EncSignLearned {
-                state3,
-                encrypted_signature,
-            } => {
-                let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::XmrLocked { state3 } => {
+                    // todo: match statement and wait for t1 can probably be expressed more cleanly
+                    let state = match state3.current_epoch(self.bitcoin_wallet.as_ref()).await? {
+                        Epoch::T0 => {
+                            let wait_for_enc_sig = wait_for_bitcoin_encrypted_signature(
+                                &mut self.event_loop_handle,
+                                self.config.monero_max_finality_time,
+                            );
+                            let state3_clone = state3.clone();
+                            let t1_timeout = state3_clone.wait_for_t1(self.bitcoin_wallet.as_ref());
+
+                            pin_mut!(wait_for_enc_sig);
+                            pin_mut!(t1_timeout);
+
+                            match select(t1_timeout, wait_for_enc_sig).await {
+                                Either::Left(_) => AliceState::T1Expired { state3 },
+                                Either::Right((enc_sig, _)) => AliceState::EncSignLearned {
+                                    state3,
+                                    encrypted_signature: enc_sig?,
+                                },
+                            }
+                        }
+                        _ => AliceState::T1Expired { state3 },
+                    };
+
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::EncSignLearned {
+                    state3,
                     encrypted_signature,
-                    &state3.tx_lock,
-                    state3.a.clone(),
-                    state3.s_a,
-                    state3.B,
-                    &state3.redeem_address,
-                ) {
-                    Ok(tx) => tx,
-                    Err(_) => {
-                        state3.wait_for_t1(bitcoin_wallet.as_ref()).await?;
+                } => {
+                    let signed_tx_redeem = match build_bitcoin_redeem_transaction(
+                        encrypted_signature,
+                        &state3.tx_lock,
+                        state3.a.clone(),
+                        state3.s_a,
+                        state3.B,
+                        &state3.redeem_address,
+                    ) {
+                        Ok(tx) => tx,
+                        Err(_) => {
+                            state3.wait_for_t1(self.bitcoin_wallet.as_ref()).await?;
 
-                        let state = AliceState::T1Expired { state3 };
-                        let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                            .await?;
-                        return run_until(
-                            state,
-                            is_target_state,
-                            event_loop_handle,
-                            bitcoin_wallet,
-                            monero_wallet,
-                            config,
-                            swap_id,
-                            db,
-                        )
+                            let state = AliceState::T1Expired { state3 };
+                            let db_state = (&state).into();
+                            self.db
+                                .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                                .await?;
+                            return self.run_until(state, is_target_state).await;
+                        }
+                    };
+
+                    // TODO(Franck): Error handling is delicate here.
+                    // If Bob sees this transaction he can redeem Monero
+                    // e.g. If the Bitcoin node is down then the user needs to take action.
+                    publish_bitcoin_redeem_transaction(
+                        signed_tx_redeem,
+                        self.bitcoin_wallet.clone(),
+                        self.config,
+                    )
+                    .await?;
+
+                    let state = AliceState::BtcRedeemed;
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::T1Expired { state3 } => {
+                    let tx_cancel = publish_cancel_transaction(
+                        state3.tx_lock.clone(),
+                        state3.a.clone(),
+                        state3.B,
+                        state3.refund_timelock,
+                        state3.tx_cancel_sig_bob.clone(),
+                        self.bitcoin_wallet.clone(),
+                    )
+                    .await?;
+
+                    let state = AliceState::BtcCancelled { state3, tx_cancel };
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    self.run_until(state, is_target_state).await
+                }
+                AliceState::BtcCancelled { state3, tx_cancel } => {
+                    let tx_cancel_height = self
+                        .bitcoin_wallet
+                        .transaction_block_height(tx_cancel.txid())
                         .await;
-                    }
-                };
 
-                // TODO(Franck): Error handling is delicate here.
-                // If Bob sees this transaction he can redeem Monero
-                // e.g. If the Bitcoin node is down then the user needs to take action.
-                publish_bitcoin_redeem_transaction(
-                    signed_tx_redeem,
-                    bitcoin_wallet.clone(),
-                    config,
-                )
-                .await?;
-
-                let state = AliceState::BtcRedeemed;
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
+                    let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
+                        &tx_cancel,
+                        tx_cancel_height,
+                        state3.punish_timelock,
+                        &state3.refund_address,
+                        self.bitcoin_wallet.clone(),
+                    )
                     .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet,
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::T1Expired { state3 } => {
-                let tx_cancel = publish_cancel_transaction(
-                    state3.tx_lock.clone(),
-                    state3.a.clone(),
-                    state3.B,
-                    state3.refund_timelock,
-                    state3.tx_cancel_sig_bob.clone(),
-                    bitcoin_wallet.clone(),
-                )
-                .await?;
 
-                let state = AliceState::BtcCancelled { state3, tx_cancel };
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                run_until(
-                    state,
-                    is_target_state,
-                    event_loop_handle,
-                    bitcoin_wallet,
-                    monero_wallet,
-                    config,
-                    swap_id,
-                    db,
-                )
-                .await
-            }
-            AliceState::BtcCancelled { state3, tx_cancel } => {
-                let tx_cancel_height = bitcoin_wallet
-                    .transaction_block_height(tx_cancel.txid())
-                    .await;
+                    // TODO(Franck): Review error handling
+                    match published_refund_tx {
+                        None => {
+                            let state = AliceState::BtcPunishable { tx_refund, state3 };
+                            let db_state = (&state).into();
+                            self.db
+                                .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                                .await?;
+                            self.run_until(state, is_target_state).await
+                        }
+                        Some(published_refund_tx) => {
+                            let spend_key = extract_monero_private_key(
+                                published_refund_tx,
+                                tx_refund,
+                                state3.s_a,
+                                state3.a.clone(),
+                                state3.S_b_bitcoin,
+                            )?;
 
-                let (tx_refund, published_refund_tx) = wait_for_bitcoin_refund(
-                    &tx_cancel,
-                    tx_cancel_height,
-                    state3.punish_timelock,
-                    &state3.refund_address,
-                    bitcoin_wallet.clone(),
-                )
-                .await?;
-
-                // TODO(Franck): Review error handling
-                match published_refund_tx {
-                    None => {
-                        let state = AliceState::BtcPunishable { tx_refund, state3 };
-                        let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                            .await?;
-                        run_until(
-                            state,
-                            is_target_state,
-                            event_loop_handle,
-                            bitcoin_wallet.clone(),
-                            monero_wallet,
-                            config,
-                            swap_id,
-                            db,
-                        )
-                        .await
-                    }
-                    Some(published_refund_tx) => {
-                        let spend_key = extract_monero_private_key(
-                            published_refund_tx,
-                            tx_refund,
-                            state3.s_a,
-                            state3.a.clone(),
-                            state3.S_b_bitcoin,
-                        )?;
-
-                        let state = AliceState::BtcRefunded { spend_key, state3 };
-                        let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                            .await?;
-                        run_until(
-                            state,
-                            is_target_state,
-                            event_loop_handle,
-                            bitcoin_wallet.clone(),
-                            monero_wallet,
-                            config,
-                            swap_id,
-                            db,
-                        )
-                        .await
+                            let state = AliceState::BtcRefunded { spend_key, state3 };
+                            let db_state = (&state).into();
+                            self.db
+                                .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                                .await?;
+                            self.run_until(state, is_target_state).await
+                        }
                     }
                 }
-            }
-            AliceState::BtcRefunded { spend_key, state3 } => {
-                let view_key = state3.v;
+                AliceState::BtcRefunded { spend_key, state3 } => {
+                    let view_key = state3.v;
 
-                monero_wallet
-                    .create_and_load_wallet_for_output(spend_key, view_key)
-                    .await?;
+                    self.monero_wallet
+                        .create_and_load_wallet_for_output(spend_key, view_key)
+                        .await?;
 
-                let state = AliceState::XmrRefunded;
-                let db_state = (&state).into();
-                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                    .await?;
-                Ok(state)
-            }
-            AliceState::BtcPunishable { tx_refund, state3 } => {
-                let signed_tx_punish = build_bitcoin_punish_transaction(
-                    &state3.tx_lock,
-                    state3.refund_timelock,
-                    &state3.punish_address,
-                    state3.punish_timelock,
-                    state3.tx_punish_sig_bob.clone(),
-                    state3.a.clone(),
-                    state3.B,
-                )?;
+                    let state = AliceState::XmrRefunded;
+                    let db_state = (&state).into();
+                    self.db
+                        .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                        .await?;
+                    Ok(state)
+                }
+                AliceState::BtcPunishable { tx_refund, state3 } => {
+                    let signed_tx_punish = build_bitcoin_punish_transaction(
+                        &state3.tx_lock,
+                        state3.refund_timelock,
+                        &state3.punish_address,
+                        state3.punish_timelock,
+                        state3.tx_punish_sig_bob.clone(),
+                        state3.a.clone(),
+                        state3.B,
+                    )?;
 
-                let punish_tx_finalised = publish_bitcoin_punish_transaction(
-                    signed_tx_punish,
-                    bitcoin_wallet.clone(),
-                    config,
-                );
+                    let punish_tx_finalised = publish_bitcoin_punish_transaction(
+                        signed_tx_punish,
+                        self.bitcoin_wallet.clone(),
+                        self.config,
+                    );
 
-                let refund_tx_seen = bitcoin_wallet.watch_for_raw_transaction(tx_refund.txid());
+                    let bitcoin_wallet_clone = self.bitcoin_wallet.clone();
 
-                pin_mut!(punish_tx_finalised);
-                pin_mut!(refund_tx_seen);
+                    let refund_tx_seen =
+                        bitcoin_wallet_clone.watch_for_raw_transaction(tx_refund.txid());
 
-                match select(punish_tx_finalised, refund_tx_seen).await {
-                    Either::Left(_) => {
-                        let state = AliceState::Punished;
-                        let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                            .await?;
-                        run_until(
-                            state,
-                            is_target_state,
-                            event_loop_handle,
-                            bitcoin_wallet.clone(),
-                            monero_wallet,
-                            config,
-                            swap_id,
-                            db,
-                        )
-                        .await
-                    }
-                    Either::Right((published_refund_tx, _)) => {
-                        let spend_key = extract_monero_private_key(
-                            published_refund_tx,
-                            tx_refund,
-                            state3.s_a,
-                            state3.a.clone(),
-                            state3.S_b_bitcoin,
-                        )?;
-                        let state = AliceState::BtcRefunded { spend_key, state3 };
-                        let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
-                            .await?;
-                        run_until(
-                            state,
-                            is_target_state,
-                            event_loop_handle,
-                            bitcoin_wallet.clone(),
-                            monero_wallet,
-                            config,
-                            swap_id,
-                            db,
-                        )
-                        .await
+                    pin_mut!(punish_tx_finalised);
+                    pin_mut!(refund_tx_seen);
+
+                    match select(punish_tx_finalised, refund_tx_seen).await {
+                        Either::Left(_) => {
+                            let state = AliceState::Punished;
+                            let db_state = (&state).into();
+                            self.db
+                                .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                                .await?;
+                            self.run_until(state, is_target_state).await
+                        }
+                        Either::Right((published_refund_tx, _)) => {
+                            let spend_key = extract_monero_private_key(
+                                published_refund_tx,
+                                tx_refund,
+                                state3.s_a,
+                                state3.a.clone(),
+                                state3.S_b_bitcoin,
+                            )?;
+                            let state = AliceState::BtcRefunded { spend_key, state3 };
+                            let db_state = (&state).into();
+                            self.db
+                                .insert_latest_state(self.swap_id, state::Swap::Alice(db_state))
+                                .await?;
+                            self.run_until(state, is_target_state).await
+                        }
                     }
                 }
+                AliceState::XmrRefunded => Ok(AliceState::XmrRefunded),
+                AliceState::BtcRedeemed => Ok(AliceState::BtcRedeemed),
+                AliceState::Punished => Ok(AliceState::Punished),
+                AliceState::SafelyAborted => Ok(AliceState::SafelyAborted),
             }
-            AliceState::XmrRefunded => Ok(AliceState::XmrRefunded),
-            AliceState::BtcRedeemed => Ok(AliceState::BtcRedeemed),
-            AliceState::Punished => Ok(AliceState::Punished),
-            AliceState::SafelyAborted => Ok(AliceState::SafelyAborted),
         }
     }
 }

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -14,7 +14,7 @@ use crate::{
     bitcoin::EncryptedSignature,
     network::request_response::AliceToBob,
     state,
-    state::{Alice, Swap},
+    state::Alice,
     storage::Database,
     SwapAmounts,
 };
@@ -290,7 +290,7 @@ pub async fn run_until(
                 };
 
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -333,7 +333,7 @@ pub async fn run_until(
                 };
 
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -374,7 +374,7 @@ pub async fn run_until(
                 };
 
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -414,7 +414,7 @@ pub async fn run_until(
                 };
 
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -446,7 +446,7 @@ pub async fn run_until(
 
                         let state = AliceState::T1Expired { state3 };
                         let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
                         return run_until(
                             state,
@@ -474,7 +474,7 @@ pub async fn run_until(
 
                 let state = AliceState::BtcRedeemed;
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -501,7 +501,7 @@ pub async fn run_until(
 
                 let state = AliceState::BtcCancelled { state3, tx_cancel };
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 run_until(
                     state,
@@ -534,7 +534,7 @@ pub async fn run_until(
                     None => {
                         let state = AliceState::BtcPunishable { tx_refund, state3 };
                         let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
                         swap(
                             state,
@@ -558,7 +558,7 @@ pub async fn run_until(
 
                         let state = AliceState::BtcRefunded { spend_key, state3 };
                         let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
                         run_until(
                             state,
@@ -583,7 +583,7 @@ pub async fn run_until(
 
                 let state = AliceState::XmrRefunded;
                 let db_state = (&state).into();
-                db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                     .await?;
                 Ok(state)
             }
@@ -613,7 +613,7 @@ pub async fn run_until(
                     Either::Left(_) => {
                         let state = AliceState::Punished;
                         let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
                         run_until(
                             state,
@@ -637,7 +637,7 @@ pub async fn run_until(
                         )?;
                         let state = AliceState::BtcRefunded { spend_key, state3 };
                         let db_state = (&state).into();
-                        db.insert_latest_state(swap_id, Swap::Alice(db_state))
+                        db.insert_latest_state(swap_id, state::Swap::Alice(db_state))
                             .await?;
                         run_until(
                             state,

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -204,7 +204,6 @@ async fn main() -> Result<()> {
                 db,
                 bitcoin_wallet.clone(),
                 monero_wallet.clone(),
-                OsRng,
                 swap_id,
             );
 

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -119,8 +119,7 @@ async fn main() -> Result<()> {
                 send_monero, receive_bitcoin, swap_id
             );
 
-            let swap = alice::swap::swap(
-                alice_state,
+            let alice_swap = alice::swap::Swap::new(
                 handle,
                 bitcoin_wallet.clone(),
                 monero_wallet.clone(),
@@ -128,6 +127,8 @@ async fn main() -> Result<()> {
                 swap_id,
                 db,
             );
+
+            let swap = alice_swap.swap(alice_state);
 
             let _event_loop = tokio::spawn(async move { event_loop.run().await });
             swap.await?;

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -198,14 +198,14 @@ async fn main() -> Result<()> {
                 send_bitcoin, receive_monero, swap_id
             );
 
-            let swap = bob::swap::swap(
-                bob_state,
+            let swap = bob::swap::Swap::new(
                 handle,
                 db,
                 bitcoin_wallet.clone(),
                 monero_wallet.clone(),
                 swap_id,
-            );
+            )
+            .swap(bob_state);
 
             let _event_loop = tokio::spawn(async move { event_loop.run().await });
             swap.await?;

--- a/swap/src/bob/swap.rs
+++ b/swap/src/bob/swap.rs
@@ -149,18 +149,6 @@ pub fn is_complete(state: &BobState) -> bool {
     )
 }
 
-pub fn is_btc_locked(state: &BobState) -> bool {
-    matches!(state, BobState::BtcLocked(..))
-}
-
-pub fn is_xmr_locked(state: &BobState) -> bool {
-    matches!(state, BobState::XmrLocked(..))
-}
-
-pub fn is_encsig_sent(state: &BobState) -> bool {
-    matches!(state, BobState::EncSigSent(..))
-}
-
 // State machine driver for swap execution
 #[allow(clippy::too_many_arguments)]
 #[async_recursion]

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -72,8 +72,7 @@ async fn happy_path() {
         )
         .await;
 
-    let alice_swap_fut = alice::swap::swap(
-        alice_state,
+    let alice_swap = alice::swap::Swap::new(
         alice_event_loop_handle,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),
@@ -81,6 +80,8 @@ async fn happy_path() {
         Uuid::new_v4(),
         alice_db,
     );
+
+    let alice_swap_fut = alice_swap.swap(alice_state);
 
     let bob_swap_fut = bob::swap::swap(
         bob_state,

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -82,14 +82,14 @@ async fn happy_path() {
 
     let alice_swap_fut = alice_swap.swap(alice_state);
 
-    let bob_swap_fut = bob::swap::swap(
-        bob_state,
+    let bob_swap_fut = bob::swap::Swap::new(
         bob_event_loop_handle,
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
         Uuid::new_v4(),
-    );
+    )
+    .swap(bob_state);
 
     tokio::spawn(async move { alice_event_loop.run().await });
     tokio::spawn(async move { bob_event_loop.run().await });

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -82,8 +82,6 @@ async fn happy_path() {
         alice_db,
     );
 
-    let _alice_swarm_fut = tokio::spawn(async move { alice_event_loop.run().await });
-
     let bob_swap_fut = bob::swap::swap(
         bob_state,
         bob_event_loop_handle,
@@ -94,8 +92,8 @@ async fn happy_path() {
         Uuid::new_v4(),
     );
 
-    let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
-
+    tokio::spawn(async move { alice_event_loop.run().await });
+    tokio::spawn(async move { bob_event_loop.run().await });
     try_join(alice_swap_fut, bob_swap_fut).await.unwrap();
 
     let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,7 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
 use libp2p::Multiaddr;
-use rand::rngs::OsRng;
 use swap::{alice, bob};
 use testcontainers::clients::Cli;
 use testutils::init_tracing;
@@ -89,7 +88,6 @@ async fn happy_path() {
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
-        OsRng,
         Uuid::new_v4(),
     );
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -71,7 +71,8 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     let bob_btc_wallet_clone = bob_btc_wallet.clone();
     let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
 
-    let _ = tokio::spawn(async move {
+    tokio::spawn(async move { bob_event_loop.run().await });
+    tokio::spawn(async move {
         bob::swap::swap(
             bob_state,
             bob_event_loop_handle,
@@ -84,32 +85,29 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         .await
     });
 
-    let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
-
     let alice_db_datadir = tempdir().unwrap();
-    let alice_db = Database::open(alice_db_datadir.path()).unwrap();
-
-    let _alice_swarm_fut = tokio::spawn(async move { alice_event_loop.run().await });
-
     let alice_swap_id = Uuid::new_v4();
-
-    let alice_state = alice::swap::run_until(
-        start_state,
-        |state| {
-            matches!(
-                state,
-                AliceState::EncSignLearned{..}
-            )
-        },
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        config,
-        alice_swap_id,
-        alice_db,
-    )
-    .await
-    .unwrap();
+    let alice_state = {
+        let alice_db = Database::open(alice_db_datadir.path()).unwrap();
+        tokio::spawn(async move { alice_event_loop.run().await });
+        alice::swap::run_until(
+            start_state,
+            |state| {
+                matches!(
+                    state,
+                    AliceState::EncSignLearned{..}
+                )
+            },
+            alice_event_loop_handle,
+            alice_btc_wallet.clone(),
+            alice_xmr_wallet.clone(),
+            config,
+            alice_swap_id,
+            alice_db,
+        )
+        .await
+        .unwrap()
+    };
 
     assert!(matches!(alice_state, AliceState::EncSignLearned {..}));
 
@@ -122,8 +120,8 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
 
     let (mut event_loop_after_restart, event_loop_handle_after_restart) =
         testutils::init_alice_event_loop(alice_multiaddr);
-    let _alice_swarm_fut = tokio::spawn(async move { event_loop_after_restart.run().await });
 
+    tokio::spawn(async move { event_loop_after_restart.run().await });
     let alice_state = alice::swap::resume_from_database(
         event_loop_handle_after_restart,
         alice_btc_wallet.clone(),

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -72,14 +72,14 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
 
     tokio::spawn(async move { bob_event_loop.run().await });
     tokio::spawn(async move {
-        bob::swap::swap(
-            bob_state,
+        bob::swap::Swap::new(
             bob_event_loop_handle,
             bob_db,
             bob_btc_wallet.clone(),
             bob_xmr_wallet.clone(),
             Uuid::new_v4(),
         )
+        .swap(bob_state)
         .await
     });
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -95,7 +95,12 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
 
     let alice_state = alice::swap::run_until(
         start_state,
-        alice::swap::is_encsig_learned,
+        |state| {
+            matches!(
+                state,
+                AliceState::EncSignLearned{..}
+            )
+        },
         alice_event_loop_handle,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,5 +1,4 @@
 use libp2p::Multiaddr;
-use rand::rngs::OsRng;
 use swap::{alice, alice::swap::AliceState, bitcoin, bob, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
@@ -79,7 +78,6 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
             bob_db,
             bob_btc_wallet.clone(),
             bob_xmr_wallet.clone(),
-            OsRng,
             Uuid::new_v4(),
         )
         .await

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -1,5 +1,4 @@
 use libp2p::Multiaddr;
-use rand::rngs::OsRng;
 use swap::{alice, bitcoin, bob, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
@@ -106,7 +105,6 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
             bob_db,
             bob_btc_wallet.clone(),
             bob_xmr_wallet.clone(),
-            OsRng,
             bob_swap_id,
         )
         .await
@@ -131,7 +129,6 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         bob_db,
         bob_btc_wallet,
         bob_xmr_wallet,
-        OsRng,
         bob_swap_id,
     )
     .await

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -100,7 +100,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
     let bob_state = bob::swap::run_until(
         bob_state,
-        bob::swap::is_encsig_sent,
+        |state| matches!(state, BobState::EncSigSent(..)),
         bob_event_loop_handle,
         bob_db,
         bob_btc_wallet.clone(),

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -79,8 +79,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
     tokio::spawn(async move { alice_event_loop.run().await });
     tokio::spawn(async move {
-        alice::swap::swap(
-            alice_state,
+        alice::swap::Swap::new(
             alice_event_loop_handle,
             alice_btc_wallet.clone(),
             alice_xmr_wallet.clone(),
@@ -88,6 +87,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
             Uuid::new_v4(),
             alice_db,
         )
+        .swap(alice_state)
         .await
     });
 

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -98,15 +98,14 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
     let bob_state = {
         let bob_db = Database::open(bob_db_datadir.path()).unwrap();
 
-        bob::swap::run_until(
-            bob_state,
-            |state| matches!(state, BobState::EncSigSent(..)),
+        bob::swap::Swap::new(
             bob_event_loop_handle,
             bob_db,
             bob_btc_wallet.clone(),
             bob_xmr_wallet.clone(),
             bob_swap_id,
         )
+        .run_until(bob_state, |state| matches!(state, BobState::EncSigSent(..)))
         .await
         .unwrap()
     };
@@ -124,13 +123,14 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         testutils::init_bob_event_loop();
 
     tokio::spawn(async move { event_loop_after_restart.run().await });
-    let alice_state = bob::swap::resume_from_database(
+    let alice_state = bob::swap::Swap::new(
         event_loop_handle_after_restart,
         bob_db,
         bob_btc_wallet,
         bob_xmr_wallet,
         bob_swap_id,
     )
+    .resume_from_database()
     .await
     .unwrap();
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -69,15 +69,14 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         )
         .await;
 
-    let bob_btc_locked_fut = bob::swap::run_until(
-        bob_state,
-        |state| matches!(state, BobState::BtcLocked(..)),
+    let bob_btc_locked_fut = bob::swap::Swap::new(
         bob_event_loop_handle,
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
         Uuid::new_v4(),
-    );
+    )
+    .run_until(bob_state, |state| matches!(state, BobState::BtcLocked(..)));
 
     let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -72,7 +72,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
 
     let bob_btc_locked_fut = bob::swap::run_until(
         bob_state,
-        bob::swap::is_btc_locked,
+        |state| matches!(state, BobState::BtcLocked(..)),
         bob_event_loop_handle,
         bob_db,
         bob_btc_wallet.clone(),

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,7 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
 use libp2p::Multiaddr;
-use rand::rngs::OsRng;
 use swap::{alice, alice::swap::AliceState, bob, bob::swap::BobState};
 use testcontainers::clients::Cli;
 use testutils::init_tracing;
@@ -77,7 +76,6 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
-        OsRng,
         Uuid::new_v4(),
     );
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -83,8 +83,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
 
     let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
 
-    let alice_fut = alice::swap::swap(
-        alice_state,
+    let alice_swap = alice::swap::Swap::new(
         alice_event_loop_handle,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),
@@ -92,6 +91,8 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         Uuid::new_v4(),
         alice_db,
     );
+
+    let alice_fut = alice_swap.swap(alice_state);
 
     let _alice_swarm_fut = tokio::spawn(async move { alice_event_loop.run().await });
 

--- a/swap/tests/refund_restart.rs
+++ b/swap/tests/refund_restart.rs
@@ -88,7 +88,12 @@ async fn both_refund() {
 
     let alice_xmr_locked_fut = alice::swap::run_until(
         alice_state,
-        alice::swap::is_xmr_locked,
+        |state| {
+            matches!(
+                state,
+                AliceState::XmrLocked{..}
+            )
+        },
         alice_event_loop_handle,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),

--- a/swap/tests/refund_restart.rs
+++ b/swap/tests/refund_restart.rs
@@ -69,14 +69,14 @@ async fn both_refund() {
         )
         .await;
 
-    let bob_fut = bob::swap::swap(
-        bob_state,
+    let bob_fut = bob::swap::Swap::new(
         bob_event_loop_handle,
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
         Uuid::new_v4(),
-    );
+    )
+    .swap(bob_state);
 
     tokio::spawn(async move { bob_event_loop.run().await });
 

--- a/swap/tests/refund_restart.rs
+++ b/swap/tests/refund_restart.rs
@@ -1,7 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
 use libp2p::Multiaddr;
-use rand::rngs::OsRng;
 use swap::{alice, alice::swap::AliceState, bob, bob::swap::BobState, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
@@ -76,7 +75,6 @@ async fn both_refund() {
         bob_db,
         bob_btc_wallet.clone(),
         bob_xmr_wallet.clone(),
-        OsRng,
         Uuid::new_v4(),
     );
 


### PR DESCRIPTION
Optional Change. 

Replaces the breaks and continues in run_until with a returns. There is one function to transition the state (`next_state`) and another to run the state machine. The state transition function no longer has to have knowledge of how it is being called.