### PR TITLE
Use get_transfer_by_txid to extract the exact block height of txlock

### DIFF
--- a/monero-harness/src/rpc/wallet.rs
+++ b/monero-harness/src/rpc/wallet.rs
@@ -185,7 +185,7 @@ impl Client {
         Ok(r.result)
     }
 
-    /// Get wallet block height, this might be behind monerod height.
+    /// Get wallet block height.
     pub async fn block_height(&self) -> Result<BlockHeight> {
         let request = Request::new("get_height", "");
 

--- a/swap/src/alice/swap.rs
+++ b/swap/src/alice/swap.rs
@@ -474,7 +474,7 @@ pub async fn run_until(
                 let view_key = state3.v;
 
                 monero_wallet
-                    .create_and_load_wallet_for_output(spend_key, view_key)
+                    .create_and_load_wallet_for_output(spend_key, view_key, None)
                     .await?;
 
                 let state = AliceState::XmrRefunded;

--- a/xmr-btc/src/alice.rs
+++ b/xmr-btc/src/alice.rs
@@ -884,10 +884,11 @@ impl State5 {
 
         let s = s_b.scalar + self.s_a.into_ed25519();
 
+        // TODO: Optimized rescan height should be passed for refund as well.
         // NOTE: This actually generates and opens a new wallet, closing the currently
         // open one.
         monero_wallet
-            .create_and_load_wallet_for_output(monero::PrivateKey::from_scalar(s), self.v)
+            .create_and_load_wallet_for_output(monero::PrivateKey::from_scalar(s), self.v, None)
             .await?;
 
         Ok(())

--- a/xmr-btc/src/lib.rs
+++ b/xmr-btc/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(
     unused_extern_crates,
     missing_debug_implementations,
-    missing_copy_implementations,
     rust_2018_idioms,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,


### PR DESCRIPTION
This is just for reference. If you spot what the problem could be we could still go for this, otherwise I would opt for the solution proposed by https://github.com/comit-network/xmr-btc-swap/pull/119
This fails with `transaction not found` on `stagenet`, not sure why.