### PR TITLE
Upgrade to tokio 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           path: target
-          key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: rust-${{ matrix.target }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cache ~/.cargo/registry directory
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: rust-${{ matrix.target }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cargo check release code with default features
         run: cargo check --workspace
@@ -100,12 +100,15 @@ jobs:
       - name: Cargo check all features
         run: cargo check --workspace --all-targets --all-features
 
-      - name: Cargo test
-        if: (!matrix.skip_tests)
-        run: cargo test --workspace --all-features
-        env:
-          MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
-          RUST_MIN_STACK: 16777216 # 16 MB. Default is 8MB. This is fine as in tests we start 2 programs: Alice and Bob.
+      - name: Build tests
+        run: cargo build --tests --workspace --all-features
+
+      - name: Run monero-harness tests
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test --package monero-harness --all-features
+
+      - name: Run library tests for swap
+        run: cargo test --package swap --lib --all-features
 
       - name: Build binary
         run: |
@@ -116,3 +119,48 @@ jobs:
         with:
           name: swap-${{ matrix.target }}
           path: target/${{ matrix.target }}/debug/swap
+
+  docker_tests:
+    env:
+      TARGET: x86_64-unknown-linux-gnu
+    strategy:
+      matrix:
+        test_name: [
+            happy_path,
+            happy_path_restart_alice,
+            happy_path_restart_bob_after_comm,
+            happy_path_restart_bob_after_lock_proof_received,
+            happy_path_restart_bob_before_comm,
+            punish,
+            refund_restart_alice_cancelled,
+            refund_restart_alice,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
+      - name: Cache target directory
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: rust-${{ env.TARGET }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
+
+      - name: Cache ~/.cargo/registry directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: rust-${{ env.TARGET }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
+
+      - name: Run test ${{ matrix.test_name }}
+        run: cargo test --package swap --all-features --test ${{ matrix.test_name }} ""
+        env:
+          MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
+          RUST_MIN_STACK: 16777216 # 16 MB. Default is 8MB. This is fine as in tests we start 2 programs: Alice and Bob.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           profile: minimal
           override: true
 
@@ -96,14 +95,14 @@ jobs:
           key: rust-${{ matrix.target }}-${{ matrix.rust_toolchain }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Cargo check release code with default features
-        run: cargo +nightly check --workspace
+        run: cargo check --workspace
 
       - name: Cargo check all features
-        run: cargo +nightly check --workspace --all-targets --all-features
+        run: cargo check --workspace --all-targets --all-features
 
       - name: Cargo test
         if: (!matrix.skip_tests)
-        run: cargo +nightly test --workspace --all -- --test-threads=1 -Z unstable-options --report-time
+        run: cargo test --workspace --all-features
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
           RUST_MIN_STACK: 16777216 # 16 MB. Default is 8MB. This is fine as in tests we start 2 programs: Alice and Bob.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Cargo test
         if: (!matrix.skip_tests)
-        run: cargo +nightly test --workspace --all-features -- -Z unstable-options --report-time
+        run: cargo +nightly test --workspace --all -- --test-threads=1 -Z unstable-options --report-time
         env:
           MONERO_ADDITIONAL_SLEEP_PERIOD: 60000
           RUST_MIN_STACK: 16777216 # 16 MB. Default is 8MB. This is fine as in tests we start 2 programs: Alice and Bob.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -75,14 +75,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arrayref"
@@ -116,6 +116,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
 name = "async-recursion"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +158,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,7 +187,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -171,14 +204,14 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backoff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c249ab59cbc483ad4294c9ee2671835c1e43e9ffc277e6b4ecfef733cfdc5"
+version = "0.2.2-alpha.0"
+source = "git+https://github.com/ihrwein/backoff?rev=9d03992a83dfdc596be26276d4e5c5254a4b11a2#9d03992a83dfdc596be26276d4e5c5254a4b11a2"
 dependencies = [
  "futures-core",
+ "getrandom 0.2.1",
  "instant",
- "pin-project 0.4.27",
- "rand 0.7.3",
+ "pin-project 1.0.4",
+ "rand 0.8.2",
  "tokio",
 ]
 
@@ -236,7 +269,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-harness"
 version = "0.2.0"
-source = "git+https://github.com/coblox/bitcoin-harness-rs?rev=864b55fcba2e770105f135781dd2e3002c503d12#864b55fcba2e770105f135781dd2e3002c503d12"
+source = "git+https://github.com/coblox/bitcoin-harness-rs?rev=ae2f6cd547496e680941c0910018bbe884128799#ae2f6cd547496e680941c0910018bbe884128799"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -315,23 +348,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2s_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
@@ -343,7 +365,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -364,18 +385,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bs58"
@@ -415,31 +424,21 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "c_linked_list"
+name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -507,10 +506,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "conquer-once"
-version = "0.3.1"
+name = "concurrent-queue"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb45322099323eefa1b48850ce6c148f5b510894c531e038539f6370c887214"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "conquer-once"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6d3a9775a69f6d1fe2cc888999b67ed30257d3da4d2af91984e722f2ec918a"
 dependencies = [
  "conquer-util",
 ]
@@ -523,9 +531,9 @@ checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -576,7 +584,7 @@ version = "0.1.0"
 source = "git+https://github.com/comit-network/cross-curve-dleq?rev=eddcdea1d1f16fa33ef581d1744014ece535c920#eddcdea1d1f16fa33ef581d1744014ece535c920"
 dependencies = [
  "bit-vec",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek 2.1.2",
  "ecdsa_fun",
  "generic-array 0.14.4",
  "hex-literal",
@@ -668,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+checksum = "434e1720189a637d44fe464f4df1e6eb900b4835255b14354497c78af37d9bb8"
 dependencies = [
  "byteorder",
  "digest 0.8.1",
@@ -682,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -701,9 +709,9 @@ checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "derivative"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+checksum = "eaed5874effa6cde088c644ddcdcb4ffd1511391c5be4fdd7a5ccd02c7e4a183"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -749,7 +757,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -783,7 +791,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek 3.0.2",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -854,6 +862,15 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -935,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -945,26 +962,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "90fa4cc29d25b0687b8570b0da86eac698dcb525110ad8b938fe6712baa711ec"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -977,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "31ebc390c6913de330e418add60e1a7e5af4cb5ec600d19111b339cafcdcc027"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -987,15 +988,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "089bd0baf024d3216916546338fffe4fc8dfffdd901e33c278abb091e0d52111"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "d0cb59f15119671c94cd9cc543dc9a50b8d5edc468b4ff5f0bb8567f66c6b48a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1005,15 +1006,30 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "3868967e4e5ab86614e2176c99949eeef6cbcacaee737765f6ae693988273997"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "95778720c3ee3c179cd0d8fd5a0f9b40aa7d745c080f86a8f8bed33c4fd89758"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1023,15 +1039,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "d4e0f6be0ec0357772fd58fb751958dd600bd0b3edfd429e77793e4282831360"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "868090f28a925db6cb7462938c51d807546e298fb314088239f0e52fb4338b96"
 dependencies = [
  "once_cell",
 ]
@@ -1044,9 +1060,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "cad5e82786df758d407932aded1235e24d8e2eb438b6adafd37930c2462fb5d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1055,23 +1071,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures",
- "memchr",
- "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -1081,25 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1128,54 +1113,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c41a39c60ae1fc5bf0e220347ce90fa1e4bb0fcdac65b09bb5f4576bebc84"
 
 [[package]]
-name = "get_if_addrs"
-version = "0.5.2"
+name = "getrandom"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54c43f691a555f724b251228f061975ce447c710898254697f97de134f40f5c"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
+ "cfg-if 1.0.0",
  "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf68ed691805f2dfe4e83cf85e3d373e704c3654c454dbb3280a15e2ea8d509"
-dependencies = [
- "gcc",
- "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
+ "opaque-debug 0.3.0",
  "polyval",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1210,14 +1185,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1295,22 +1270,22 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "http",
 ]
 
@@ -1328,11 +1303,11 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1342,7 +1317,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -1352,15 +1327,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
- "tokio-tls",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1382,7 +1357,7 @@ checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
 dependencies = [
  "if-addrs-sys",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1393,6 +1368,22 @@ checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "if-watch"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d7c5e361e6b05c882b4847dd98992534cebc6fcde7f4bc98225bcf10fd6d0d"
+dependencies = [
+ "async-io",
+ "futures",
+ "futures-lite",
+ "if-addrs",
+ "ipnet",
+ "libc",
+ "log",
+ "winapi",
 ]
 
 [[package]]
@@ -1424,15 +1415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,18 +1422,18 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
@@ -1464,8 +1446,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc_client"
-version = "0.3.0"
-source = "git+https://github.com/thomaseizinger/rust-jsonrpc-client?rev=c7010817e0f86ab24b3dc10d6bb0463faa0aace4#c7010817e0f86ab24b3dc10d6bb0463faa0aace4"
+version = "0.5.0"
+source = "git+https://github.com/thomaseizinger/rust-jsonrpc-client?rev=f60c839481c1ac68909ada0141a3a3bf085bb1af#f60c839481c1ac68909ada0141a3a3bf085bb1af"
 dependencies = [
  "async-trait",
  "jsonrpc_client_macro",
@@ -1477,18 +1459,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc_client_macro"
-version = "0.1.0"
-source = "git+https://github.com/thomaseizinger/rust-jsonrpc-client?rev=c7010817e0f86ab24b3dc10d6bb0463faa0aace4#c7010817e0f86ab24b3dc10d6bb0463faa0aace4"
+version = "0.2.0"
+source = "git+https://github.com/thomaseizinger/rust-jsonrpc-client?rev=f60c839481c1ac68909ada0141a3a3bf085bb1af#f60c839481c1ac68909ada0141a3a3bf085bb1af"
 dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keccak-hash"
@@ -1511,16 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,18 +1494,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libp2p"
-version = "0.29.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021f703bfef6e3da78ef9828c8a244d639b8d57eedf58360922aca5ff69dfdcd"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
+ "bytes",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1551,22 +1517,21 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "multihash",
  "parity-multiaddr",
  "parking_lot",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "smallvec",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3960524389409633550567e8a9e0684d25a33f4f8408887ff897dd9fdfbdb771"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
- "bs58 0.3.1",
+ "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
@@ -1579,7 +1544,7 @@ dependencies = [
  "multistream-select",
  "parity-multiaddr",
  "parking_lot",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -1588,16 +1553,16 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
 dependencies = [
  "quote",
  "syn",
@@ -1605,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1616,30 +1581,30 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92b538238c80067c6417a58a07e41002b69d129355b60ec147d6337fdff0eb0"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes",
  "futures",
- "futures_codec",
  "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c77142e3e5b18fefa7d267305c777c9cbe9b2232ec489979390100bebcc1e6"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 0.5.6",
- "curve25519-dalek 3.0.0",
+ "bytes",
+ "curve25519-dalek 3.0.2",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1656,12 +1621,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.4.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ba1aa5727ccc118c09ba5111480873f2fe5608cb304e258fd12c173ecf27c9"
+checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes",
  "futures",
  "libp2p-core",
  "libp2p-swarm",
@@ -1670,15 +1635,15 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6fa33b16956b8a58afbfebe1406866011a1ab8960765bd36868952d7be6a1"
+checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
 dependencies = [
  "either",
  "futures",
@@ -1692,14 +1657,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0b6f4ef48d9493607fae069deecce0579320a1f3de6cb056770b151018a9a5"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
  "log",
  "socket2",
@@ -1707,28 +1675,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-tokio-socks5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0280d1cf7c88bca8862ae9d2d7d0a17d3230b3eee5d6cdcecc4b1a254ec94017"
-dependencies = [
- "data-encoding",
- "futures",
- "futures-timer",
- "get_if_addrs",
- "ipnet",
- "libp2p",
- "log",
- "socket2",
- "tokio",
- "tokio-socks 0.2.2",
-]
-
-[[package]]
 name = "libp2p-yamux"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0c9b6ef7a168c2ae854170b0b6b77550599afe06cc3ac390eb45c5d9c7110"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1764,32 +1714,19 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
  "serde",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "lru"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abe07af102235a56ac9a6dd904aab1e05483e2e8afdfffec3598be55b1b7606"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
@@ -1842,29 +1779,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minicbor"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2ef6aa869726518c5d8206fa5d1337bda8a0442807611be617891c018fa781"
+checksum = "0164190d1771b1458c3742075b057ed55d25cd9dfb930aade99315a1eb1fe12d"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3569c0dbfff1b8d5f1434c642b67f5bf81c0f354a3f5f8f180b549dba3c07c"
+checksum = "2e071b3159835ee91df62dbdbfdd7ec366b7ea77c838f43aff4acda6b61bcfb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1883,33 +1810,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -1920,7 +1839,7 @@ checksum = "d53d4207d0bd4d1eb3323e33a64f9ea99e5e3d257d5cd7a659fad5be48c8b9af"
 dependencies = [
  "base58-monero",
  "byteorder",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek 2.1.2",
  "fixed-hash 0.3.2",
  "hex 0.4.2",
  "keccak-hash 0.3.0",
@@ -1952,17 +1871,29 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.11.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd",
  "digest 0.9.0",
- "sha-1",
+ "generic-array 0.14.4",
+ "multihash-derive",
  "sha2 0.9.2",
- "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1973,23 +1904,23 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures",
  "log",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2004,14 +1935,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
+name = "nb-connect"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
- "cfg-if 0.1.10",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2019,6 +1949,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -2128,9 +2067,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2148,9 +2087,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2161,33 +2100,39 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
+ "bs58",
  "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding",
  "serde",
  "static_assertions 1.1.0",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "url",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "serde",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -2202,16 +2147,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2252,11 +2197,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -2272,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2283,15 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2306,6 +2245,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,11 +2269,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fd92d8e0c06d08525d2e2643cc2b5c80c69ae8eb12c18272d501cd7079ccc0"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool 0.2.0",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2363,6 +2316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,9 +2356,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2409,21 +2371,21 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "heck",
  "itertools",
  "log",
@@ -2437,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2450,19 +2412,19 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -2483,7 +2445,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2496,7 +2458,7 @@ dependencies = [
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2515,7 +2477,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2524,11 +2486,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2552,6 +2526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,7 +2556,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -2594,6 +2587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,7 +2612,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2624,7 +2626,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2662,21 +2664,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "regex-syntax",
 ]
@@ -2693,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -2703,17 +2714,17 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2726,16 +2737,14 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-socks 0.3.0",
- "tokio-tls",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2755,7 +2764,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2772,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
+checksum = "a5c739ba050709eae138f053356d27ff818d71fe54ce5a8d9f4c7a660bfb6684"
 dependencies = [
  "num-traits",
  "serde",
@@ -2825,14 +2834,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2922,9 +2925,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 dependencies = [
  "serde_derive",
 ]
@@ -2960,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2971,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2990,19 +2993,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpuid-bool 0.1.2",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3037,32 +3027,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
@@ -3088,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snow"
@@ -3112,13 +3089,13 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e0e9fd577458a4f61fb91fcb559ea2afecc54c934119421f9f5d3d5b1a1057"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3138,9 +3115,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
+checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
 dependencies = [
  "version_check",
 ]
@@ -3293,7 +3270,7 @@ dependencies = [
  "bitcoin-harness",
  "conquer-once",
  "cross-curve-dleq",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek 2.1.2",
  "derivative",
  "ecdsa_fun",
  "ed25519-dalek",
@@ -3301,7 +3278,6 @@ dependencies = [
  "get-port",
  "hyper",
  "libp2p",
- "libp2p-tokio-socks5",
  "log",
  "miniscript",
  "monero",
@@ -3338,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3361,16 +3337,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3381,7 +3357,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3411,18 +3387,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3431,18 +3407,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
+checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
 dependencies = [
  "const_fn",
  "libc",
@@ -3450,7 +3426,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3502,28 +3478,25 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
 dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
+ "autocfg 1.0.1",
+ "bytes",
+ "libc",
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite 0.1.11",
- "slab",
+ "pin-project-lite",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3531,53 +3504,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-socks"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997788a0e25e09300e44680ba1ef9d44d6f634a883641f80109e8b59c928daf"
-dependencies = [
- "bytes 0.4.12",
- "either",
- "futures",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
+name = "tokio-native-tls"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d611fd5d241872372d52a0a3d309c52d0b95a6a67671a6c8f7ab2c4a37fb2539"
-dependencies = [
- "bytes 0.4.12",
- "either",
- "futures",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
 dependencies = [
- "bytes 0.5.6",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ae4751faa60b9f96dd8344d74592e5a17c0c9a220413dbc6942d14139bbfcc"
+dependencies = [
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3593,8 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3695,15 +3662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,11 +3712,17 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes",
  "futures-io",
  "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -3781,11 +3745,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.7.3",
+ "getrandom 0.2.1",
  "serde",
 ]
 
@@ -3794,6 +3758,12 @@ name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+
+[[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -3814,6 +3784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,6 +3804,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3923,19 +3905,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "3.1.1"
+name = "wepoll-sys"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
- "libc",
+ "cc",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
+name = "which"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
+]
 
 [[package]]
 name = "winapi"
@@ -3946,12 +3932,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3971,17 +3951,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]
@@ -3990,7 +3960,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek 3.0.2",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,13 @@
 status = [
     "static_analysis",
     "build_test (x86_64-unknown-linux-gnu)",
-    "build_test (x86_64-apple-darwin)"
+    "build_test (x86_64-apple-darwin)",
+    "docker_tests (happy_path)",
+    "docker_tests (happy_path_restart_alice)",
+    "docker_tests (happy_path_restart_bob_after_comm)",
+    "docker_tests (happy_path_restart_bob_after_lock_proof_received)",
+    "docker_tests (happy_path_restart_bob_before_comm)",
+    "docker_tests (punish)",
+    "docker_tests (refund_restart_alice_cancelled)",
+    "docker_tests (refund_restart_alice)",
 ]

--- a/monero-harness/Cargo.toml
+++ b/monero-harness/Cargo.toml
@@ -10,12 +10,12 @@ digest_auth = "0.2.3"
 futures = "0.3"
 port_check = "0.1"
 rand = "0.7"
-reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spectral = "0.6"
 testcontainers = "0.11"
-tokio = { version = "0.2", default-features = false, features = ["blocking", "macros", "rt-core", "time"] }
+tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "time", "macros"] }
 tracing = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "ansi", "env-filter"] }

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -266,7 +266,7 @@ impl<'c> MoneroWalletRpc {
                 // ~30 seconds
                 bail!("Wallet could not catch up with monerod after 30 retries.")
             }
-            time::delay_for(Duration::from_millis(WAIT_WALLET_SYNC_MILLIS)).await;
+            time::sleep(Duration::from_millis(WAIT_WALLET_SYNC_MILLIS)).await;
             retry += 1;
         }
         Ok(())
@@ -293,7 +293,7 @@ impl<'c> MoneroWalletRpc {
 /// Mine a block ever BLOCK_TIME_SECS seconds.
 async fn mine(monerod: monerod::Client, reward_address: String) -> Result<()> {
     loop {
-        time::delay_for(Duration::from_secs(BLOCK_TIME_SECS)).await;
+        time::sleep(Duration::from_secs(BLOCK_TIME_SECS)).await;
         monerod.generate_blocks(1, &reward_address).await?;
     }
 }

--- a/monero-harness/tests/monerod.rs
+++ b/monero-harness/tests/monerod.rs
@@ -22,7 +22,7 @@ async fn init_miner_and_mine_to_miner_address() {
     let got_miner_balance = miner_wallet.balance().await.unwrap();
     assert_that!(got_miner_balance).is_greater_than(0);
 
-    time::delay_for(Duration::from_millis(1010)).await;
+    time::sleep(Duration::from_millis(1010)).await;
 
     // after a bit more than 1 sec another block should have been mined
     let block_height = monerod.client().get_block_count().await.unwrap();

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -10,10 +10,10 @@ anyhow = "1"
 async-recursion = "0.3.1"
 async-trait = "0.1"
 atty = "0.2"
-backoff = { version = "0.2", features = ["tokio"] }
+backoff = { git = "https://github.com/ihrwein/backoff", rev = "9d03992a83dfdc596be26276d4e5c5254a4b11a2", features = ["tokio"] }
 base64 = "0.12"
 bitcoin = { version = "0.25", features = ["rand", "use-serde"] }
-bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs", rev = "864b55fcba2e770105f135781dd2e3002c503d12" }
+bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs", rev = "ae2f6cd547496e680941c0910018bbe884128799" }
 conquer-once = "0.3"
 cross-curve-dleq = { git = "https://github.com/comit-network/cross-curve-dleq", rev = "eddcdea1d1f16fa33ef581d1744014ece535c920", features = ["serde"] }
 curve25519-dalek = "2"
@@ -21,8 +21,7 @@ derivative = "2"
 ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", rev = "cdfbc766045ea678a41780919d6228dd5acee3be", features = ["libsecp_compat", "serde"] }
 ed25519-dalek = { version = "1.0.0-pre.4", features = ["serde"] }# Cannot be 1 because they depend on curve25519-dalek version 3
 futures = { version = "0.3", default-features = false }
-libp2p = { version = "0.29", default-features = false, features = ["tcp-tokio", "yamux", "mplex", "dns", "noise", "request-response"] }
-libp2p-tokio-socks5 = "0.4"
+libp2p = { version = "0.34", default-features = false, features = ["tcp-tokio", "yamux", "mplex", "dns", "noise", "request-response"] }
 log = { version = "0.4", features = ["serde"] }
 miniscript = { version = "4", features = ["serde"] }
 monero = { version = "0.9", features = ["serde_support"] }
@@ -30,7 +29,7 @@ monero-harness = { path = "../monero-harness" }
 pem = "0.8"
 prettytable-rs = "0.8"
 rand = "0.7"
-reqwest = { version = "0.10", default-features = false, features = ["socks"] }
+reqwest = { version = "0.11", default-features = false }
 rust_decimal = "1.8"
 serde = { version = "1", features = ["derive"] }
 serde_cbor = "0.11"
@@ -43,7 +42,7 @@ strum = { version = "0.20", features = ["derive"] }
 tempfile = "3"
 thiserror = "1"
 time = "0.2"
-tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "sync"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "time", "macros", "sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-core = "0.1"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }
@@ -55,7 +54,7 @@ void = "1"
 
 [dev-dependencies]
 get-port = "3"
-hyper = "0.13"
+hyper = "0.14"
 port_check = "0.1"
 serde_cbor = "0.11"
 spectral = "0.6"

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -252,7 +252,7 @@ where
     B: GetBlockHeight,
 {
     while client.get_block_height().await < target {
-        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 }
 

--- a/swap/src/config.rs
+++ b/swap/src/config.rs
@@ -16,9 +16,23 @@ pub struct Config {
     pub monero_network: monero::Network,
 }
 
-impl Config {
-    pub fn mainnet() -> Self {
-        Self {
+// TODO: This trait is not needed
+pub trait GetConfig {
+    fn get_config() -> Config;
+}
+
+#[derive(Clone, Copy)]
+pub struct Mainnet;
+
+#[derive(Clone, Copy)]
+pub struct Testnet;
+
+#[derive(Clone, Copy)]
+pub struct Regtest;
+
+impl GetConfig for Mainnet {
+    fn get_config() -> Config {
+        Config {
             bob_time_to_act: *mainnet::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: mainnet::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *mainnet::BITCOIN_AVG_BLOCK_TIME,
@@ -29,9 +43,11 @@ impl Config {
             monero_network: monero::Network::Mainnet,
         }
     }
+}
 
-    pub fn testnet() -> Self {
-        Self {
+impl GetConfig for Testnet {
+    fn get_config() -> Config {
+        Config {
             bob_time_to_act: *testnet::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: testnet::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *testnet::BITCOIN_AVG_BLOCK_TIME,
@@ -42,9 +58,11 @@ impl Config {
             monero_network: monero::Network::Stagenet,
         }
     }
+}
 
-    pub fn regtest() -> Self {
-        Self {
+impl GetConfig for Regtest {
+    fn get_config() -> Config {
+        Config {
             bob_time_to_act: *regtest::BOB_TIME_TO_ACT,
             bitcoin_finality_confirmations: regtest::BITCOIN_FINALITY_CONFIRMATIONS,
             bitcoin_avg_block_time: *regtest::BITCOIN_AVG_BLOCK_TIME,

--- a/swap/src/config.rs
+++ b/swap/src/config.rs
@@ -104,7 +104,7 @@ mod regtest {
 
     pub static MONERO_FINALITY_CONFIRMATIONS: u32 = 1;
 
-    pub static BITCOIN_CANCEL_TIMELOCK: Timelock = Timelock::new(50);
+    pub static BITCOIN_CANCEL_TIMELOCK: Timelock = Timelock::new(100);
 
     pub static BITCOIN_PUNISH_TIMELOCK: Timelock = Timelock::new(50);
 }

--- a/swap/src/database/alice.rs
+++ b/swap/src/database/alice.rs
@@ -60,7 +60,7 @@ impl From<&AliceState> for Alice {
                 ..
             } => Alice::Negotiated {
                 state3: state3.as_ref().clone(),
-                bob_peer_id: bob_peer_id.clone(),
+                bob_peer_id: *bob_peer_id,
             },
             AliceState::BtcLocked {
                 state3,
@@ -68,7 +68,7 @@ impl From<&AliceState> for Alice {
                 ..
             } => Alice::BtcLocked {
                 state3: state3.as_ref().clone(),
-                bob_peer_id: bob_peer_id.clone(),
+                bob_peer_id: *bob_peer_id,
             },
             AliceState::XmrLocked { state3 } => Alice::XmrLocked(state3.as_ref().clone()),
             AliceState::EncSigLearned {

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -16,12 +16,13 @@ use crate::cli::{Command, Options, Resume};
 use anyhow::{Context, Result};
 use config::Config;
 use database::Database;
+use log::LevelFilter;
 use prettytable::{row, Table};
 use protocol::{alice, bob, bob::Builder, SwapAmounts};
 use std::sync::Arc;
 use structopt::StructOpt;
 use trace::init_tracing;
-use tracing::{info, log::LevelFilter};
+use tracing::info;
 use uuid::Uuid;
 
 pub mod bitcoin;

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -96,8 +96,7 @@ async fn main() -> Result<()> {
                 Arc::new(monero_wallet),
                 db_path,
                 listen_addr,
-            )
-            .await;
+            );
             let (swap, mut event_loop) =
                 alice_factory.with_init_params(swap_amounts).build().await?;
 
@@ -185,8 +184,7 @@ async fn main() -> Result<()> {
                 Arc::new(monero_wallet),
                 db_path,
                 listen_addr,
-            )
-            .await;
+            );
             let (swap, mut event_loop) = alice_factory.build().await?;
 
             tokio::spawn(async move { event_loop.run().await });

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -14,7 +14,7 @@
 
 use crate::cli::{Command, Options, Resume};
 use anyhow::{Context, Result};
-use config::Config;
+use config::{Config, GetConfig};
 use database::Database;
 use log::LevelFilter;
 use prettytable::{row, Table};
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     init_tracing(LevelFilter::Info).expect("initialize tracing");
 
     let opt = Options::from_args();
-    let config = Config::testnet();
+    let config = config::Testnet::get_config();
 
     info!(
         "Database and Seed will be stored in directory: {}",

--- a/swap/src/network/peer_tracker.rs
+++ b/swap/src/network/peer_tracker.rs
@@ -12,7 +12,7 @@ use std::{
     task::Poll,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum OutEvent {
     ConnectionEstablished(PeerId),
 }
@@ -42,7 +42,7 @@ impl PeerTracker {
     /// Returns the peer id of counterparty if we are connected.
     pub fn counterparty_peer_id(&self) -> Option<PeerId> {
         if let Some((id, _)) = &self.connected {
-            return Some(id.clone());
+            return Some(*id);
         }
         None
     }
@@ -50,7 +50,7 @@ impl PeerTracker {
     /// Returns the peer_id and multiaddr of counterparty if we are connected.
     pub fn counterparty(&self) -> Option<(PeerId, Multiaddr)> {
         if let Some((peer_id, addr)) = &self.connected {
-            return Some((peer_id.clone(), addr.clone()));
+            return Some((*peer_id, addr.clone()));
         }
         None
     }
@@ -97,18 +97,18 @@ impl NetworkBehaviour for PeerTracker {
     ) {
         match point {
             ConnectedPoint::Dialer { address } => {
-                self.connected = Some((peer.clone(), address.clone()));
+                self.connected = Some((*peer, address.clone()));
             }
             ConnectedPoint::Listener {
                 local_addr: _,
                 send_back_addr,
             } => {
-                self.connected = Some((peer.clone(), send_back_addr.clone()));
+                self.connected = Some((*peer, send_back_addr.clone()));
             }
         }
 
         self.events
-            .push_back(OutEvent::ConnectionEstablished(peer.clone()));
+            .push_back(OutEvent::ConnectionEstablished(*peer));
     }
 
     fn inject_connection_closed(&mut self, _: &PeerId, _: &ConnectionId, _: &ConnectedPoint) {

--- a/swap/src/network/request_response.rs
+++ b/swap/src/network/request_response.rs
@@ -7,7 +7,6 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, io, marker::PhantomData};
-use tracing::debug;
 
 /// Time to wait for a response back once we send a request.
 pub const TIMEOUT: u64 = 3600; // One hour.
@@ -123,7 +122,6 @@ where
     where
         T: AsyncRead + Unpin + Send,
     {
-        debug!("enter read_request");
         let message = upgrade::read_one(io, BUF_SIZE)
             .await
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -144,7 +142,6 @@ where
     where
         T: AsyncRead + Unpin + Send,
     {
-        debug!("enter read_response");
         let message = upgrade::read_one(io, BUF_SIZE)
             .await
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -183,7 +180,6 @@ where
     where
         T: AsyncWrite + Unpin + Send,
     {
-        debug!("enter write_response");
         let bytes = serde_cbor::to_vec(&res).map_err(|e| {
             tracing::debug!("serde write_reponse error: {:?}", e);
             io::Error::new(io::ErrorKind::InvalidData, e)
@@ -212,7 +208,6 @@ where
     where
         T: AsyncRead + Unpin + Send,
     {
-        debug!("enter read_request");
         let message = upgrade::read_one(io, BUF_SIZE).await.map_err(|e| match e {
             ReadOneError::Io(err) => err,
             e => io::Error::new(io::ErrorKind::Other, e),
@@ -234,7 +229,6 @@ where
     where
         T: AsyncRead + Unpin + Send,
     {
-        debug!("enter read_response");
         let message = upgrade::read_one(io, BUF_SIZE)
             .await
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -273,7 +267,6 @@ where
     where
         T: AsyncWrite + Unpin + Send,
     {
-        debug!("enter write_response");
         let bytes = serde_cbor::to_vec(&res).map_err(|e| {
             tracing::debug!("serde write_reponse error: {:?}", e);
             io::Error::new(io::ErrorKind::InvalidData, e)

--- a/swap/src/network/transport.rs
+++ b/swap/src/network/transport.rs
@@ -31,7 +31,7 @@ pub fn build(id_keys: identity::Keypair) -> Result<SwapTransport> {
         .upgrade(Version::V1)
         .authenticate(noise)
         .multiplex(SelectUpgrade::new(
-            yamux::Config::default(),
+            yamux::YamuxConfig::default(),
             MplexConfig::new(),
         ))
         .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -75,7 +75,7 @@ enum InitParams {
 }
 
 impl Builder {
-    pub async fn new(
+    pub fn new(
         seed: Seed,
         config: Config,
         swap_id: Uuid,
@@ -210,7 +210,7 @@ impl Builder {
         EventLoop::new(
             alice_transport,
             alice_behaviour,
-            self.listen_address.clone(),
+            self.listen_address(),
             self.peer_id,
         )
     }

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -165,7 +165,7 @@ impl Builder {
     }
 
     pub fn peer_id(&self) -> PeerId {
-        self.peer_id.clone()
+        self.peer_id
     }
 
     pub fn listen_address(&self) -> Multiaddr {
@@ -211,7 +211,7 @@ impl Builder {
             alice_transport,
             alice_behaviour,
             self.listen_address.clone(),
-            self.peer_id.clone(),
+            self.peer_id,
         )
     }
 }
@@ -322,21 +322,32 @@ impl Behaviour {
         &mut self,
         channel: ResponseChannel<AliceToBob>,
         swap_response: SwapResponse,
-    ) {
-        self.amounts.send(channel, swap_response);
+    ) -> Result<()> {
+        self.amounts.send(channel, swap_response)?;
         info!("Sent amounts response");
+        Ok(())
     }
 
     /// Send Message0 to Bob in response to receiving his Message0.
-    pub fn send_message0(&mut self, channel: ResponseChannel<AliceToBob>, msg: Message0) {
-        self.message0.send(channel, msg);
+    pub fn send_message0(
+        &mut self,
+        channel: ResponseChannel<AliceToBob>,
+        msg: Message0,
+    ) -> Result<()> {
+        self.message0.send(channel, msg)?;
         debug!("Sent Message0");
+        Ok(())
     }
 
     /// Send Message1 to Bob in response to receiving his Message1.
-    pub fn send_message1(&mut self, channel: ResponseChannel<AliceToBob>, msg: Message1) {
-        self.message1.send(channel, msg);
+    pub fn send_message1(
+        &mut self,
+        channel: ResponseChannel<AliceToBob>,
+        msg: Message1,
+    ) -> Result<()> {
+        self.message1.send(channel, msg)?;
         debug!("Sent Message1");
+        Ok(())
     }
 
     /// Send Transfer Proof to Bob.

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -236,7 +236,7 @@ pub enum OutEvent {
         msg: Box<bob::Message2>,
         bob_peer_id: PeerId,
     },
-    TransferProof,
+    TransferProofAcknowledged,
     EncryptedSignature(EncryptedSignature),
 }
 
@@ -289,7 +289,7 @@ impl From<message2::OutEvent> for OutEvent {
 impl From<transfer_proof::OutEvent> for OutEvent {
     fn from(event: transfer_proof::OutEvent) -> Self {
         match event {
-            transfer_proof::OutEvent::Msg => OutEvent::TransferProof,
+            transfer_proof::OutEvent::Acknowledged => OutEvent::TransferProofAcknowledged,
         }
     }
 }

--- a/swap/src/protocol/alice/encrypted_signature.rs
+++ b/swap/src/protocol/alice/encrypted_signature.rs
@@ -84,7 +84,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
                     // Send back empty response so that the request/response protocol completes.
                     if let Err(error) = self.rr.send_response(channel, Response::EncryptedSignature)
                     {
-                        error!("Failed to sen Encrypted Signature ack: {:?}", error);
+                        error!("Failed to send Encrypted Signature ack: {:?}", error);
                     }
                 }
             }

--- a/swap/src/protocol/alice/encrypted_signature.rs
+++ b/swap/src/protocol/alice/encrypted_signature.rs
@@ -82,7 +82,10 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
                     debug!("Received encrypted signature");
                     self.events.push_back(OutEvent::Msg(*msg));
                     // Send back empty response so that the request/response protocol completes.
-                    let _ = self.rr.send_response(channel, Response::EncryptedSignature);
+                    if let Err(error) = self.rr.send_response(channel, Response::EncryptedSignature)
+                    {
+                        error!("Failed to sen Encrypted Signature ack: {:?}", error);
+                    }
                 }
             }
             RequestResponseEvent::Message {
@@ -94,6 +97,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
             }
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
+            }
+            RequestResponseEvent::ResponseSent { .. } => {
+                debug!("Alice has sent an Message3 response to Bob");
             }
         }
     }

--- a/swap/src/protocol/alice/message2.rs
+++ b/swap/src/protocol/alice/message2.rs
@@ -96,6 +96,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                debug!("Alice has sent an Message2 response to Bob");
+            }
         }
     }
 }

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -55,6 +55,7 @@ pub async fn run(swap: alice::Swap) -> Result<AliceState> {
     run_until(swap, is_complete).await
 }
 
+#[tracing::instrument(name = "swap", skip(swap,is_target_state), fields(id = %swap.swap_id))]
 pub async fn run_until(
     swap: alice::Swap,
     is_target_state: fn(&AliceState) -> bool,

--- a/swap/src/protocol/alice/transfer_proof.rs
+++ b/swap/src/protocol/alice/transfer_proof.rs
@@ -25,7 +25,7 @@ pub struct TransferProof {
 
 #[derive(Debug, Copy, Clone)]
 pub enum OutEvent {
-    Msg,
+    Acknowledged,
 }
 
 /// A `NetworkBehaviour` that represents sending the Monero transfer proof to
@@ -88,7 +88,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
                 ..
             } => {
                 if let Response::TransferProof = response {
-                    self.events.push_back(OutEvent::Msg);
+                    self.events.push_back(OutEvent::Acknowledged);
                 }
             }
             RequestResponseEvent::InboundFailure { error, .. } => {

--- a/swap/src/protocol/alice/transfer_proof.rs
+++ b/swap/src/protocol/alice/transfer_proof.rs
@@ -97,6 +97,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {}
         }
     }
 }

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -213,7 +213,7 @@ pub enum OutEvent {
     Message1(Box<alice::Message1>),
     Message2,
     TransferProof(Box<TransferProof>),
-    EncryptedSignature,
+    EncryptedSignatureAcknowledged,
 }
 
 impl From<peer_tracker::OutEvent> for OutEvent {
@@ -267,7 +267,7 @@ impl From<transfer_proof::OutEvent> for OutEvent {
 impl From<encrypted_signature::OutEvent> for OutEvent {
     fn from(event: encrypted_signature::OutEvent) -> Self {
         match event {
-            encrypted_signature::OutEvent::Msg => OutEvent::EncryptedSignature,
+            encrypted_signature::OutEvent::Acknowledged => OutEvent::EncryptedSignatureAcknowledged,
         }
     }
 }

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -296,19 +296,19 @@ impl Behaviour {
     /// Sends Bob's first message to Alice.
     pub fn send_message0(&mut self, alice: PeerId, msg: bob::Message0) {
         self.message0.send(alice, msg);
-        debug!("Sent Message0");
+        debug!("Message0 sent");
     }
 
     /// Sends Bob's second message to Alice.
     pub fn send_message1(&mut self, alice: PeerId, msg: bob::Message1) {
         self.message1.send(alice, msg);
-        debug!("Sent Message1");
+        debug!("Message1 sent");
     }
 
     /// Sends Bob's third message to Alice.
     pub fn send_message2(&mut self, alice: PeerId, msg: bob::Message2) {
         self.message2.send(alice, msg);
-        debug!("Sent Message2");
+        debug!("Message2 sent");
     }
 
     /// Sends Bob's fourth message to Alice.
@@ -319,7 +319,7 @@ impl Behaviour {
     ) {
         let msg = EncryptedSignature { tx_redeem_encsig };
         self.encrypted_signature.send(alice, msg);
-        debug!("Sent Message3");
+        debug!("Encrypted signature sent");
     }
 
     /// Add a known address for the given peer

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -173,8 +173,8 @@ impl Builder {
         bob::event_loop::EventLoop::new(
             bob_transport,
             bob_behaviour,
-            self.peer_id.clone(),
-            self.alice_peer_id.clone(),
+            self.peer_id,
+            self.alice_peer_id,
             self.alice_address.clone(),
         )
     }
@@ -289,7 +289,7 @@ pub struct Behaviour {
 impl Behaviour {
     /// Sends a swap request to Alice to negotiate the swap.
     pub fn send_swap_request(&mut self, alice: PeerId, swap_request: SwapRequest) {
-        let _id = self.swap_request.send(alice.clone(), swap_request);
+        let _id = self.swap_request.send(alice, swap_request);
         info!("Requesting swap from: {}", alice);
     }
 

--- a/swap/src/protocol/bob/encrypted_signature.rs
+++ b/swap/src/protocol/bob/encrypted_signature.rs
@@ -96,6 +96,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                unreachable!("Bob should never send a Amounts response to Alice");
+            }
         }
     }
 }

--- a/swap/src/protocol/bob/encrypted_signature.rs
+++ b/swap/src/protocol/bob/encrypted_signature.rs
@@ -24,7 +24,7 @@ pub struct EncryptedSignature {
 
 #[derive(Debug, Copy, Clone)]
 pub enum OutEvent {
-    Msg,
+    Acknowledged,
 }
 
 /// A `NetworkBehaviour` that represents sending encrypted signature to Alice.
@@ -87,7 +87,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
                 ..
             } => {
                 if let Response::EncryptedSignature = response {
-                    self.events.push_back(OutEvent::Msg);
+                    self.events.push_back(OutEvent::Acknowledged);
                 }
             }
             RequestResponseEvent::InboundFailure { error, .. } => {

--- a/swap/src/protocol/bob/message0.rs
+++ b/swap/src/protocol/bob/message0.rs
@@ -102,6 +102,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                unreachable!("Bob should never send a Amounts response to Alice");
+            }
         }
     }
 }

--- a/swap/src/protocol/bob/message1.rs
+++ b/swap/src/protocol/bob/message1.rs
@@ -97,6 +97,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                unreachable!("Bob should never send a Amounts response to Alice");
+            }
         }
     }
 }

--- a/swap/src/protocol/bob/message2.rs
+++ b/swap/src/protocol/bob/message2.rs
@@ -95,6 +95,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                unreachable!("Bob should never send a Amounts response to Alice");
+            }
         }
     }
 }

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -32,6 +32,7 @@ pub async fn run(swap: bob::Swap) -> Result<BobState> {
     run_until(swap, is_complete).await
 }
 
+#[tracing::instrument(name = "swap", skip(swap,is_target_state), fields(id = %swap.swap_id))]
 pub async fn run_until(
     swap: bob::Swap,
     is_target_state: fn(&BobState) -> bool,

--- a/swap/src/protocol/bob/swap_request.rs
+++ b/swap/src/protocol/bob/swap_request.rs
@@ -103,6 +103,9 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<BobToAlice, AliceToBob>> 
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => {
+                error!("Bob should never send a Amounts response to Alice");
+            }
         }
     }
 }

--- a/swap/src/protocol/bob/transfer_proof.rs
+++ b/swap/src/protocol/bob/transfer_proof.rs
@@ -92,6 +92,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<Request, Response>> for B
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 error!("Outbound failure: {:?}", error);
             }
+            RequestResponseEvent::ResponseSent { .. } => debug!("Bob ack'd transfer proof message"),
         }
     }
 }

--- a/swap/src/trace.rs
+++ b/swap/src/trace.rs
@@ -4,7 +4,7 @@ use tracing::{info, subscriber};
 use tracing_log::LogTracer;
 use tracing_subscriber::FmtSubscriber;
 
-pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
+pub fn init_tracing(level: LevelFilter) -> anyhow::Result<()> {
     if level == LevelFilter::Off {
         return Ok(());
     }
@@ -15,8 +15,8 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
     let is_terminal = atty::is(atty::Stream::Stderr);
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(format!(
-            "swap={},xmr_btc={},monero_harness={},bitcoin_harness={},http=warn,warp=warn",
-            level, level, level, level
+            "swap={},monero_harness={},bitcoin_harness={},http=warn,warp=warn",
+            level, level, level,
         ))
         .with_writer(std::io::stderr)
         .with_ansi(is_terminal)

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -8,12 +8,12 @@ use tokio::join;
 #[tokio::test]
 async fn happy_path() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, _) = ctx.new_swap_as_alice().await;
+        let (bob_swap, _) = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
-
         let bob = bob::run(bob_swap);
+
         let (alice_state, bob_state) = join!(alice, bob);
 
         ctx.assert_alice_redeemed(alice_state.unwrap()).await;

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,9 +1,6 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, bob},
-};
+use swap::protocol::{alice, bob};
 use testutils::SlowCancelConfig;
 use tokio::join;
 
@@ -11,7 +8,7 @@ use tokio::join;
 
 #[tokio::test]
 async fn happy_path() {
-    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,13 +1,17 @@
 pub mod testutils;
 
-use swap::protocol::{alice, bob};
+use swap::{
+    config::GetConfig,
+    protocol::{alice, bob},
+};
+use testutils::SlowCancelConfig;
 use tokio::join;
 
 /// Run the following tests with RUST_MIN_STACK=10000000
 
 #[tokio::test]
 async fn happy_path() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,14 +1,11 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, alice::AliceState, bob},
-};
+use swap::protocol::{alice, alice::AliceState, bob};
 use testutils::{alice_run_until::is_encsig_learned, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -6,8 +6,8 @@ use testutils::alice_run_until::is_encsig_learned;
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
+        let (bob_swap, _) = ctx.new_swap_as_bob().await;
 
         let bob = bob::run(bob_swap);
         let bob_handle = tokio::spawn(bob);
@@ -17,7 +17,7 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
             .unwrap();
         assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
 
-        let alice_swap = ctx.recover_alice_from_db().await;
+        let alice_swap = ctx.stop_and_resume_alice_from_db(alice_join_handle).await;
         assert!(matches!(alice_swap.state, AliceState::EncSigLearned {..}));
 
         let alice_state = alice::run(alice_swap).await.unwrap();

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,11 +1,14 @@
 pub mod testutils;
 
-use swap::protocol::{alice, alice::AliceState, bob};
-use testutils::alice_run_until::is_encsig_learned;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, alice::AliceState, bob},
+};
+use testutils::{alice_run_until::is_encsig_learned, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -1,14 +1,11 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, bob, bob::BobState},
-};
+use swap::protocol::{alice, bob, bob::BobState};
 use testutils::{bob_run_until::is_encsig_sent, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -6,8 +6,8 @@ use testutils::bob_run_until::is_encsig_sent;
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, _) = ctx.new_swap_as_alice().await;
+        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
         let alice_handle = tokio::spawn(alice);
@@ -16,7 +16,7 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
         assert!(matches!(bob_state, BobState::EncSigSent {..}));
 
-        let bob_swap = ctx.recover_bob_from_db().await;
+        let bob_swap = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::EncSigSent {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -1,11 +1,14 @@
 pub mod testutils;
 
-use swap::protocol::{alice, bob, bob::BobState};
-use testutils::bob_run_until::is_encsig_sent;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, bob, bob::BobState},
+};
+use testutils::{bob_run_until::is_encsig_sent, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
+++ b/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
@@ -6,8 +6,8 @@ use testutils::bob_run_until::is_lock_proof_received;
 #[tokio::test]
 async fn given_bob_restarts_after_lock_proof_received_resume_swap() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, _) = ctx.new_swap_as_alice().await;
+        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 
         let alice_handle = alice::run(alice_swap);
         let alice_swap_handle = tokio::spawn(alice_handle);
@@ -18,8 +18,9 @@ async fn given_bob_restarts_after_lock_proof_received_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLockProofReceived {..}));
 
-        let bob_swap = ctx.recover_bob_from_db().await;
-        assert!(matches!(bob_swap.state, BobState::XmrLockProofReceived {..}));
+        let bob_swap = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        assert!(matches!(bob_swap.state, BobState::XmrLockProofReceived
+        {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();
 

--- a/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
+++ b/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
@@ -1,11 +1,14 @@
 pub mod testutils;
 
-use swap::protocol::{alice, bob, bob::BobState};
-use testutils::bob_run_until::is_lock_proof_received;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, bob, bob::BobState},
+};
+use testutils::{bob_run_until::is_lock_proof_received, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_lock_proof_received_resume_swap() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
+++ b/swap/tests/happy_path_restart_bob_after_lock_proof_received.rs
@@ -1,14 +1,11 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, bob, bob::BobState},
-};
+use swap::protocol::{alice, bob, bob::BobState};
 use testutils::{bob_run_until::is_lock_proof_received, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_lock_proof_received_resume_swap() {
-    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,14 +1,11 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, bob, bob::BobState},
-};
+use swap::protocol::{alice, bob, bob::BobState};
 use testutils::{bob_run_until::is_xmr_locked, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -6,8 +6,8 @@ use testutils::bob_run_until::is_xmr_locked;
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, _) = ctx.new_swap_as_alice().await;
+        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 
         let alice_handle = alice::run(alice_swap);
         let alice_swap_handle = tokio::spawn(alice_handle);
@@ -16,7 +16,7 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked {..}));
 
-        let bob_swap = ctx.recover_bob_from_db().await;
+        let bob_swap = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,11 +1,14 @@
 pub mod testutils;
 
-use swap::protocol::{alice, bob, bob::BobState};
-use testutils::bob_run_until::is_xmr_locked;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, bob, bob::BobState},
+};
+use testutils::{bob_run_until::is_xmr_locked, SlowCancelConfig};
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(SlowCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,13 +1,16 @@
 pub mod testutils;
 
-use swap::protocol::{alice, bob, bob::BobState};
-use testutils::bob_run_until::is_btc_locked;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, bob, bob::BobState},
+};
+use testutils::{bob_run_until::is_btc_locked, FastPunishConfig};
 
 /// Bob locks Btc and Alice locks Xmr. Bob does not act; he fails to send Alice
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(FastPunishConfig::get_config(), |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -8,8 +8,8 @@ use testutils::bob_run_until::is_btc_locked;
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, _) = ctx.new_swap_as_alice().await;
+        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
         let alice_handle = tokio::spawn(alice);
@@ -23,7 +23,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
 
         // Restart Bob after Alice punished to ensure Bob transitions to
         // punished and does not run indefinitely
-        let bob_swap = ctx.recover_bob_from_db().await;
+        let bob_swap = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,16 +1,13 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, bob, bob::BobState},
-};
+use swap::protocol::{alice, bob, bob::BobState};
 use testutils::{bob_run_until::is_btc_locked, FastPunishConfig};
 
 /// Bob locks Btc and Alice locks Xmr. Bob does not act; he fails to send Alice
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    testutils::setup_test(FastPunishConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(FastPunishConfig, |mut ctx| async move {
         let (alice_swap, _) = ctx.new_swap_as_alice().await;
         let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,13 +1,16 @@
 pub mod testutils;
 
-use swap::protocol::{alice, alice::AliceState, bob};
-use testutils::alice_run_until::is_xmr_locked;
+use swap::{
+    config::GetConfig,
+    protocol::{alice, alice::AliceState, bob},
+};
+use testutils::{alice_run_until::is_xmr_locked, FastCancelConfig};
 
 /// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
 /// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_refund_swap() {
-    testutils::setup_test(|mut ctx| async move {
+    testutils::setup_test(FastCancelConfig::get_config(), |mut ctx| async move {
         let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,16 +1,13 @@
 pub mod testutils;
 
-use swap::{
-    config::GetConfig,
-    protocol::{alice, alice::AliceState, bob},
-};
+use swap::protocol::{alice, alice::AliceState, bob};
 use testutils::{alice_run_until::is_xmr_locked, FastCancelConfig};
 
 /// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
 /// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_refund_swap() {
-    testutils::setup_test(FastCancelConfig::get_config(), |mut ctx| async move {
+    testutils::setup_test(FastCancelConfig, |mut ctx| async move {
         let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -8,21 +8,22 @@ use testutils::alice_run_until::is_xmr_locked;
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_refund_swap() {
     testutils::setup_test(|mut ctx| async move {
-        let alice_swap = ctx.new_swap_as_alice().await;
-        let bob_swap = ctx.new_swap_as_bob().await;
+        let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
+        let (bob_swap, _) = ctx.new_swap_as_bob().await;
 
         let bob = bob::run(bob_swap);
         let bob_handle = tokio::spawn(bob);
 
         let alice_state = alice::run_until(alice_swap, is_xmr_locked).await.unwrap();
-        assert!(matches!(alice_state, AliceState::XmrLocked {..}));
+        assert!(matches!(alice_state,
+        AliceState::XmrLocked {..}));
 
         // Alice does not act, Bob refunds
         let bob_state = bob_handle.await.unwrap();
         ctx.assert_bob_refunded(bob_state.unwrap()).await;
 
         // Once bob has finished Alice is restarted and refunds as well
-        let alice_swap = ctx.recover_alice_from_db().await;
+        let alice_swap = ctx.stop_and_resume_alice_from_db(alice_join_handle).await;
         assert!(matches!(alice_swap.state, AliceState::XmrLocked {..}));
 
         let alice_state = alice::run(alice_swap).await.unwrap();

--- a/swap/tests/refund_restart_alice_cancelled.rs
+++ b/swap/tests/refund_restart_alice_cancelled.rs
@@ -2,7 +2,6 @@ pub mod testutils;
 
 use swap::{
     config,
-    config::GetConfig,
     protocol::{alice, alice::AliceState, bob},
 };
 use testutils::alice_run_until::is_encsig_learned;
@@ -12,7 +11,7 @@ use testutils::alice_run_until::is_encsig_learned;
 /// redeem had the timelock not expired.
 #[tokio::test]
 async fn given_alice_restarts_after_enc_sig_learned_and_bob_already_cancelled_refund_swap() {
-    testutils::setup_test(config::Regtest::get_config(), |mut ctx| async move {
+    testutils::setup_test(config::Regtest, |mut ctx| async move {
         let (alice_swap, alice_join_handle) = ctx.new_swap_as_alice().await;
         let (bob_swap, _) = ctx.new_swap_as_bob().await;
 

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -217,7 +217,7 @@ impl TestContext {
         let lock_tx_id = if let BobState::XmrRedeemed { tx_lock_id } = state {
             tx_lock_id
         } else {
-            panic!("Bob in unexpected state");
+            panic!("Bob in not in xmr redeemed state: {:?}", state);
         };
 
         let lock_tx_bitcoin_fee = self
@@ -250,7 +250,7 @@ impl TestContext {
         let lock_tx_id = if let BobState::BtcRefunded(state4) = state {
             state4.tx_lock_id()
         } else {
-            panic!("Bob in unexpected state");
+            panic!("Bob in not in btc refunded state: {:?}", state);
         };
         let lock_tx_bitcoin_fee = self
             .bob_bitcoin_wallet
@@ -282,7 +282,7 @@ impl TestContext {
         let lock_tx_id = if let BobState::BtcPunished { tx_lock_id } = state {
             tx_lock_id
         } else {
-            panic!("Bob in unexpected state");
+            panic!("Bob in not in btc punished state: {:?}", state);
         };
 
         let lock_tx_bitcoin_fee = self

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -304,14 +304,17 @@ impl TestContext {
     }
 }
 
-pub async fn setup_test<T, F>(config: Config, testfn: T)
+pub async fn setup_test<T, F, C>(_config: C, testfn: T)
 where
     T: Fn(TestContext) -> F,
     F: Future<Output = ()>,
+    C: GetConfig,
 {
     let cli = Cli::default();
 
     let _guard = init_tracing();
+
+    let config = C::get_config();
 
     let (monero, containers) = testutils::init_containers(&cli).await;
 

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -73,7 +73,7 @@ impl BobParams {
             self.bitcoin_wallet.clone(),
             self.monero_wallet.clone(),
             self.alice_address.clone(),
-            self.alice_peer_id.clone(),
+            self.alice_peer_id,
             self.config,
         )
     }


### PR DESCRIPTION
When we were refactoring tests we realised we probably want the ability to abort a `tokio::JoinHandle` to kill the `EventLoop` to simulate a real world crash. tokio 1.0 is needed for this. It is probably about time to upgrade tokio anyway. 

In order to upgrade to tokio 1.0 the following dependencies were also upgraded in the swap crate and monero-harness-rs
* backoff
* libp2p
* request

UPDATE: This should be merged until the following dependencies are uprgraded to Tokio 1.0 or Tokio compat  is used

- [x] bitcoin-harness-rs https://github.com/coblox/bitcoin-harness-rs/pull/20