### PR TITLE
Fix tracing subscribe filter for xmr-btc`

### DIFF
--- a/swap/src/trace.rs
+++ b/swap/src/trace.rs
@@ -15,7 +15,7 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
     let is_terminal = atty::is(atty::Stream::Stderr);
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(format!(
-            "swap={},xmr-btc={},http=warn,warp=warn",
+            "swap={},xmr_btc={},http=warn,warp=warn",
             level, level
         ))
         .with_writer(std::io::stderr)

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -274,7 +274,7 @@ pub fn init_tracing() -> DefaultGuard {
     use tracing_subscriber::util::SubscriberInitExt as _;
     tracing_subscriber::fmt()
         .with_env_filter(format!(
-            "{},swap={},xmr-btc={},monero_harness={},bitcoin_harness={}",
+            "{},swap={},xmr_btc={},monero_harness={},bitcoin_harness={}",
             global_filter,
             swap_filter,
             xmr_btc_filter,


### PR DESCRIPTION
We actually never saw the `xmr-btc` logs, the filter has to be `xmr_btc` to work.