### PR TITLE
Allow Bob to try to refund after T2 has passed

### DIFF
--- a/swap/src/bob/swap.rs
+++ b/swap/src/bob/swap.rs
@@ -10,7 +10,7 @@ use async_recursion::async_recursion;
 use rand::{CryptoRng, RngCore};
 use std::{convert::TryFrom, fmt, sync::Arc};
 use tokio::select;
-use tracing::{info, warn};
+use tracing::{error, info};
 use uuid::Uuid;
 use xmr_btc::{
     bob::{self, State2},
@@ -407,7 +407,7 @@ where
                         match refund_result {
                             Ok(()) => BobState::BtcRefunded(state),
                             Err(err) => {
-                                warn!("Bob tried to refund after T2 has passed, but sending the refund tx errored with {}", err);
+                                error!("Bob tried to refund after T2 has passed, but sending the refund tx errored with {}", err);
                                 BobState::Punished
                             }
                         }


### PR DESCRIPTION
If we don't allow this, then Bob cannot refund Bitcoin if:
Alice started a swap with Bob but never acts after the start (and remains offline).
Bob is offline until T2 has passed.

Note: This helps recovering funds, but strictly speaking we would not have to implement it because in a scenario where T2 is expired Alice should punish. Bob has to act to refund after T1 but before T2 expired. I would still add this, because it should not change the behavior and makes recovery for Bob easier.