### PR TITLE
Test refactor

### DIFF
--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -20,8 +20,13 @@ use crate::{
 };
 
 pub use self::{
-    amounts::*, event_loop::EventLoop, message0::Message0, message1::Message1, message2::Message2,
-    state::*, swap::swap,
+    amounts::*,
+    event_loop::{EventLoop, EventLoopHandle},
+    message0::Message0,
+    message1::Message1,
+    message2::Message2,
+    state::*,
+    swap::swap,
 };
 
 mod amounts;

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -19,7 +19,9 @@ use crate::{
     SwapAmounts,
 };
 
-pub use self::{amounts::*, message0::Message0, message1::Message1, message2::Message2, state::*};
+pub use self::{
+    amounts::*, message0::Message0, message1::Message1, message2::Message2, state::*, swap::swap,
+};
 
 mod amounts;
 pub mod event_loop;

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -20,7 +20,8 @@ use crate::{
 };
 
 pub use self::{
-    amounts::*, message0::Message0, message1::Message1, message2::Message2, state::*, swap::swap,
+    amounts::*, event_loop::EventLoop, message0::Message0, message1::Message1, message2::Message2,
+    state::*, swap::swap,
 };
 
 mod amounts;

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -26,7 +26,7 @@ pub use self::{
     message1::Message1,
     message2::Message2,
     state::*,
-    swap::swap,
+    swap::{run_until, swap},
 };
 
 mod amounts;

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -88,12 +88,11 @@ pub async fn run_until(
     state: AliceState,
     is_target_state: fn(&AliceState) -> bool,
     mut event_loop_handle: EventLoopHandle,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    monero_wallet: Arc<crate::monero::Wallet>,
+    bitcoin_wallet: Arc<bitcoin::Wallet>,
+    monero_wallet: Arc<monero::Wallet>,
     config: Config,
     swap_id: Uuid,
     db: Database,
-    // TODO: Remove EventLoopHandle!
 ) -> Result<AliceState> {
     info!("Current state:{}", state);
     if is_target_state(&state) {

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -26,7 +26,7 @@ pub use self::{
     message2::Message2,
     message3::Message3,
     state::*,
-    swap::swap,
+    swap::{run_until, swap},
 };
 
 mod amounts;

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub use self::{
     amounts::*, message0::Message0, message1::Message1, message2::Message2, message3::Message3,
-    state::*,
+    state::*, swap::swap,
 };
 
 mod amounts;

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -19,8 +19,8 @@ use crate::{
 };
 
 pub use self::{
-    amounts::*, message0::Message0, message1::Message1, message2::Message2, message3::Message3,
-    state::*, swap::swap,
+    amounts::*, event_loop::EventLoop, message0::Message0, message1::Message1, message2::Message2,
+    message3::Message3, state::*, swap::swap,
 };
 
 mod amounts;

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -19,8 +19,14 @@ use crate::{
 };
 
 pub use self::{
-    amounts::*, event_loop::EventLoop, message0::Message0, message1::Message1, message2::Message2,
-    message3::Message3, state::*, swap::swap,
+    amounts::*,
+    event_loop::{EventLoop, EventLoopHandle},
+    message0::Message0,
+    message1::Message1,
+    message2::Message2,
+    message3::Message3,
+    state::*,
+    swap::swap,
 };
 
 mod amounts;

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -7,7 +7,9 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::{
+    bitcoin,
     database::{Database, Swap},
+    monero,
     protocol::bob::{self, event_loop::EventLoopHandle, state::*},
     ExpiredTimelocks, SwapAmounts,
 };
@@ -18,8 +20,8 @@ pub async fn swap<R>(
     state: BobState,
     event_loop_handle: EventLoopHandle,
     db: Database,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    monero_wallet: Arc<crate::monero::Wallet>,
+    bitcoin_wallet: Arc<bitcoin::Wallet>,
+    monero_wallet: Arc<monero::Wallet>,
     rng: R,
     swap_id: Uuid,
 ) -> Result<BobState>
@@ -69,8 +71,8 @@ pub async fn run_until<R>(
     is_target_state: fn(&BobState) -> bool,
     mut event_loop_handle: EventLoopHandle,
     db: Database,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    monero_wallet: Arc<crate::monero::Wallet>,
+    bitcoin_wallet: Arc<bitcoin::Wallet>,
+    monero_wallet: Arc<monero::Wallet>,
     mut rng: R,
     swap_id: Uuid,
 ) -> Result<BobState>

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,21 +1,9 @@
-use crate::testutils::{init_alice, init_bob};
-use futures::{
-    future::{join, select},
-    FutureExt,
-};
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use swap::{
     bitcoin,
-    config::Config,
-    monero,
-    protocol::{alice, bob},
-    seed::Seed,
+    protocol::{alice, alice::AliceState, bob, bob::BobState},
 };
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use uuid::Uuid;
+use tokio::join;
 
 pub mod testutils;
 
@@ -23,108 +11,47 @@ pub mod testutils;
 
 #[tokio::test]
 async fn happy_path() {
-    let _guard = init_tracing();
+    testutils::test(|alice, bob, swap_amounts| async move {
+        let alice_swap_fut = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        );
+        let bob_swap_fut = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        );
+        let (alice_state, bob_state) = join!(alice_swap_fut, bob_swap_fut);
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let btc_alice_final = alice.bitcoin_wallet.as_ref().balance().await.unwrap();
+        let btc_bob_final = bob.bitcoin_wallet.as_ref().balance().await.unwrap();
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let btc_alice = bitcoin::Amount::ZERO;
-    let btc_bob = btc_to_swap * 10;
+        let xmr_alice_final = alice.monero_wallet.as_ref().get_balance().await.unwrap();
 
-    // this xmr value matches the logic of alice::calculate_amounts i.e. btc *
-    // 10_000 * 100
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-    let xmr_alice = xmr_to_swap * 10;
-    let xmr_bob = monero::Amount::ZERO;
+        bob.monero_wallet.as_ref().inner.refresh().await.unwrap();
+        let xmr_bob_final = bob.monero_wallet.as_ref().get_balance().await.unwrap();
 
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
+        assert!(matches!(alice_state.unwrap(), AliceState::BtcRedeemed));
+        assert!(matches!(bob_state.unwrap(), BobState::XmrRedeemed));
 
-    let config = Config::regtest();
+        assert_eq!(
+            btc_alice_final,
+            alice.btc_starting_balance + swap_amounts.btc
+                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+        );
+        assert!(btc_bob_final <= bob.btc_starting_balance - swap_amounts.btc);
 
-    let (
-        alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_db,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        xmr_alice,
-        alice_multiaddr.clone(),
-        config,
-        Seed::random().unwrap(),
-    )
+        assert!(xmr_alice_final <= alice.xmr_starting_balance - swap_amounts.xmr);
+        assert_eq!(xmr_bob_final, bob.xmr_starting_balance + swap_amounts.xmr);
+    })
     .await;
-
-    let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_event_loop.peer_id(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            btc_bob,
-            xmr_to_swap,
-            config,
-        )
-        .await;
-
-    let alice_swap_fut = alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        config,
-        Uuid::new_v4(),
-        alice_db,
-    )
-    .boxed();
-
-    let alice_fut = select(alice_swap_fut, alice_event_loop.run().boxed());
-
-    let bob_swap_fut = bob::swap::swap(
-        bob_state,
-        bob_event_loop_handle,
-        bob_db,
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        Uuid::new_v4(),
-    )
-    .boxed();
-
-    let bob_fut = select(bob_swap_fut, bob_event_loop.run().boxed());
-
-    join(alice_fut, bob_fut).await;
-
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
-
-    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    bob_xmr_wallet.as_ref().inner.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    assert_eq!(
-        btc_alice_final,
-        btc_alice + btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
-    assert!(btc_bob_final <= btc_bob - btc_to_swap);
-
-    assert!(xmr_alice_final <= xmr_alice - xmr_to_swap);
-    assert_eq!(xmr_bob_final, xmr_bob + xmr_to_swap);
 }

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -10,7 +10,9 @@ pub mod testutils;
 async fn happy_path() {
     testutils::test(|alice_harness, bob_harness| async move {
         let alice = alice_harness.new_alice().await;
-        let alice_swap_fut = alice::swap(
+        let bob = bob_harness.new_bob().await;
+
+        let alice_swap = alice::swap(
             alice.state,
             alice.event_loop_handle,
             alice.bitcoin_wallet.clone(),
@@ -20,8 +22,7 @@ async fn happy_path() {
             alice.db,
         );
 
-        let bob = bob_harness.new_bob().await;
-        let bob_swap_fut = bob::swap(
+        let bob_swap = bob::swap(
             bob.state,
             bob.event_loop_handle,
             bob.db,
@@ -30,7 +31,7 @@ async fn happy_path() {
             OsRng,
             bob.swap_id,
         );
-        let (alice_state, bob_state) = join!(alice_swap_fut, bob_swap_fut);
+        let (alice_state, bob_state) = join!(alice_swap, bob_swap);
 
         alice_harness.assert_redeemed(alice_state.unwrap()).await;
         bob_harness.assert_redeemed(bob_state.unwrap()).await;

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -11,12 +11,13 @@ pub mod testutils;
 
 #[tokio::test]
 async fn happy_path() {
-    testutils::test(|alice, bob, swap_amounts| async move {
+    testutils::test(|alice_factory, bob, swap_amounts| async move {
+        let alice = alice_factory.new_alice().await;
         let alice_swap_fut = alice::swap(
             alice.state,
             alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
+            alice.btc_wallet.clone(),
+            alice.xmr_wallet.clone(),
             alice.config,
             alice.swap_id,
             alice.db,
@@ -32,10 +33,10 @@ async fn happy_path() {
         );
         let (alice_state, bob_state) = join!(alice_swap_fut, bob_swap_fut);
 
-        let btc_alice_final = alice.bitcoin_wallet.as_ref().balance().await.unwrap();
+        let btc_alice_final = alice.btc_wallet.as_ref().balance().await.unwrap();
         let btc_bob_final = bob.bitcoin_wallet.as_ref().balance().await.unwrap();
 
-        let xmr_alice_final = alice.monero_wallet.as_ref().get_balance().await.unwrap();
+        let xmr_alice_final = alice.xmr_wallet.as_ref().get_balance().await.unwrap();
 
         bob.monero_wallet.as_ref().inner.refresh().await.unwrap();
         let xmr_bob_final = bob.monero_wallet.as_ref().get_balance().await.unwrap();

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -9,7 +9,7 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         let alice = alice_harness.new_alice().await;
         let bob = bob_harness.new_bob().await;
 
-        let bob_swap_fut = bob::swap(
+        let bob_swap = bob::swap(
             bob.state,
             bob.event_loop_handle,
             bob.db,
@@ -18,7 +18,7 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
             OsRng,
             bob.swap_id,
         );
-        let bob_swap_handle = tokio::spawn(bob_swap_fut);
+        let bob_swap_handle = tokio::spawn(bob_swap);
 
         let alice_state = alice::run_until(
             alice.state,

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,166 +1,78 @@
-use crate::testutils::{init_alice, init_bob};
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
 use swap::{
     bitcoin,
-    config::Config,
-    database::Database,
-    monero,
-    protocol::{alice, alice::AliceState, bob},
-    seed::Seed,
+    protocol::{alice, alice::AliceState, bob, bob::BobState},
 };
-use tempfile::tempdir;
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use uuid::Uuid;
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    let _guard = init_tracing();
+    testutils::test(|alice_factory, bob, swap_amounts| async move {
+        let alice = alice_factory.new_alice().await;
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let bob_swap_fut = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        );
+        let bob_swap_handle = tokio::spawn(bob_swap_fut);
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let config = Config::regtest();
-
-    let alice_seed = Seed::random().unwrap();
-    let (
-        start_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        _,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        config,
-        alice_seed,
-    )
-    .await;
-
-    let alice_peer_id = alice_event_loop.peer_id();
-
-    let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_peer_id.clone(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            config,
+        let alice_state = alice::run_until(
+            alice.state,
+            alice::swap::is_encsig_learned,
+            alice.event_loop_handle,
+            alice.btc_wallet.clone(),
+            alice.xmr_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
         )
-        .await;
+        .await
+        .unwrap();
+        assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
 
-    // TODO: we are making a clone of Bob's wallets here to keep them in scope after
-    // Bob's wallets are moved into an async task.
-    let bob_btc_wallet_clone = bob_btc_wallet.clone();
-    let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
+        let alice = alice_factory.recover_alice_from_db().await;
+        assert!(matches!(alice.state, AliceState::EncSigLearned {..}));
 
-    let bob_fut = bob::swap::swap(
-        bob_state,
-        bob_event_loop_handle,
-        bob_db,
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        Uuid::new_v4(),
-    );
+        let alice_state = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.btc_wallet.clone(),
+            alice.xmr_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        )
+        .await
+        .unwrap();
 
-    let alice_db_datadir = tempdir().unwrap();
-    let alice_db = Database::open(alice_db_datadir.path()).unwrap();
+        let bob_state = bob_swap_handle.await.unwrap();
 
-    tokio::spawn(async move { alice_event_loop.run().await });
-    let bob_swap_handle = tokio::spawn(bob_fut);
-    tokio::spawn(bob_event_loop.run());
+        let btc_alice_final = alice.btc_wallet.as_ref().balance().await.unwrap();
+        let btc_bob_final = bob.bitcoin_wallet.as_ref().balance().await.unwrap();
 
-    let alice_swap_id = Uuid::new_v4();
+        let xmr_alice_final = alice.xmr_wallet.as_ref().get_balance().await.unwrap();
 
-    let alice_state = alice::swap::run_until(
-        start_state,
-        alice::swap::is_encsig_learned,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        config,
-        alice_swap_id,
-        alice_db,
-    )
-    .await
-    .unwrap();
+        bob.monero_wallet.as_ref().inner.refresh().await.unwrap();
+        let xmr_bob_final = bob.monero_wallet.as_ref().get_balance().await.unwrap();
 
-    assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
+        assert!(matches!(alice_state, AliceState::BtcRedeemed));
+        assert!(matches!(bob_state.unwrap(), BobState::XmrRedeemed));
 
-    let alice_db = Database::open(alice_db_datadir.path()).unwrap();
+        assert_eq!(
+            btc_alice_final,
+            alice.btc_starting_balance + swap_amounts.btc
+                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+        );
+        assert!(btc_bob_final <= bob.btc_starting_balance - swap_amounts.btc);
 
-    let resume_state =
-        if let swap::database::Swap::Alice(state) = alice_db.get_state(alice_swap_id).unwrap() {
-            assert!(matches!(state, swap::database::Alice::EncSigLearned {..}));
-            state.into()
-        } else {
-            unreachable!()
-        };
-
-    let (mut event_loop_after_restart, event_loop_handle_after_restart) =
-        testutils::init_alice_event_loop(alice_multiaddr, alice_seed);
-    tokio::spawn(async move { event_loop_after_restart.run().await });
-
-    let alice_state = alice::swap::swap(
-        resume_state,
-        event_loop_handle_after_restart,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        config,
-        alice_swap_id,
-        alice_db,
-    )
-    .await
-    .unwrap();
-
-    // Wait for Bob to finish
-    bob_swap_handle.await.unwrap().unwrap();
-
-    assert!(matches!(alice_state, AliceState::BtcRedeemed {..}));
-
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet_clone.as_ref().balance().await.unwrap();
-
-    assert_eq!(
-        btc_alice_final,
-        btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
-    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
-
-    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-    bob_xmr_wallet_clone.as_ref().inner.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
-
-    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
-    assert_eq!(xmr_bob_final, xmr_to_swap);
+        assert!(xmr_alice_final <= alice.xmr_starting_balance - swap_amounts.xmr);
+        assert_eq!(xmr_bob_final, bob.xmr_starting_balance + swap_amounts.xmr);
+    })
+    .await;
 }

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,15 +1,12 @@
 use rand::rngs::OsRng;
-use swap::{
-    bitcoin,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
-};
+use swap::protocol::{alice, alice::AliceState, bob, bob::BobState};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::test(|alice_factory, bob, swap_amounts| async move {
-        let alice = alice_factory.new_alice().await;
+    testutils::test(|alice_harness, bob, swap_amounts| async move {
+        let alice = alice_harness.new_alice().await;
 
         let bob_swap_fut = bob::swap(
             bob.state,
@@ -26,8 +23,8 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
             alice.state,
             alice::swap::is_encsig_learned,
             alice.event_loop_handle,
-            alice.btc_wallet.clone(),
-            alice.xmr_wallet.clone(),
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
             alice.config,
             alice.swap_id,
             alice.db,
@@ -36,14 +33,14 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         .unwrap();
         assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
 
-        let alice = alice_factory.recover_alice_from_db().await;
+        let alice = alice_harness.recover_alice_from_db().await;
         assert!(matches!(alice.state, AliceState::EncSigLearned {..}));
 
         let alice_state = alice::swap(
             alice.state,
             alice.event_loop_handle,
-            alice.btc_wallet.clone(),
-            alice.xmr_wallet.clone(),
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
             alice.config,
             alice.swap_id,
             alice.db,
@@ -51,27 +48,14 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
         .await
         .unwrap();
 
+        alice_harness.assert_redeemed(alice_state).await;
+
         let bob_state = bob_swap_handle.await.unwrap();
-
-        let btc_alice_final = alice.btc_wallet.as_ref().balance().await.unwrap();
         let btc_bob_final = bob.bitcoin_wallet.as_ref().balance().await.unwrap();
-
-        let xmr_alice_final = alice.xmr_wallet.as_ref().get_balance().await.unwrap();
-
         bob.monero_wallet.as_ref().inner.refresh().await.unwrap();
         let xmr_bob_final = bob.monero_wallet.as_ref().get_balance().await.unwrap();
-
-        assert!(matches!(alice_state, AliceState::BtcRedeemed));
         assert!(matches!(bob_state.unwrap(), BobState::XmrRedeemed));
-
-        assert_eq!(
-            btc_alice_final,
-            alice.btc_starting_balance + swap_amounts.btc
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-        );
         assert!(btc_bob_final <= bob.btc_starting_balance - swap_amounts.btc);
-
-        assert!(xmr_alice_final <= alice.xmr_starting_balance - swap_amounts.xmr);
         assert_eq!(xmr_bob_final, bob.xmr_starting_balance + swap_amounts.xmr);
     })
     .await;

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -1,168 +1,59 @@
-use crate::testutils::{init_alice, init_bob};
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
-use swap::{
-    bitcoin,
-    config::Config,
-    database::Database,
-    monero,
-    protocol::{alice, bob, bob::BobState},
-    seed::Seed,
-};
-use tempfile::tempdir;
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use uuid::Uuid;
+use swap::protocol::{alice, bob, bob::BobState};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    let _guard = init_tracing();
+    testutils::test(|alice_harness, bob_harness| async move {
+        let alice = alice_harness.new_alice().await;
+        let bob = bob_harness.new_bob().await;
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let alice_swap = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        );
+        let alice_swap_handle = tokio::spawn(alice_swap);
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let config = Config::regtest();
-
-    let (
-        alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_db,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        config,
-        Seed::random().unwrap(),
-    )
-    .await;
-
-    let alice_peer_id = alice_event_loop.peer_id();
-    let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, _) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_peer_id.clone(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            config,
+        let bob_state = bob::run_until(
+            bob.state,
+            bob::swap::is_encsig_sent,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
         )
-        .await;
+        .await
+        .unwrap();
 
-    // TODO: we are making a clone of Alices's wallets here to keep them in scope
-    // after Alices's wallets are moved into an async task.
-    let alice_btc_wallet_clone = alice_btc_wallet.clone();
-    let alice_xmr_wallet_clone = alice_xmr_wallet.clone();
+        assert!(matches!(bob_state, BobState::EncSigSent {..}));
 
-    // TODO: we are making a clone of Bob's wallets here to keep them in scope after
-    // Bob's wallets are moved into an async task.
-    let bob_btc_wallet_clone = bob_btc_wallet.clone();
-    let bob_xmr_wallet_clone = bob_xmr_wallet.clone();
+        let bob = bob_harness.recover_bob_from_db().await;
+        assert!(matches!(bob.state, BobState::EncSigSent {..}));
 
-    let alice_swap_handle = tokio::spawn(alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        config,
-        Uuid::new_v4(),
-        alice_db,
-    ));
+        let bob_state = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        )
+        .await
+        .unwrap();
 
-    tokio::spawn(async move { alice_event_loop.run().await });
+        bob_harness.assert_redeemed(bob_state).await;
 
-    tokio::spawn(bob_event_loop.run());
-
-    let bob_swap_id = Uuid::new_v4();
-    let bob_db_datadir = tempdir().unwrap();
-    let bob_db = Database::open(bob_db_datadir.path()).unwrap();
-
-    let bob_state = bob::swap::run_until(
-        bob_state,
-        bob::swap::is_encsig_sent,
-        bob_event_loop_handle,
-        bob_db,
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        bob_swap_id,
-    )
-    .await
-    .unwrap();
-
-    assert!(matches!(bob_state, BobState::EncSigSent {..}));
-
-    let bob_db = Database::open(bob_db_datadir.path()).unwrap();
-
-    let resume_state =
-        if let swap::database::Swap::Bob(state) = bob_db.get_state(bob_swap_id).unwrap() {
-            assert!(matches!(state, swap::database::Bob::EncSigSent {..}));
-            state.into()
-        } else {
-            unreachable!()
-        };
-
-    let (event_loop_after_restart, event_loop_handle_after_restart) =
-        testutils::init_bob_event_loop(alice_peer_id, alice_multiaddr);
-    tokio::spawn(event_loop_after_restart.run());
-
-    let bob_state = bob::swap::swap(
-        resume_state,
-        event_loop_handle_after_restart,
-        bob_db,
-        bob_btc_wallet,
-        bob_xmr_wallet,
-        OsRng,
-        bob_swap_id,
-    )
-    .await
-    .unwrap();
-
-    // Wait for Alice to finish too
-    alice_swap_handle.await.unwrap().unwrap();
-
-    assert!(matches!(bob_state, BobState::XmrRedeemed {..}));
-
-    let btc_alice_final = alice_btc_wallet_clone.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet_clone.as_ref().balance().await.unwrap();
-
-    assert_eq!(
-        btc_alice_final,
-        btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
-    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
-
-    let xmr_alice_final = alice_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
-    bob_xmr_wallet_clone.as_ref().inner.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet_clone.as_ref().get_balance().await.unwrap();
-
-    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
-    assert_eq!(xmr_bob_final, xmr_to_swap);
+        let alice_state = alice_swap_handle.await.unwrap();
+        alice_harness.assert_redeemed(alice_state.unwrap()).await;
+    })
+    .await;
 }

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,159 +1,59 @@
-use crate::testutils::{init_alice, init_bob};
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
-use swap::{
-    bitcoin,
-    config::Config,
-    database::Database,
-    monero,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
-    seed::Seed,
-};
-use tempfile::tempdir;
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use tokio::select;
-use uuid::Uuid;
+use swap::protocol::{alice, bob, bob::BobState};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    let _guard = init_tracing();
+    testutils::test(|alice_harness, bob_harness| async move {
+        let alice = alice_harness.new_alice().await;
+        let bob = bob_harness.new_bob().await;
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let alice_swap = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        );
+        let alice_swap_handle = tokio::spawn(alice_swap);
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-    let bob_xmr_starting_balance = monero::Amount::from_piconero(0);
-
-    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let (
-        alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_db,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        Config::regtest(),
-        Seed::random().unwrap(),
-    )
-    .await;
-
-    let alice_peer_id = alice_event_loop.peer_id();
-    let (bob_state, bob_event_loop_1, bob_event_loop_handle_1, bob_btc_wallet, bob_xmr_wallet, _) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_peer_id.clone(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            Config::regtest(),
-        )
-        .await;
-
-    let alice_fut = alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        Config::regtest(),
-        Uuid::new_v4(),
-        alice_db,
-    );
-
-    let bob_swap_id = Uuid::new_v4();
-    let bob_db_datadir = tempdir().unwrap();
-
-    let bob_xmr_locked_fut = {
-        let bob_db = Database::open(bob_db_datadir.path()).unwrap();
-        bob::swap::run_until(
-            bob_state,
+        let bob_state = bob::run_until(
+            bob.state,
             bob::swap::is_xmr_locked,
-            bob_event_loop_handle_1,
-            bob_db,
-            bob_btc_wallet.clone(),
-            bob_xmr_wallet.clone(),
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
             OsRng,
-            bob_swap_id,
+            bob.swap_id,
         )
-    };
+        .await
+        .unwrap();
 
-    tokio::spawn(async move { alice_event_loop.run().await });
+        assert!(matches!(bob_state, BobState::XmrLocked {..}));
 
-    let alice_fut_handle = tokio::spawn(alice_fut);
+        let bob = bob_harness.recover_bob_from_db().await;
+        assert!(matches!(bob.state, BobState::XmrLocked {..}));
 
-    // We are selecting with bob_event_loop_1 so that we stop polling on it once
-    // bob reaches `xmr locked` state.
-    let bob_restart_state = select! {
-        res = bob_xmr_locked_fut => res.unwrap(),
-        _ = bob_event_loop_1.run() => panic!("The event loop should never finish")
-    };
+        let bob_state = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        )
+        .await
+        .unwrap();
 
-    let (bob_event_loop_2, bob_event_loop_handle_2) =
-        testutils::init_bob_event_loop(alice_peer_id, alice_multiaddr);
+        bob_harness.assert_redeemed(bob_state).await;
 
-    let bob_fut = bob::swap::swap(
-        bob_restart_state,
-        bob_event_loop_handle_2,
-        Database::open(bob_db_datadir.path()).unwrap(),
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        bob_swap_id,
-    );
-
-    let bob_final_state = select! {
-     bob_final_state = bob_fut => bob_final_state.unwrap(),
-     _ = bob_event_loop_2.run() => panic!("Event loop is not expected to stop")
-    };
-
-    assert!(matches!(bob_final_state, BobState::XmrRedeemed));
-
-    // Wait for Alice to finish too.
-    let alice_final_state = alice_fut_handle.await.unwrap().unwrap();
-    assert!(matches!(alice_final_state, AliceState::BtcRedeemed));
-
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
-
-    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    bob_xmr_wallet.as_ref().inner.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
-
-    assert_eq!(
-        btc_alice_final,
-        alice_btc_starting_balance + btc_to_swap - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-    );
-    assert!(btc_bob_final <= bob_btc_starting_balance - btc_to_swap);
-
-    assert!(xmr_alice_final <= alice_xmr_starting_balance - xmr_to_swap);
-    assert_eq!(xmr_bob_final, bob_xmr_starting_balance + xmr_to_swap);
+        let alice_state = alice_swap_handle.await.unwrap();
+        alice_harness.assert_redeemed(alice_state.unwrap()).await;
+    })
+    .await;
 }

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,21 +1,5 @@
-use crate::testutils::{init_alice, init_bob};
-use futures::{
-    future::{join, select, Either},
-    FutureExt,
-};
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
-use swap::{
-    bitcoin,
-    config::Config,
-    monero,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
-    seed::Seed,
-};
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use uuid::Uuid;
+use swap::protocol::{alice, bob, bob::BobState};
 
 pub mod testutils;
 
@@ -23,128 +7,64 @@ pub mod testutils;
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    let _guard = init_tracing();
+    testutils::test(|alice_harness, bob_harness| async move {
+        let alice = alice_harness.new_alice().await;
+        let bob = bob_harness.new_bob().await;
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let alice_swap = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        );
+        let alice_swap_handle = tokio::spawn(alice_swap);
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-
-    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let config = Config::regtest();
-
-    let (
-        alice_state,
-        mut alice_event_loop,
-        alice_event_loop_handle,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        alice_db,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        config,
-        Seed::random().unwrap(),
-    )
-    .await;
-
-    let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
-        init_bob(
-            alice_multiaddr,
-            alice_event_loop.peer_id(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            config,
+        let bob_state = bob::run_until(
+            bob.state,
+            bob::swap::is_btc_locked,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
         )
-        .await;
-
-    let bob_btc_locked_fut = bob::swap::run_until(
-        bob_state,
-        bob::swap::is_btc_locked,
-        bob_event_loop_handle,
-        bob_db,
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        Uuid::new_v4(),
-    )
-    .boxed();
-
-    let bob_fut = select(bob_btc_locked_fut, bob_event_loop.run().boxed());
-
-    let alice_fut = alice::swap::swap(
-        alice_state,
-        alice_event_loop_handle,
-        alice_btc_wallet.clone(),
-        alice_xmr_wallet.clone(),
-        Config::regtest(),
-        Uuid::new_v4(),
-        alice_db,
-    )
-    .boxed();
-
-    let alice_fut = select(alice_fut, alice_event_loop.run().boxed());
-
-    // Wait until alice has locked xmr and bob has locked btc
-    let (alice_state, bob_state) = join(alice_fut, bob_fut).await;
-
-    let alice_state = match alice_state {
-        Either::Left((state, _)) => state.unwrap(),
-        Either::Right(_) => panic!("Alice event loop should not terminate."),
-    };
-
-    let bob_state = match bob_state {
-        Either::Left((state, _)) => state.unwrap(),
-        Either::Right(_) => panic!("Bob event loop should not terminate."),
-    };
-
-    assert!(matches!(alice_state, AliceState::BtcPunished));
-    let bob_state3 = if let BobState::BtcLocked(state3, ..) = bob_state {
-        state3
-    } else {
-        panic!("Bob in unexpected state");
-    };
-
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
-
-    // lock_tx_bitcoin_fee is determined by the wallet, it is not necessarily equal
-    // to TX_FEE
-    let lock_tx_bitcoin_fee = bob_btc_wallet
-        .transaction_fee(bob_state3.tx_lock_id())
         .await
         .unwrap();
 
-    assert_eq!(
-        btc_alice_final,
-        alice_btc_starting_balance + btc_to_swap - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE)
-    );
+        assert!(matches!(bob_state, BobState::BtcLocked {..}));
 
-    assert_eq!(
-        btc_bob_final,
-        bob_btc_starting_balance - btc_to_swap - lock_tx_bitcoin_fee
-    );
+        let alice_state = alice_swap_handle.await.unwrap();
+        alice_harness.assert_punished(alice_state.unwrap()).await;
+
+        // Restart Bob after Alice punished to ensure Bob transitions to
+        // punished and does not run indefinitely
+        let bob = bob_harness.recover_bob_from_db().await;
+        assert!(matches!(bob.state, BobState::BtcLocked {..}));
+
+        // TODO: make lock-tx-id available in final states
+        let lock_tx_id = if let BobState::BtcLocked(state3) = bob_state {
+            state3.tx_lock_id()
+        } else {
+            panic!("Bob in unexpected state");
+        };
+
+        let bob_state = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        )
+        .await
+        .unwrap();
+
+        bob_harness.assert_punished(bob_state, lock_tx_id).await;
+    })
+    .await;
 }

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,174 +1,66 @@
-use crate::testutils::{init_alice, init_bob};
-use futures::future::try_join;
-use get_port::get_port;
-use libp2p::Multiaddr;
 use rand::rngs::OsRng;
-use swap::{
-    bitcoin,
-    config::Config,
-    database::Database,
-    monero,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
-    seed::Seed,
-};
-use tempfile::tempdir;
-use testcontainers::clients::Cli;
-use testutils::init_tracing;
-use tokio::select;
-use uuid::Uuid;
+use swap::protocol::{alice, alice::AliceState, bob};
 
 pub mod testutils;
 
-// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
-// then also refunds.
+/// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
+/// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
-    let _guard = init_tracing();
+    testutils::test(|alice_harness, bob_harness| async move {
+        let alice = alice_harness.new_alice().await;
+        let bob = bob_harness.new_bob().await;
 
-    let cli = Cli::default();
-    let (
-        monero,
-        testutils::Containers {
-            bitcoind,
-            monerods: _monerods,
-        },
-    ) = testutils::init_containers(&cli).await;
+        let bob_swap = bob::swap(
+            bob.state,
+            bob.event_loop_handle,
+            bob.db,
+            bob.bitcoin_wallet.clone(),
+            bob.monero_wallet.clone(),
+            OsRng,
+            bob.swap_id,
+        );
+        let bob_swap_handle = tokio::spawn(bob_swap);
 
-    let btc_to_swap = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_to_swap = monero::Amount::from_piconero(1_000_000_000_000);
-
-    let bob_btc_starting_balance = btc_to_swap * 10;
-    let bob_xmr_starting_balance = monero::Amount::from_piconero(0);
-
-    let alice_btc_starting_balance = bitcoin::Amount::ZERO;
-    let alice_xmr_starting_balance = xmr_to_swap * 10;
-
-    let port = get_port().expect("Failed to find a free port");
-    let alice_multiaddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", port)
-        .parse()
-        .expect("failed to parse Alice's address");
-
-    let alice_seed = Seed::random().unwrap();
-    let (
-        alice_state,
-        mut alice_event_loop_1,
-        alice_event_loop_handle_1,
-        alice_btc_wallet,
-        alice_xmr_wallet,
-        _,
-    ) = init_alice(
-        &bitcoind,
-        &monero,
-        btc_to_swap,
-        xmr_to_swap,
-        alice_xmr_starting_balance,
-        alice_multiaddr.clone(),
-        Config::regtest(),
-        alice_seed,
-    )
-    .await;
-
-    let (bob_state, bob_event_loop, bob_event_loop_handle, bob_btc_wallet, bob_xmr_wallet, bob_db) =
-        init_bob(
-            alice_multiaddr.clone(),
-            alice_event_loop_1.peer_id(),
-            &bitcoind,
-            &monero,
-            btc_to_swap,
-            bob_btc_starting_balance,
-            xmr_to_swap,
-            Config::regtest(),
-        )
-        .await;
-
-    let bob_fut = bob::swap::swap(
-        bob_state,
-        bob_event_loop_handle,
-        bob_db,
-        bob_btc_wallet.clone(),
-        bob_xmr_wallet.clone(),
-        OsRng,
-        Uuid::new_v4(),
-    );
-
-    let alice_swap_id = Uuid::new_v4();
-    let alice_db_datadir = tempdir().unwrap();
-
-    let alice_xmr_locked_fut = {
-        let alice_db = Database::open(alice_db_datadir.path()).unwrap();
-        alice::swap::run_until(
-            alice_state,
+        let alice_state = alice::run_until(
+            alice.state,
             alice::swap::is_xmr_locked,
-            alice_event_loop_handle_1,
-            alice_btc_wallet.clone(),
-            alice_xmr_wallet.clone(),
-            Config::regtest(),
-            alice_swap_id,
-            alice_db,
-        )
-    };
-
-    tokio::spawn(bob_event_loop.run());
-
-    // We are selecting with alice_event_loop_1 so that we stop polling on it once
-    // the try_join is finished.
-    let (bob_state, alice_restart_state) = select! {
-        res = try_join(bob_fut, alice_xmr_locked_fut) => res.unwrap(),
-        _ = alice_event_loop_1.run() => panic!("The event loop should never finish")
-    };
-
-    let tx_lock_id = if let BobState::BtcRefunded(state4) = bob_state {
-        state4.tx_lock_id()
-    } else {
-        panic!("Bob in unexpected state");
-    };
-
-    let (mut alice_event_loop_2, alice_event_loop_handle_2) =
-        testutils::init_alice_event_loop(alice_multiaddr, alice_seed);
-
-    let alice_final_state = {
-        let alice_db = Database::open(alice_db_datadir.path()).unwrap();
-        alice::swap::swap(
-            alice_restart_state,
-            alice_event_loop_handle_2,
-            alice_btc_wallet.clone(),
-            alice_xmr_wallet.clone(),
-            Config::regtest(),
-            alice_swap_id,
-            alice_db,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
         )
         .await
-        .unwrap()
-    };
-    tokio::spawn(async move { alice_event_loop_2.run().await });
+        .unwrap();
+        assert!(matches!(alice_state, AliceState::XmrLocked {..}));
 
-    assert!(matches!(alice_final_state, AliceState::XmrRefunded));
+        // Alice does not act, Bob refunds
+        let bob_state = bob_swap_handle.await.unwrap();
 
-    let btc_alice_final = alice_btc_wallet.as_ref().balance().await.unwrap();
-    let btc_bob_final = bob_btc_wallet.as_ref().balance().await.unwrap();
+        // Once bob has finished Alice is restarted and refunds as well
+        let alice = alice_harness.recover_alice_from_db().await;
+        assert!(matches!(alice.state, AliceState::XmrLocked {..}));
 
-    let lock_tx_bitcoin_fee = bob_btc_wallet.transaction_fee(tx_lock_id).await.unwrap();
+        let alice_state = alice::swap(
+            alice.state,
+            alice.event_loop_handle,
+            alice.bitcoin_wallet.clone(),
+            alice.monero_wallet.clone(),
+            alice.config,
+            alice.swap_id,
+            alice.db,
+        )
+        .await
+        .unwrap();
 
-    assert_eq!(btc_alice_final, alice_btc_starting_balance);
-
-    // Alice or Bob could publish TxCancel. This means Bob could pay tx fees for
-    // TxCancel and TxRefund or only TxRefund
-    let btc_bob_final_alice_submitted_cancel = btc_bob_final
-        == bob_btc_starting_balance
-            - lock_tx_bitcoin_fee
-            - bitcoin::Amount::from_sat(bitcoin::TX_FEE);
-
-    let btc_bob_final_bob_submitted_cancel = btc_bob_final
-        == bob_btc_starting_balance
-            - lock_tx_bitcoin_fee
-            - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE);
-    assert!(btc_bob_final_alice_submitted_cancel || btc_bob_final_bob_submitted_cancel);
-
-    alice_xmr_wallet.as_ref().inner.refresh().await.unwrap();
-    let xmr_alice_final = alice_xmr_wallet.as_ref().get_balance().await.unwrap();
-    assert_eq!(xmr_alice_final, xmr_to_swap);
-
-    bob_xmr_wallet.as_ref().inner.refresh().await.unwrap();
-    let xmr_bob_final = bob_xmr_wallet.as_ref().get_balance().await.unwrap();
-    assert_eq!(xmr_bob_final, bob_xmr_starting_balance);
+        // TODO: The test passes like this, but the assertion should be done after Bob
+        // refunded, not at the end because this can cause side-effects!
+        //  We have to properly wait for the refund tx's finality inside the assertion,
+        // which requires storing the refund_tx_id in the the state!
+        bob_harness.assert_refunded(bob_state.unwrap()).await;
+        alice_harness.assert_refunded(alice_state).await;
+    })
+    .await;
 }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -32,7 +32,7 @@ pub async fn init_wallets(
     name: &str,
     bitcoind: &Bitcoind<'_>,
     monero: &Monero,
-    btc_starting_balance: Option<::bitcoin::Amount>,
+    btc_starting_balance: Option<bitcoin::Amount>,
     xmr_starting_balance: Option<monero::Amount>,
     config: Config,
 ) -> (Arc<bitcoin::Wallet>, Arc<monero::Wallet>) {


### PR DESCRIPTION
This PR is pure refactoring, keeping the logic of the tests we had before. No production code is touched besides re-exports in early commits (no logic changes).

In the follow ups improvements will be introduced, that touch the production code as well.

All remaining tasks actioned since Friday: 

- [x] `happy_path_bob _restart` (trivial)
- [x] add refund assertions to harnesses (trivial)
- [x] convert all refund scenarios currently being tested (trivial)
- [x] remove dead test init code once all old tests are converted
- [ ] ~~(optional) move alice and bob harness code into separate files~~ -> might action this once re-using test code in production.

Out of scope, follow up:
- [x] https://github.com/comit-network/xmr-btc-swap/pull/145 - We can do exact assertions for Bob's redeem as well, but have to store Bob's `tx_lock` id in the respective final state. Make `tx_lock` available in `BtcRedeemed` and `BtcPunished` to have better assertions / harmonize test behaviour. 
- [ ] update the production code to use the `Alice` and `Bob` structs to bundle the params - update tests to use the production struct.
- [ ] Re-use test swap setup in production (i.e. `Alice-/BobHarness::new`) to setup the swap.
- [ ] add additional tests
- [ ] re-try moving the tests from `test` to `src` (if the peer_id was the only problem this should be trivial now - but should be done after the refactor is finished)
- [ ] creating new wallets upon restart
- [ ] aborting the old event loop after restart