### PR TITLE
Add minimum monero confirmations to config use it for Bob

### DIFF
--- a/swap/src/bob/swap.rs
+++ b/swap/src/bob/swap.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use uuid::Uuid;
 use xmr_btc::{
     bob::{self, State2},
+    config::Config,
     ExpiredTimelocks,
 };
 
@@ -59,6 +60,7 @@ pub async fn swap<R>(
     monero_wallet: Arc<crate::monero::Wallet>,
     rng: R,
     swap_id: Uuid,
+    config: Config,
 ) -> Result<BobState>
 where
     R: RngCore + CryptoRng + Send,
@@ -72,6 +74,7 @@ where
         monero_wallet,
         rng,
         swap_id,
+        config,
     )
     .await
 }
@@ -110,6 +113,7 @@ pub async fn run_until<R>(
     monero_wallet: Arc<crate::monero::Wallet>,
     mut rng: R,
     swap_id: Uuid,
+    config: Config,
 ) -> Result<BobState>
 where
     R: RngCore + CryptoRng + Send,
@@ -144,6 +148,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -166,6 +171,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -220,6 +226,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -262,6 +269,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -298,6 +306,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -318,6 +327,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -343,6 +353,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -371,6 +382,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<()> {
                 config.bitcoin_cancel_timelock,
                 config.bitcoin_punish_timelock,
                 refund_address,
+                config.monero_finality_confirmations,
             );
 
             let amounts = SwapAmounts {
@@ -159,6 +160,7 @@ async fn main() -> Result<()> {
                 db,
                 alice_peer_id,
                 alice_addr,
+                config,
             )
             .await?;
         }
@@ -234,6 +236,7 @@ async fn main() -> Result<()> {
                 db,
                 alice_peer_id,
                 alice_addr,
+                config,
             )
             .await?;
         }
@@ -301,6 +304,7 @@ async fn alice_swap(
     swap.await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn bob_swap(
     swap_id: Uuid,
     state: BobState,
@@ -309,6 +313,7 @@ async fn bob_swap(
     db: Database,
     alice_peer_id: PeerId,
     alice_addr: Multiaddr,
+    config: Config,
 ) -> Result<BobState> {
     let bob_behaviour = bob::Behaviour::default();
     let bob_transport = build(bob_behaviour.identity())?;
@@ -324,6 +329,7 @@ async fn bob_swap(
         monero_wallet.clone(),
         OsRng,
         swap_id,
+        config,
     );
 
     tokio::spawn(event_loop.run());

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -98,6 +98,7 @@ async fn happy_path() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        config,
     )
     .boxed();
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -83,6 +83,7 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        config,
     );
 
     let alice_db_datadir = tempdir().unwrap();

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -106,6 +106,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         bob_xmr_wallet.clone(),
         OsRng,
         bob_swap_id,
+        config,
     )
     .await
     .unwrap();
@@ -134,6 +135,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
         bob_xmr_wallet,
         OsRng,
         bob_swap_id,
+        config,
     )
     .await
     .unwrap();

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -95,6 +95,7 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
             bob_xmr_wallet.clone(),
             OsRng,
             bob_swap_id,
+            Config::regtest(),
         )
     };
 
@@ -120,6 +121,7 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
         bob_xmr_wallet.clone(),
         OsRng,
         bob_swap_id,
+        Config::regtest(),
     );
 
     let bob_final_state = select! {

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -84,6 +84,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        config,
     )
     .boxed();
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -81,6 +81,7 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         bob_xmr_wallet.clone(),
         OsRng,
         Uuid::new_v4(),
+        Config::regtest(),
     );
 
     let alice_swap_id = Uuid::new_v4();

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -176,6 +176,7 @@ pub async fn init_bob_state(
         config.bitcoin_cancel_timelock,
         config.bitcoin_punish_timelock,
         refund_address,
+        config.monero_finality_confirmations,
     );
 
     BobState::Started { state0, amounts }

--- a/xmr-btc/src/bob.rs
+++ b/xmr-btc/src/bob.rs
@@ -359,6 +359,7 @@ pub struct State0 {
     cancel_timelock: Timelock,
     punish_timelock: Timelock,
     refund_address: bitcoin::Address,
+    min_monero_confirmations: u32,
 }
 
 impl State0 {
@@ -369,6 +370,7 @@ impl State0 {
         cancel_timelock: Timelock,
         punish_timelock: Timelock,
         refund_address: bitcoin::Address,
+        min_monero_confirmations: u32,
     ) -> Self {
         let b = bitcoin::SecretKey::new_random(rng);
 
@@ -384,6 +386,7 @@ impl State0 {
             cancel_timelock,
             punish_timelock,
             refund_address,
+            min_monero_confirmations,
         }
     }
 
@@ -432,6 +435,7 @@ impl State0 {
             redeem_address: msg.redeem_address,
             punish_address: msg.punish_address,
             tx_lock,
+            min_monero_confirmations: self.min_monero_confirmations,
         })
     }
 }
@@ -453,6 +457,7 @@ pub struct State1 {
     redeem_address: bitcoin::Address,
     punish_address: bitcoin::Address,
     tx_lock: bitcoin::TxLock,
+    min_monero_confirmations: u32,
 }
 
 impl State1 {
@@ -491,6 +496,7 @@ impl State1 {
             tx_lock: self.tx_lock,
             tx_cancel_sig_a: msg.tx_cancel_sig,
             tx_refund_encsig: msg.tx_refund_encsig,
+            min_monero_confirmations: self.min_monero_confirmations,
         })
     }
 }
@@ -514,6 +520,7 @@ pub struct State2 {
     pub tx_lock: bitcoin::TxLock,
     pub tx_cancel_sig_a: Signature,
     pub tx_refund_encsig: EncryptedSignature,
+    pub min_monero_confirmations: u32,
 }
 
 impl State2 {
@@ -558,6 +565,7 @@ impl State2 {
             tx_lock: self.tx_lock,
             tx_cancel_sig_a: self.tx_cancel_sig_a,
             tx_refund_encsig: self.tx_refund_encsig,
+            min_monero_confirmations: self.min_monero_confirmations,
         })
     }
 }
@@ -581,6 +589,7 @@ pub struct State3 {
     pub tx_lock: bitcoin::TxLock,
     pub tx_cancel_sig_a: Signature,
     pub tx_refund_encsig: EncryptedSignature,
+    pub min_monero_confirmations: u32,
 }
 
 impl State3 {
@@ -599,7 +608,7 @@ impl State3 {
                 self.v.public(),
                 msg.tx_lock_proof,
                 self.xmr,
-                monero::MIN_CONFIRMATIONS,
+                self.min_monero_confirmations,
             )
             .await?;
 

--- a/xmr-btc/src/config.rs
+++ b/xmr-btc/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub bitcoin_finality_confirmations: u32,
     pub bitcoin_avg_block_time: Duration,
     pub monero_max_finality_time: Duration,
+    pub monero_finality_confirmations: u32,
     pub bitcoin_cancel_timelock: Timelock,
     pub bitcoin_punish_timelock: Timelock,
     pub bitcoin_network: ::bitcoin::Network,
@@ -24,6 +25,7 @@ impl Config {
             // blockchain is slow
             monero_max_finality_time: (*mainnet::MONERO_AVG_BLOCK_TIME).mul_f64(1.5)
                 * mainnet::MONERO_FINALITY_CONFIRMATIONS,
+            monero_finality_confirmations: mainnet::MONERO_FINALITY_CONFIRMATIONS,
             bitcoin_cancel_timelock: mainnet::BITCOIN_CANCEL_TIMELOCK,
             bitcoin_punish_timelock: mainnet::BITCOIN_PUNISH_TIMELOCK,
             bitcoin_network: ::bitcoin::Network::Bitcoin,
@@ -40,6 +42,7 @@ impl Config {
             // blockchain is slow
             monero_max_finality_time: (*testnet::MONERO_AVG_BLOCK_TIME).mul_f64(1.5)
                 * testnet::MONERO_FINALITY_CONFIRMATIONS,
+            monero_finality_confirmations: testnet::MONERO_FINALITY_CONFIRMATIONS,
             bitcoin_cancel_timelock: testnet::BITCOIN_CANCEL_TIMELOCK,
             bitcoin_punish_timelock: testnet::BITCOIN_PUNISH_TIMELOCK,
             bitcoin_network: ::bitcoin::Network::Testnet,
@@ -56,6 +59,7 @@ impl Config {
             // blockchain is slow
             monero_max_finality_time: (*regtest::MONERO_AVG_BLOCK_TIME).mul_f64(1.5)
                 * regtest::MONERO_FINALITY_CONFIRMATIONS,
+            monero_finality_confirmations: regtest::MONERO_FINALITY_CONFIRMATIONS,
             bitcoin_cancel_timelock: regtest::BITCOIN_CANCEL_TIMELOCK,
             bitcoin_punish_timelock: regtest::BITCOIN_PUNISH_TIMELOCK,
             bitcoin_network: ::bitcoin::Network::Regtest,
@@ -96,7 +100,9 @@ mod testnet {
     // This does not reflect recommended values for mainnet!
     pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 5;
 
-    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(2 * 60));
+    // The average blocktime on Monero stagenet is not as constant as on mainnet,
+    // hence 4 minutes it set
+    pub static MONERO_AVG_BLOCK_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(4 * 60));
 
     // This does not reflect recommended values for mainnet!
     pub static BITCOIN_CANCEL_TIMELOCK: Timelock = Timelock::new(6);

--- a/xmr-btc/src/monero.rs
+++ b/xmr-btc/src/monero.rs
@@ -14,7 +14,6 @@ use rust_decimal::{
 };
 use std::{fmt::Display, str::FromStr};
 
-pub const MIN_CONFIRMATIONS: u32 = 10;
 pub const PICONERO_OFFSET: u64 = 1_000_000_000_000;
 
 pub fn random_private_key<R: RngCore + CryptoRng>(rng: &mut R) -> PrivateKey {


### PR DESCRIPTION
After discussion with @bonomat about enforced `10` confirmations until a tx is spendable on Monero I gave it a try with only `1` confirmation on regtest happy-path-test and `5` for `stagenet` and did not encounter problems. Both swaps passed without problems so I am proposing to merge these changes. 

One additional change crept in: Changed the average blocktime for `stagenet` to `4` mins, because the blocktime fluctuates a lot. See: https://monero-stagenet.exan.tech/