### PR TITLE
 Bob refunds swap after restart that requires communication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: cargo +nightly test --workspace --all-features -- -Z unstable-options --report-time
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
-          RUST_MIN_STACK: 10000000
+          RUST_MIN_STACK: 16777216 # 16 MB. Default is 8MB. This is fine as in tests we start 2 programs: Alice and Bob.
 
       - name: Build binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-port"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c41a39c60ae1fc5bf0e220347ce90fa1e4bb0fcdac65b09bb5f4576bebc84"
+
+[[package]]
 name = "get_if_addrs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3318,7 @@ dependencies = [
  "ecdsa_fun",
  "futures",
  "genawaiter",
+ "get-port",
  "hyper",
  "libp2p",
  "libp2p-tokio-socks5",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -48,6 +48,7 @@ void = "1"
 xmr-btc = { path = "../xmr-btc" }
 
 [dev-dependencies]
+get-port = "3"
 hyper = "0.13"
 port_check = "0.1"
 spectral = "0.6"

--- a/swap/src/alice/event_loop.rs
+++ b/swap/src/alice/event_loop.rs
@@ -242,4 +242,8 @@ impl EventLoop {
             }
         }
     }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.swarm.peer_id()
+    }
 }

--- a/swap/src/bob.rs
+++ b/swap/src/bob.rs
@@ -10,7 +10,10 @@ use crate::{
     SwapAmounts,
 };
 use anyhow::Result;
-use libp2p::{core::identity::Keypair, NetworkBehaviour, PeerId};
+use libp2p::{
+    core::{identity::Keypair, Multiaddr},
+    NetworkBehaviour, PeerId,
+};
 use tracing::{debug, info};
 use xmr_btc::{
     alice,
@@ -159,9 +162,9 @@ impl Behaviour {
         debug!("Sent Message3");
     }
 
-    /// Returns Alice's peer id if we are connected.
-    pub fn peer_id_of_alice(&self) -> Option<PeerId> {
-        self.pt.counterparty_peer_id()
+    /// Add a known address for the given peer
+    pub fn add_address(&mut self, peer_id: PeerId, address: Multiaddr) {
+        self.pt.add_address(peer_id, address)
     }
 }
 

--- a/swap/src/bob/event_loop.rs
+++ b/swap/src/bob/event_loop.rs
@@ -69,6 +69,7 @@ impl EventLoopHandle {
     /// Dials other party and wait for the connection to be established.
     /// Do nothing if we are already connected
     pub async fn dial(&mut self, peer_id: PeerId) -> Result<()> {
+        debug!("Attempt to dial Alice {}", peer_id);
         let _ = self.dial_alice.send(peer_id).await?;
 
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -82,7 +83,7 @@ impl EventLoopHandle {
     }
 
     pub async fn add_address(&mut self, peer_id: PeerId, addr: Multiaddr) -> Result<()> {
-        debug!("Add address {} for peer id {}", addr, peer_id);
+        debug!("Attempt to add address {} for peer id {}", addr, peer_id);
         self.add_address.send((peer_id, addr)).await?;
         Ok(())
     }

--- a/swap/src/bob/event_loop.rs
+++ b/swap/src/bob/event_loop.rs
@@ -72,8 +72,6 @@ impl EventLoopHandle {
         debug!("Attempt to dial Alice {}", peer_id);
         let _ = self.dial_alice.send(peer_id).await?;
 
-        std::thread::sleep(std::time::Duration::from_millis(100));
-
         self.conn_established
             .recv()
             .await

--- a/swap/src/bob/event_loop.rs
+++ b/swap/src/bob/event_loop.rs
@@ -9,7 +9,7 @@ use tokio::{
     stream::StreamExt,
     sync::mpsc::{Receiver, Sender},
 };
-use tracing::info;
+use tracing::{debug, error, info};
 use xmr_btc::{alice, bitcoin::EncryptedSignature, bob};
 
 pub struct Channels<T> {
@@ -36,7 +36,8 @@ pub struct EventLoopHandle {
     msg2: Receiver<alice::Message2>,
     request_amounts: Sender<(PeerId, ::bitcoin::Amount)>,
     conn_established: Receiver<PeerId>,
-    dial_alice: Sender<Multiaddr>,
+    dial_alice: Sender<PeerId>,
+    add_address: Sender<(PeerId, Multiaddr)>,
     send_msg0: Sender<(PeerId, bob::Message0)>,
     send_msg1: Sender<(PeerId, bob::Message1)>,
     send_msg2: Sender<(PeerId, bob::Message2)>,
@@ -44,13 +45,6 @@ pub struct EventLoopHandle {
 }
 
 impl EventLoopHandle {
-    pub async fn recv_conn_established(&mut self) -> Result<PeerId> {
-        self.conn_established
-            .recv()
-            .await
-            .ok_or_else(|| anyhow!("Failed to receive connection established from Bob"))
-    }
-
     pub async fn recv_message0(&mut self) -> Result<alice::Message0> {
         self.msg0
             .recv()
@@ -72,9 +66,24 @@ impl EventLoopHandle {
             .ok_or_else(|| anyhow!("Failed o receive message 2 from Bob"))
     }
 
-    pub async fn dial_alice(&mut self, addr: Multiaddr) -> Result<()> {
-        info!("sending msg to ourselves to dial alice: {}", addr);
-        let _ = self.dial_alice.send(addr).await?;
+    /// Dials other party and wait for the connection to be established.
+    /// Do nothing if we are already connected
+    pub async fn dial(&mut self, peer_id: PeerId) -> Result<()> {
+        let _ = self.dial_alice.send(peer_id).await?;
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        self.conn_established
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("Failed to receive connection established from Alice"))?;
+
+        Ok(())
+    }
+
+    pub async fn add_address(&mut self, peer_id: PeerId, addr: Multiaddr) -> Result<()> {
+        debug!("Add address {} for peer id {}", addr, peer_id);
+        self.add_address.send((peer_id, addr)).await?;
         Ok(())
     }
 
@@ -119,7 +128,8 @@ pub struct EventLoop {
     msg2: Sender<alice::Message2>,
     conn_established: Sender<PeerId>,
     request_amounts: Receiver<(PeerId, ::bitcoin::Amount)>,
-    dial_alice: Receiver<Multiaddr>,
+    dial_alice: Receiver<PeerId>,
+    add_address: Receiver<(PeerId, Multiaddr)>,
     send_msg0: Receiver<(PeerId, bob::Message0)>,
     send_msg1: Receiver<(PeerId, bob::Message1)>,
     send_msg2: Receiver<(PeerId, bob::Message2)>,
@@ -142,6 +152,7 @@ impl EventLoop {
         let msg2 = Channels::new();
         let conn_established = Channels::new();
         let dial_alice = Channels::new();
+        let add_address = Channels::new();
         let send_msg0 = Channels::new();
         let send_msg1 = Channels::new();
         let send_msg2 = Channels::new();
@@ -155,6 +166,7 @@ impl EventLoop {
             msg2: msg2.sender,
             conn_established: conn_established.sender,
             dial_alice: dial_alice.receiver,
+            add_address: add_address.receiver,
             send_msg0: send_msg0.receiver,
             send_msg1: send_msg1.receiver,
             send_msg2: send_msg2.receiver,
@@ -168,6 +180,7 @@ impl EventLoop {
             msg2: msg2.receiver,
             conn_established: conn_established.receiver,
             dial_alice: dial_alice.sender,
+            add_address: add_address.sender,
             send_msg0: send_msg0.sender,
             send_msg1: send_msg1.sender,
             send_msg2: send_msg2.sender,
@@ -182,8 +195,8 @@ impl EventLoop {
             tokio::select! {
                 swarm_event = self.swarm.next().fuse() => {
                     match swarm_event {
-                        OutEvent::ConnectionEstablished(alice) => {
-                            let _ = self.conn_established.send(alice).await;
+                        OutEvent::ConnectionEstablished(peer_id) => {
+                            let _ = self.conn_established.send(peer_id).await;
                         }
                         OutEvent::Amounts(_amounts) => info!("Amounts received from Alice"),
                         OutEvent::Message0(msg) => {
@@ -198,10 +211,25 @@ impl EventLoop {
                         OutEvent::Message3 => info!("Alice acknowledged message 3 received"),
                     }
                 },
-                addr = self.dial_alice.next().fuse() => {
-                    if let Some(addr) = addr {
-                        info!("dialing alice: {}", addr);
-                        libp2p::Swarm::dial_addr(&mut self.swarm, addr).expect("Could not dial alice");
+                peer_id_addr = self.add_address.next().fuse() => {
+                    if let Some((peer_id, addr)) = peer_id_addr {
+                        debug!("Add address for {}: {}", peer_id, addr);
+                        self.swarm.add_address(peer_id, addr);
+                    }
+                },
+                peer_id = self.dial_alice.next().fuse() => {
+                    if let Some(peer_id) = peer_id {
+                        if self.swarm.pt.is_connected(&peer_id) {
+                            debug!("Already connected to Alice: {}", peer_id);
+                            let _ = self.conn_established.send(peer_id).await;
+                        } else {
+                            info!("dialing alice: {}", peer_id);
+                            if let Err(err) = libp2p::Swarm::dial(&mut self.swarm, &peer_id) {
+                                error!("Could not dial alice: {}", err);
+                                // TODO(Franck): If Dial fails then we should report it.
+                            }
+
+                        }
                     }
                 },
                 amounts = self.request_amounts.next().fuse() =>  {

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -1,4 +1,4 @@
-use libp2p::core::Multiaddr;
+use libp2p::{core::Multiaddr, PeerId};
 use url::Url;
 use uuid::Uuid;
 
@@ -47,6 +47,9 @@ pub enum Command {
         receive_bitcoin: bitcoin::Amount,
     },
     BuyXmr {
+        #[structopt(short = "p", long = "connect-peer-id")]
+        alice_peer_id: PeerId,
+
         #[structopt(short = "a", long = "connect-addr")]
         alice_addr: Multiaddr,
 
@@ -77,6 +80,12 @@ pub enum Command {
     Resume {
         #[structopt(short = "id", long = "swap-id")]
         swap_id: Uuid,
+
+        #[structopt(short = "p", long = "connect-peer-id")]
+        alice_peer_id: PeerId,
+
+        #[structopt(short = "a", long = "connect-addr")]
+        alice_addr: Multiaddr,
 
         #[structopt(
             short = "b",

--- a/swap/src/state.rs
+++ b/swap/src/state.rs
@@ -56,8 +56,6 @@ pub enum Bob {
     },
     EncSigSent {
         state4: bob::State4,
-        #[serde(with = "crate::serde::peer_id")]
-        peer_id: PeerId,
     },
     BtcRedeemed(bob::State5),
     T1Expired(bob::State4),

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,5 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
+use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use swap::{alice, bob};
@@ -35,8 +36,8 @@ async fn happy_path() {
     let xmr_alice = xmr_to_swap * 10;
     let xmr_bob = xmr_btc::monero::Amount::ZERO;
 
-    // todo: This should not be hardcoded
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9876"
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
         .parse()
         .expect("failed to parse Alice's address");
 

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -63,7 +63,8 @@ async fn happy_path() {
 
     let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
         init_bob(
-            alice_multiaddr,
+            alice_multiaddr.clone(),
+            alice_event_loop.peer_id(),
             &bitcoind,
             &monero,
             btc_to_swap,
@@ -83,6 +84,8 @@ async fn happy_path() {
         alice_db,
     );
 
+    let alice_peer_id = alice_event_loop.peer_id();
+
     let _alice_swarm_fut = tokio::spawn(async move { alice_event_loop.run().await });
 
     let bob_swap_fut = bob::swap::swap(
@@ -93,6 +96,8 @@ async fn happy_path() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        alice_peer_id,
+        alice_multiaddr,
     );
 
     let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -56,9 +56,12 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     )
     .await;
 
+    let alice_peer_id = alice_event_loop.peer_id();
+
     let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
         init_bob(
             alice_multiaddr.clone(),
+            alice_peer_id.clone(),
             &bitcoind,
             &monero,
             btc_to_swap,
@@ -73,18 +76,17 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     let bob_btc_wallet_clone = bob_btc_wallet.clone();
     let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
 
-    let _ = tokio::spawn(async move {
-        bob::swap::swap(
-            bob_state,
-            bob_event_loop_handle,
-            bob_db,
-            bob_btc_wallet.clone(),
-            bob_xmr_wallet.clone(),
-            OsRng,
-            Uuid::new_v4(),
-        )
-        .await
-    });
+    let _ = tokio::spawn(bob::swap::swap(
+        bob_state,
+        bob_event_loop_handle,
+        bob_db,
+        bob_btc_wallet.clone(),
+        bob_xmr_wallet.clone(),
+        OsRng,
+        Uuid::new_v4(),
+        alice_peer_id,
+        alice_multiaddr.clone(),
+    ));
 
     let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,16 +1,16 @@
+use crate::testutils::{init_alice, init_bob};
+use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
+use std::convert::TryFrom;
 use swap::{alice, alice::swap::AliceState, bitcoin, bob, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
+use testutils::init_tracing;
 use uuid::Uuid;
 use xmr_btc::config::Config;
 
 pub mod testutils;
-
-use crate::testutils::{init_alice, init_bob};
-use std::convert::TryFrom;
-use testutils::init_tracing;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
@@ -31,7 +31,8 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     let bob_btc_starting_balance = btc_to_swap * 10;
     let alice_xmr_starting_balance = xmr_to_swap * 10;
 
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9877"
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
         .parse()
         .expect("failed to parse Alice's address");
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -76,7 +76,7 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     let bob_btc_wallet_clone = bob_btc_wallet.clone();
     let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
 
-    let _ = tokio::spawn(bob::swap::swap(
+    let bob_fut = bob::swap::swap(
         bob_state,
         bob_event_loop_handle,
         bob_db,
@@ -86,14 +86,14 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         Uuid::new_v4(),
         alice_peer_id,
         alice_multiaddr.clone(),
-    ));
-
-    let _bob_swarm_fut = tokio::spawn(async move { bob_event_loop.run().await });
+    );
 
     let alice_db_datadir = tempdir().unwrap();
     let alice_db = Database::open(alice_db_datadir.path()).unwrap();
 
-    let _alice_swarm_fut = tokio::spawn(async move { alice_event_loop.run().await });
+    tokio::spawn(async move { alice_event_loop.run().await });
+    tokio::spawn(bob_fut);
+    tokio::spawn(bob_event_loop.run());
 
     let alice_swap_id = Uuid::new_v4();
 

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -3,10 +3,11 @@ use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use std::convert::TryFrom;
-use swap::{alice, bitcoin, bob, bob::swap::BobState, storage::Database};
+use swap::{alice, alice::swap::AliceState, bitcoin, bob, bob::swap::BobState, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
 use testutils::init_tracing;
+use tokio::select;
 use uuid::Uuid;
 use xmr_btc::config::Config;
 
@@ -56,9 +57,11 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
     )
     .await;
 
+    let alice_peer_id = alice_event_loop.peer_id();
     let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, _) =
         init_bob(
             alice_multiaddr.clone(),
+            alice_peer_id.clone(),
             &bitcoind,
             &monero,
             btc_to_swap,
@@ -136,6 +139,8 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         bob_xmr_wallet,
         OsRng,
         bob_swap_id,
+        alice_peer_id,
+        alice_multiaddr,
     )
     .await
     .unwrap();
@@ -157,4 +162,150 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
     assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
     assert_eq!(xmr_bob_final, xmr_to_swap);
+}
+
+#[tokio::test]
+async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
+    let _guard = init_tracing();
+
+    let cli = Cli::default();
+    let (
+        monero,
+        testutils::Containers {
+            bitcoind,
+            monerods: _monerods,
+        },
+    ) = testutils::init_containers(&cli).await;
+
+    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
+    let xmr_to_swap = xmr_btc::monero::Amount::from_piconero(1_000_000_000_000);
+
+    let bob_btc_starting_balance = btc_to_swap * 10;
+    let bob_xmr_starting_balance = xmr_btc::monero::Amount::from_piconero(0);
+
+    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
+    let alice_xmr_starting_balance = xmr_to_swap * 10;
+
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
+        .parse()
+        .expect("failed to parse Alice's address");
+
+    let (
+        alice_state,
+        mut alice_event_loop,
+        alice_event_loop_handle,
+        alice_btc_wallet,
+        alice_xmr_wallet,
+        alice_db,
+    ) = init_alice(
+        &bitcoind,
+        &monero,
+        btc_to_swap,
+        xmr_to_swap,
+        alice_xmr_starting_balance,
+        alice_multiaddr.clone(),
+        Config::regtest(),
+    )
+    .await;
+
+    let alice_peer_id = alice_event_loop.peer_id();
+    let (bob_state, bob_event_loop_1, bob_event_loop_handle_1, bob_btc_wallet, bob_xmr_wallet, _) =
+        init_bob(
+            alice_multiaddr.clone(),
+            alice_peer_id.clone(),
+            &bitcoind,
+            &monero,
+            btc_to_swap,
+            bob_btc_starting_balance,
+            xmr_to_swap,
+            Config::regtest(),
+        )
+        .await;
+
+    let alice_fut = alice::swap::swap(
+        alice_state,
+        alice_event_loop_handle,
+        alice_btc_wallet.clone(),
+        alice_xmr_wallet.clone(),
+        Config::regtest(),
+        Uuid::new_v4(),
+        alice_db,
+    );
+
+    let bob_swap_id = Uuid::new_v4();
+    let bob_db_datadir = tempdir().unwrap();
+
+    let bob_xmr_locked_fut = {
+        let bob_db = Database::open(bob_db_datadir.path()).unwrap();
+        bob::swap::run_until(
+            bob_state,
+            bob::swap::is_xmr_locked,
+            bob_event_loop_handle_1,
+            bob_db,
+            bob_btc_wallet.clone(),
+            bob_xmr_wallet.clone(),
+            OsRng,
+            bob_swap_id,
+        )
+    };
+
+    tokio::spawn(async move { alice_event_loop.run().await });
+
+    let alice_fut_handle = tokio::spawn(alice_fut);
+
+    // We are selecting with bob_event_loop_1 so that we stop polling on it once
+    // bob reaches `xmr locked` state.
+    let bob_restart_state = select! {
+        res = bob_xmr_locked_fut => res.unwrap(),
+        _ = bob_event_loop_1.run() => panic!("The event loop should never finish")
+    };
+
+    // let tx_lock_id = if let AliceState::BtcRefunded { state3, .. } = alice_state
+    // {     state3.tx_lock.txid()
+    // } else {
+    //     panic!(format!("Alice in unexpected state: {}", alice_state));
+    // };
+
+    let (bob_event_loop_2, bob_event_loop_handle_2) = testutils::init_bob_event_loop();
+
+    let bob_fut = bob::swap::swap(
+        bob_restart_state,
+        bob_event_loop_handle_2,
+        Database::open(bob_db_datadir.path()).unwrap(),
+        bob_btc_wallet.clone(),
+        bob_xmr_wallet.clone(),
+        OsRng,
+        bob_swap_id,
+        alice_peer_id,
+        alice_multiaddr,
+    );
+
+    let bob_final_state = select! {
+     bob_final_state = bob_fut => bob_final_state.unwrap(),
+     _ = bob_event_loop_2.run() => panic!("Event loop is not expected to stop")
+    };
+
+    assert!(matches!(bob_final_state, BobState::XmrRedeemed));
+
+    // Wait for Alice to finish too.
+    let alice_final_state = alice_fut_handle.await.unwrap().unwrap();
+    assert!(matches!(alice_final_state, AliceState::BtcRedeemed));
+
+    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
+    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
+
+    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
+
+    bob_xmr_wallet.as_ref().0.refresh().await.unwrap();
+    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
+
+    assert_eq!(
+        btc_alice_final,
+        alice_btc_starting_balance + btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+    );
+    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
+
+    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
+    assert_eq!(xmr_bob_final, bob_xmr_starting_balance + xmr_to_swap);
 }

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -1,17 +1,16 @@
+use crate::testutils::{init_alice, init_bob};
+use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
-use swap::{alice, bitcoin, bob, storage::Database};
+use std::convert::TryFrom;
+use swap::{alice, bitcoin, bob, bob::swap::BobState, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
+use testutils::init_tracing;
 use uuid::Uuid;
 use xmr_btc::config::Config;
 
 pub mod testutils;
-
-use crate::testutils::{init_alice, init_bob};
-use std::convert::TryFrom;
-use swap::bob::swap::BobState;
-use testutils::init_tracing;
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
@@ -32,7 +31,8 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
     let bob_btc_starting_balance = btc_to_swap * 10;
     let alice_xmr_starting_balance = xmr_to_swap * 10;
 
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9877"
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
         .parse()
         .expect("failed to parse Alice's address");
 

--- a/swap/tests/happy_path_restart_bob.rs
+++ b/swap/tests/happy_path_restart_bob.rs
@@ -261,12 +261,6 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
         _ = bob_event_loop_1.run() => panic!("The event loop should never finish")
     };
 
-    // let tx_lock_id = if let AliceState::BtcRefunded { state3, .. } = alice_state
-    // {     state3.tx_lock.txid()
-    // } else {
-    //     panic!(format!("Alice in unexpected state: {}", alice_state));
-    // };
-
     let (bob_event_loop_2, bob_event_loop_handle_2) = testutils::init_bob_event_loop();
 
     let bob_fut = bob::swap::swap(

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -3,11 +3,10 @@ use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use std::convert::TryFrom;
-use swap::{alice, alice::swap::AliceState, bitcoin, bob, bob::swap::BobState, storage::Database};
+use swap::{alice, bitcoin, bob, bob::swap::BobState, storage::Database};
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
 use testutils::init_tracing;
-use tokio::select;
 use uuid::Uuid;
 use xmr_btc::config::Config;
 
@@ -162,144 +161,4 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
     assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
     assert_eq!(xmr_bob_final, xmr_to_swap);
-}
-
-#[tokio::test]
-async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    let _guard = init_tracing();
-
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
-
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = xmr_btc::monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-    let bob_xmr_starting_balance = xmr_btc::monero::Amount::from_piconero(0);
-
-    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let (
-        alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_db,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        Config::regtest(),
-    )
-    .await;
-
-    let alice_peer_id = alice_event_loop.peer_id();
-    let (bob_state, bob_event_loop_1, bob_event_loop_handle_1, bob_btc_wallet, bob_xmr_wallet, _) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_peer_id.clone(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            Config::regtest(),
-        )
-        .await;
-
-    let alice_fut = alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        Config::regtest(),
-        Uuid::new_v4(),
-        alice_db,
-    );
-
-    let bob_swap_id = Uuid::new_v4();
-    let bob_db_datadir = tempdir().unwrap();
-
-    let bob_xmr_locked_fut = {
-        let bob_db = Database::open(bob_db_datadir.path()).unwrap();
-        bob::swap::run_until(
-            bob_state,
-            bob::swap::is_xmr_locked,
-            bob_event_loop_handle_1,
-            bob_db,
-            bob_btc_wallet.clone(),
-            bob_xmr_wallet.clone(),
-            OsRng,
-            bob_swap_id,
-        )
-    };
-
-    tokio::spawn(async move { alice_event_loop.run().await });
-
-    let alice_fut_handle = tokio::spawn(alice_fut);
-
-    // We are selecting with bob_event_loop_1 so that we stop polling on it once
-    // bob reaches `xmr locked` state.
-    let bob_restart_state = select! {
-        res = bob_xmr_locked_fut => res.unwrap(),
-        _ = bob_event_loop_1.run() => panic!("The event loop should never finish")
-    };
-
-    let (bob_event_loop_2, bob_event_loop_handle_2) = testutils::init_bob_event_loop();
-
-    let bob_fut = bob::swap::swap(
-        bob_restart_state,
-        bob_event_loop_handle_2,
-        Database::open(bob_db_datadir.path()).unwrap(),
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        bob_swap_id,
-        alice_peer_id,
-        alice_multiaddr,
-    );
-
-    let bob_final_state = select! {
-     bob_final_state = bob_fut => bob_final_state.unwrap(),
-     _ = bob_event_loop_2.run() => panic!("Event loop is not expected to stop")
-    };
-
-    assert!(matches!(bob_final_state, BobState::XmrRedeemed));
-
-    // Wait for Alice to finish too.
-    let alice_final_state = alice_fut_handle.await.unwrap().unwrap();
-    assert!(matches!(alice_final_state, AliceState::BtcRedeemed));
-
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
-
-    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    bob_xmr_wallet.as_ref().0.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    assert_eq!(
-        btc_alice_final,
-        alice_btc_starting_balance + btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
-    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
-
-    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
-    assert_eq!(xmr_bob_final, bob_xmr_starting_balance + xmr_to_swap);
 }

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,0 +1,153 @@
+use crate::testutils::{init_alice, init_bob};
+use get_port::get_port;
+use libp2p::Multiaddr;
+use rand::rngs::OsRng;
+use swap::{alice, alice::swap::AliceState, bitcoin, bob, bob::swap::BobState, storage::Database};
+use tempfile::tempdir;
+use testcontainers::clients::Cli;
+use testutils::init_tracing;
+use tokio::select;
+use uuid::Uuid;
+use xmr_btc::config::Config;
+
+pub mod testutils;
+
+#[tokio::test]
+async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
+    let _guard = init_tracing();
+
+    let cli = Cli::default();
+    let (
+        monero,
+        testutils::Containers {
+            bitcoind,
+            monerods: _monerods,
+        },
+    ) = testutils::init_containers(&cli).await;
+
+    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
+    let xmr_to_swap = xmr_btc::monero::Amount::from_piconero(1_000_000_000_000);
+
+    let bob_btc_starting_balance = btc_to_swap * 10;
+    let bob_xmr_starting_balance = xmr_btc::monero::Amount::from_piconero(0);
+
+    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
+    let alice_xmr_starting_balance = xmr_to_swap * 10;
+
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
+        .parse()
+        .expect("failed to parse Alice's address");
+
+    let (
+        alice_state,
+        mut alice_event_loop,
+        alice_event_loop_handle,
+        alice_btc_wallet,
+        alice_xmr_wallet,
+        alice_db,
+    ) = init_alice(
+        &bitcoind,
+        &monero,
+        btc_to_swap,
+        xmr_to_swap,
+        alice_xmr_starting_balance,
+        alice_multiaddr.clone(),
+        Config::regtest(),
+    )
+    .await;
+
+    let alice_peer_id = alice_event_loop.peer_id();
+    let (bob_state, bob_event_loop_1, bob_event_loop_handle_1, bob_btc_wallet, bob_xmr_wallet, _) =
+        init_bob(
+            alice_multiaddr.clone(),
+            alice_peer_id.clone(),
+            &bitcoind,
+            &monero,
+            btc_to_swap,
+            bob_btc_starting_balance,
+            xmr_to_swap,
+            Config::regtest(),
+        )
+        .await;
+
+    let alice_fut = alice::swap::swap(
+        alice_state,
+        alice_event_loop_handle,
+        alice_btc_wallet.clone(),
+        alice_xmr_wallet.clone(),
+        Config::regtest(),
+        Uuid::new_v4(),
+        alice_db,
+    );
+
+    let bob_swap_id = Uuid::new_v4();
+    let bob_db_datadir = tempdir().unwrap();
+
+    let bob_xmr_locked_fut = {
+        let bob_db = Database::open(bob_db_datadir.path()).unwrap();
+        bob::swap::run_until(
+            bob_state,
+            bob::swap::is_xmr_locked,
+            bob_event_loop_handle_1,
+            bob_db,
+            bob_btc_wallet.clone(),
+            bob_xmr_wallet.clone(),
+            OsRng,
+            bob_swap_id,
+        )
+    };
+
+    tokio::spawn(async move { alice_event_loop.run().await });
+
+    let alice_fut_handle = tokio::spawn(alice_fut);
+
+    // We are selecting with bob_event_loop_1 so that we stop polling on it once
+    // bob reaches `xmr locked` state.
+    let bob_restart_state = select! {
+        res = bob_xmr_locked_fut => res.unwrap(),
+        _ = bob_event_loop_1.run() => panic!("The event loop should never finish")
+    };
+
+    let (bob_event_loop_2, bob_event_loop_handle_2) = testutils::init_bob_event_loop();
+
+    let bob_fut = bob::swap::swap(
+        bob_restart_state,
+        bob_event_loop_handle_2,
+        Database::open(bob_db_datadir.path()).unwrap(),
+        bob_btc_wallet.clone(),
+        bob_xmr_wallet.clone(),
+        OsRng,
+        bob_swap_id,
+        alice_peer_id,
+        alice_multiaddr,
+    );
+
+    let bob_final_state = select! {
+     bob_final_state = bob_fut => bob_final_state.unwrap(),
+     _ = bob_event_loop_2.run() => panic!("Event loop is not expected to stop")
+    };
+
+    assert!(matches!(bob_final_state, BobState::XmrRedeemed));
+
+    // Wait for Alice to finish too.
+    let alice_final_state = alice_fut_handle.await.unwrap().unwrap();
+    assert!(matches!(alice_final_state, AliceState::BtcRedeemed));
+
+    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
+    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
+
+    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
+
+    bob_xmr_wallet.as_ref().0.refresh().await.unwrap();
+    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
+
+    assert_eq!(
+        btc_alice_final,
+        alice_btc_starting_balance + btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+    );
+    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
+
+    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
+    assert_eq!(xmr_bob_final, bob_xmr_starting_balance + xmr_to_swap);
+}

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,5 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
+use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use swap::{alice, alice::swap::AliceState, bob, bob::swap::BobState};
@@ -33,8 +34,8 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
     let alice_btc_starting_balance = bitcoin::Amount::ZERO;
     let alice_xmr_starting_balance = xmr_to_swap * 10;
 
-    // todo: This should not be hardcoded
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9877"
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
         .parse()
         .expect("failed to parse Alice's address");
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -62,6 +62,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
     let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
         init_bob(
             alice_multiaddr,
+            alice_event_loop.peer_id(),
             &bitcoind,
             &monero,
             btc_to_swap,

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -7,6 +7,7 @@ use swap::{alice, alice::swap::AliceState, bob, bob::swap::BobState, storage::Da
 use tempfile::tempdir;
 use testcontainers::clients::Cli;
 use testutils::init_tracing;
+use tokio::select;
 use uuid::Uuid;
 use xmr_btc::{bitcoin, config::Config};
 
@@ -43,8 +44,8 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
 
     let (
         alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
+        mut alice_event_loop_1,
+        alice_event_loop_handle_1,
         alice_btc_wallet,
         alice_xmr_wallet,
         _,
@@ -81,8 +82,6 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         Uuid::new_v4(),
     );
 
-    tokio::spawn(async move { bob_event_loop.run().await });
-
     let alice_swap_id = Uuid::new_v4();
     let alice_db_datadir = tempdir().unwrap();
     let alice_db = Database::open(alice_db_datadir.path()).unwrap();
@@ -90,7 +89,7 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     let alice_xmr_locked_fut = alice::swap::run_until(
         alice_state,
         alice::swap::is_xmr_locked,
-        alice_event_loop_handle,
+        alice_event_loop_handle_1,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),
         Config::regtest(),
@@ -98,10 +97,14 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         alice_db,
     );
 
-    tokio::spawn(async move { alice_event_loop.run().await });
+    tokio::spawn(async move { bob_event_loop.run().await });
 
-    // Wait until alice has locked xmr and bob has locked btc
-    let (bob_state, alice_state) = try_join(bob_fut, alice_xmr_locked_fut).await.unwrap();
+    // We are selecting with alice_event_loop_1 so that we stop polling on it once
+    // the try_join is finished.
+    let (bob_state, alice_restart_state) = select! {
+        res = try_join(bob_fut, alice_xmr_locked_fut) => res.unwrap(),
+        _ = alice_event_loop_1.run() => panic!("The event loop should never finish")
+    };
 
     let bob_state4 = if let BobState::BtcRefunded(state4) = bob_state {
         state4
@@ -110,12 +113,12 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     };
 
     let alice_db = Database::open(alice_db_datadir.path()).unwrap();
-    let (mut alice_event_loop, alice_event_loop_handle) =
+    let (mut alice_event_loop_2, alice_event_loop_handle_2) =
         testutils::init_alice_event_loop(alice_multiaddr);
 
-    let alice_state = alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
+    let alice_final_state = alice::swap::swap(
+        alice_restart_state,
+        alice_event_loop_handle_2,
         alice_btc_wallet.clone(),
         alice_xmr_wallet.clone(),
         Config::regtest(),
@@ -124,15 +127,13 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     )
     .await
     .unwrap();
-    tokio::spawn(async move { alice_event_loop.run().await });
+    tokio::spawn(async move { alice_event_loop_2.run().await });
 
-    assert!(matches!(alice_state, AliceState::XmrRefunded));
+    assert!(matches!(alice_final_state, AliceState::XmrRefunded));
 
     let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
     let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
 
-    // lock_tx_bitcoin_fee is determined by the wallet, it is not necessarily equal
-    // to TX_FEE
     let lock_tx_bitcoin_fee = bob_btc_wallet
         .transaction_fee(bob_state4.tx_lock_id())
         .await

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,5 +1,6 @@
 use crate::testutils::{init_alice, init_bob};
 use futures::future::try_join;
+use get_port::get_port;
 use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use swap::{alice, alice::swap::AliceState, bob, bob::swap::BobState, storage::Database};
@@ -35,8 +36,8 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     let alice_btc_starting_balance = bitcoin::Amount::ZERO;
     let alice_xmr_starting_balance = xmr_to_swap * 10;
 
-    // todo: This should not be hardcoded
-    let alice_multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/9879"
+    let port = get_port().expect("Failed to find a free port");
+    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
         .parse()
         .expect("failed to parse Alice's address");
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -108,8 +108,8 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         _ = alice_event_loop_1.run() => panic!("The event loop should never finish")
     };
 
-    let bob_state4 = if let BobState::BtcRefunded(state4) = bob_state {
-        state4
+    let tx_lock_id = if let BobState::BtcRefunded(state4) = bob_state {
+        state4.tx_lock_id()
     } else {
         panic!("Bob in unexpected state");
     };
@@ -138,10 +138,7 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
     let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
 
-    let lock_tx_bitcoin_fee = bob_btc_wallet
-        .transaction_fee(bob_state4.tx_lock_id())
-        .await
-        .unwrap();
+    let lock_tx_bitcoin_fee = bob_btc_wallet.transaction_fee(tx_lock_id).await.unwrap();
 
     assert_eq!(btc_alice_final, alice_btc_starting_balance);
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -14,7 +14,7 @@ pub mod testutils;
 // Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
 // then also refunds.
 #[tokio::test]
-async fn both_refund() {
+async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     let _guard = init_tracing();
 
     let cli = Cli::default();

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -63,6 +63,7 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
     let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
         init_bob(
             alice_multiaddr.clone(),
+            alice_event_loop_1.peer_id(),
             &bitcoind,
             &monero,
             btc_to_swap,
@@ -80,6 +81,8 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        alice_event_loop_1.peer_id(),
+        alice_multiaddr.clone(),
     );
 
     let alice_swap_id = Uuid::new_v4();


### PR DESCRIPTION
As Bob is dialing Alice, we now ensure that we are connected to Alice
at each step that needs communication.
If we are not connected, we proceed with dialing.

In an attempt to improve libp2p usage, we also add known address of
Alice first and only use peer_id to dial.
This ensures that we use the expected peer id.