### PR TITLE
Make lock-tx id available in redeem/punish state to be able to assert exact fees

### DIFF
--- a/swap/src/database.rs
+++ b/swap/src/database.rs
@@ -130,7 +130,7 @@ mod tests {
             .await
             .expect("Failed to save second state");
 
-        let state_2 = Swap::Bob(Bob::Done(BobEndState::XmrRedeemed));
+        let state_2 = Swap::Bob(Bob::Done(BobEndState::SafelyAborted));
         let swap_id_2 = Uuid::new_v4();
         db.insert_latest_state(swap_id_2, state_2.clone())
             .await
@@ -186,7 +186,7 @@ mod tests {
             .await
             .expect("Failed to save second state");
 
-        let state_2 = Swap::Bob(Bob::Done(BobEndState::BtcPunished));
+        let state_2 = Swap::Bob(Bob::Done(BobEndState::SafelyAborted));
         let swap_id_2 = Uuid::new_v4();
         db.insert_latest_state(swap_id_2, state_2.clone())
             .await

--- a/swap/src/database/bob.rs
+++ b/swap/src/database/bob.rs
@@ -33,9 +33,9 @@ pub enum Bob {
 #[derive(Clone, strum::Display, Debug, Deserialize, Serialize, PartialEq)]
 pub enum BobEndState {
     SafelyAborted,
-    XmrRedeemed,
+    XmrRedeemed(Box<bob::State6>),
     BtcRefunded(Box<bob::State4>),
-    BtcPunished,
+    BtcPunished(Box<bob::State6>),
 }
 
 impl From<BobState> for Bob {
@@ -50,8 +50,8 @@ impl From<BobState> for Bob {
             BobState::CancelTimelockExpired(state4) => Bob::CancelTimelockExpired(state4),
             BobState::BtcCancelled(state4) => Bob::BtcCancelled(state4),
             BobState::BtcRefunded(state4) => Bob::Done(BobEndState::BtcRefunded(Box::new(state4))),
-            BobState::XmrRedeemed => Bob::Done(BobEndState::XmrRedeemed),
-            BobState::BtcPunished => Bob::Done(BobEndState::BtcPunished),
+            BobState::XmrRedeemed(state6) => Bob::Done(BobEndState::XmrRedeemed(Box::new(state6))),
+            BobState::BtcPunished(state6) => Bob::Done(BobEndState::BtcPunished(Box::new(state6))),
             BobState::SafelyAborted => Bob::Done(BobEndState::SafelyAborted),
         }
     }
@@ -70,9 +70,9 @@ impl From<Bob> for BobState {
             Bob::BtcCancelled(state4) => BobState::BtcCancelled(state4),
             Bob::Done(end_state) => match end_state {
                 BobEndState::SafelyAborted => BobState::SafelyAborted,
-                BobEndState::XmrRedeemed => BobState::XmrRedeemed,
+                BobEndState::XmrRedeemed(state6) => BobState::XmrRedeemed(*state6),
                 BobEndState::BtcRefunded(state4) => BobState::BtcRefunded(*state4),
-                BobEndState::BtcPunished => BobState::BtcPunished,
+                BobEndState::BtcPunished(state6) => BobState::BtcPunished(*state6),
             },
         }
     }

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -35,8 +35,8 @@ pub enum BobState {
     CancelTimelockExpired(State4),
     BtcCancelled(State4),
     BtcRefunded(State4),
-    XmrRedeemed,
-    BtcPunished,
+    XmrRedeemed(State6),
+    BtcPunished(State6),
     SafelyAborted,
 }
 
@@ -52,8 +52,8 @@ impl fmt::Display for BobState {
             BobState::CancelTimelockExpired(..) => write!(f, "cancel timelock is expired"),
             BobState::BtcCancelled(..) => write!(f, "btc is cancelled"),
             BobState::BtcRefunded(..) => write!(f, "btc is refunded"),
-            BobState::XmrRedeemed => write!(f, "xmr is redeemed"),
-            BobState::BtcPunished => write!(f, "btc is punished"),
+            BobState::XmrRedeemed(..) => write!(f, "xmr is redeemed"),
+            BobState::BtcPunished(..) => write!(f, "btc is punished"),
             BobState::SafelyAborted => write!(f, "safely aborted"),
         }
     }
@@ -592,6 +592,12 @@ impl State4 {
     pub fn tx_lock_id(&self) -> bitcoin::Txid {
         self.tx_lock.txid()
     }
+
+    pub fn state6(&self) -> State6 {
+        State6 {
+            tx_lock_id: self.tx_lock.txid(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -643,5 +649,22 @@ impl State5 {
     }
     pub fn tx_lock_id(&self) -> bitcoin::Txid {
         self.tx_lock.txid()
+    }
+
+    pub fn state6(&self) -> State6 {
+        State6 {
+            tx_lock_id: self.tx_lock.txid(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct State6 {
+    pub tx_lock_id: Txid,
+}
+
+impl State6 {
+    pub fn tx_lock_id(&self) -> bitcoin::Txid {
+        self.tx_lock_id
     }
 }

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -45,13 +45,6 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         let bob = bob_harness.recover_bob_from_db().await;
         assert!(matches!(bob.state, BobState::BtcLocked {..}));
 
-        // TODO: make lock-tx-id available in final states
-        let lock_tx_id = if let BobState::BtcLocked(state3) = bob_state {
-            state3.tx_lock_id()
-        } else {
-            panic!("Bob in unexpected state");
-        };
-
         let bob_state = bob::swap(
             bob.state,
             bob.event_loop_handle,
@@ -64,7 +57,7 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         .await
         .unwrap();
 
-        bob_harness.assert_punished(bob_state, lock_tx_id).await;
+        bob_harness.assert_punished(bob_state).await;
     })
     .await;
 }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -363,10 +363,23 @@ impl BobHarness {
     }
 
     pub async fn assert_redeemed(&self, state: BobState) {
-        assert!(matches!(state, BobState::XmrRedeemed));
+        let lock_tx_id = if let BobState::XmrRedeemed(state6) = state {
+            state6.tx_lock_id()
+        } else {
+            panic!("Bob in unexpected state");
+        };
+
+        let lock_tx_bitcoin_fee = self
+            .bitcoin_wallet
+            .transaction_fee(lock_tx_id)
+            .await
+            .unwrap();
 
         let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert!(btc_balance_after_swap <= self.starting_balances.btc - self.swap_amounts.btc);
+        assert_eq!(
+            btc_balance_after_swap,
+            self.starting_balances.btc - self.swap_amounts.btc - lock_tx_bitcoin_fee
+        );
 
         // Ensure that Bob's balance is refreshed as we use a newly created wallet
         self.monero_wallet.as_ref().inner.refresh().await.unwrap();
@@ -409,8 +422,12 @@ impl BobHarness {
         assert_eq!(xmr_balance_after_swap, self.starting_balances.xmr);
     }
 
-    pub async fn assert_punished(&self, state: BobState, lock_tx_id: ::bitcoin::Txid) {
-        assert!(matches!(state, BobState::BtcPunished));
+    pub async fn assert_punished(&self, state: BobState) {
+        let lock_tx_id = if let BobState::BtcPunished(state6) = state {
+            state6.tx_lock_id()
+        } else {
+            panic!("Bob in unexpected state");
+        };
 
         let lock_tx_bitcoin_fee = self
             .bitcoin_wallet


### PR DESCRIPTION
We can do exact assertions for Bob's redeem as well, but have to store Bob's tx_lock id in the respective final state. Make tx_lock available in BtcRedeemed and BtcPunished to have better assertions / harmonize test behaviour.

Storing this information is strictly speaking not needed for the production environment. But it is static information that can be seen as additional information that can be handy for a user. We could potentially extract it inside the tests as well (for redeem without restart would be a bit tricky), but I think this solution is more elegant. 