### PR TITLE
Refactor prod code after test refactoring

### DIFF
--- a/swap/src/lib.rs
+++ b/swap/src/lib.rs
@@ -56,12 +56,6 @@ pub struct SwapAmounts {
     pub xmr: monero::Amount,
 }
 
-#[derive(Debug, Clone)]
-pub struct StartingBalances {
-    pub xmr: monero::Amount,
-    pub btc: bitcoin::Amount,
-}
-
 // TODO: Display in XMR and BTC (not picos and sats).
 impl Display for SwapAmounts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/swap/src/lib.rs
+++ b/swap/src/lib.rs
@@ -56,6 +56,12 @@ pub struct SwapAmounts {
     pub xmr: monero::Amount,
 }
 
+#[derive(Debug, Clone)]
+pub struct StartingBalances {
+    pub xmr: monero::Amount,
+    pub btc: bitcoin::Amount,
+}
+
 // TODO: Display in XMR and BTC (not picos and sats).
 impl Display for SwapAmounts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -292,13 +292,16 @@ async fn alice_swap(
     db: Database,
     seed: Seed,
 ) -> Result<AliceState> {
-    let alice_behaviour = alice::Behaviour::new(network::Seed::new(seed));
-    let alice_peer_id = alice_behaviour.peer_id();
-    info!("Own Peer-ID: {}", alice_peer_id);
-    let alice_transport = build(alice_behaviour.identity())?;
+    let identity = network::Seed::new(seed).derive_libp2p_identity();
+
+    let peer_id = identity.public().into_peer_id();
+
+    let alice_behaviour = alice::Behaviour::default();
+    info!("Own Peer-ID: {}", peer_id);
+    let alice_transport = build(identity)?;
 
     let (mut event_loop, handle) =
-        alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen_addr)?;
+        alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen_addr, peer_id)?;
 
     let swap = alice::Swap {
         state,

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -23,7 +23,7 @@ use swap::{
     config::Config,
     database::Database,
     monero,
-    protocol::{alice, bob, bob::BobSwapFactory},
+    protocol::{alice, bob, bob::SwapFactory},
     trace::init_tracing,
     StartingBalances, SwapAmounts,
 };
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
                 send_monero, receive_bitcoin, swap_id
             );
 
-            let alice_factory = alice::AliceSwapFactory::new(
+            let alice_factory = alice::SwapFactory::new(
                 seed,
                 config,
                 swap_id,
@@ -127,7 +127,7 @@ async fn main() -> Result<()> {
                 send_bitcoin, receive_monero, swap_id
             );
 
-            let bob_factory = BobSwapFactory::new(
+            let bob_factory = SwapFactory::new(
                 seed,
                 db_path,
                 swap_id,
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let alice_factory = alice::AliceSwapFactory::new(
+            let alice_factory = alice::SwapFactory::new(
                 seed,
                 config,
                 swap_id,
@@ -204,7 +204,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let bob_factory = BobSwapFactory::new(
+            let bob_factory = SwapFactory::new(
                 seed,
                 db_path,
                 swap_id,

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -26,10 +26,10 @@ use swap::{
     database::{Database, Swap},
     monero, network,
     network::transport::build,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
+    protocol::{alice, bob, bob::BobState},
     seed::Seed,
     trace::init_tracing,
-    SwapAmounts,
+    StartingBalances, SwapAmounts,
 };
 use tracing::{info, log::LevelFilter};
 use uuid::Uuid;
@@ -51,8 +51,9 @@ async fn main() -> Result<()> {
         opt.data_dir
     );
     let data_dir = std::path::Path::new(opt.data_dir.as_str()).to_path_buf();
-    let db =
-        Database::open(data_dir.join("database").as_path()).context("Could not open database")?;
+    let db_path = data_dir.join("database");
+
+    let db = Database::open(db_path.as_path()).context("Could not open database")?;
 
     let seed = swap::config::seed::Seed::from_file_or_generate(&data_dir)
         .expect("Could not retrieve/initialize seed")
@@ -67,7 +68,12 @@ async fn main() -> Result<()> {
             send_monero,
             receive_bitcoin,
         } => {
-            let (bitcoin_wallet, monero_wallet) = setup_wallets(
+            let swap_amounts = SwapAmounts {
+                xmr: send_monero,
+                btc: receive_bitcoin,
+            };
+
+            let (bitcoin_wallet, monero_wallet, starting_balances) = setup_wallets(
                 bitcoind_url,
                 bitcoin_wallet_name.as_str(),
                 monero_wallet_rpc_url,
@@ -75,50 +81,23 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let amounts = SwapAmounts {
-                btc: receive_bitcoin,
-                xmr: send_monero,
-            };
-
-            let alice_state = {
-                let rng = &mut OsRng;
-                let a = bitcoin::SecretKey::new_random(rng);
-                let s_a = cross_curve_dleq::Scalar::random(rng);
-                let v_a = monero::PrivateViewKey::new_random(rng);
-                let redeem_address = bitcoin_wallet.as_ref().new_address().await?;
-                let punish_address = redeem_address.clone();
-                let state0 = alice::state::State0::new(
-                    a,
-                    s_a,
-                    v_a,
-                    amounts.btc,
-                    amounts.xmr,
-                    config.bitcoin_cancel_timelock,
-                    config.bitcoin_punish_timelock,
-                    redeem_address,
-                    punish_address,
-                );
-
-                AliceState::Started { amounts, state0 }
-            };
-
             let swap_id = Uuid::new_v4();
-            info!(
-                "Swap sending {} and receiving {} started with ID {}",
-                send_monero, receive_bitcoin, swap_id
-            );
 
-            alice_swap(
+            let alice_factory = alice::AliceSwapFactory::new(
+                seed,
+                config,
                 swap_id,
-                alice_state,
-                listen_addr,
                 bitcoin_wallet,
                 monero_wallet,
-                config,
-                db,
-                seed,
+                starting_balances,
+                db_path,
+                listen_addr,
             )
-            .await?;
+            .await;
+            let (swap, mut event_loop) = alice_factory.new_swap_as_alice(swap_amounts).await?;
+
+            tokio::spawn(async move { event_loop.run().await });
+            alice::run(swap).await?;
         }
         Command::BuyXmr {
             alice_peer_id,
@@ -129,7 +108,7 @@ async fn main() -> Result<()> {
             send_bitcoin,
             receive_monero,
         } => {
-            let (bitcoin_wallet, monero_wallet) = setup_wallets(
+            let (bitcoin_wallet, monero_wallet, _) = setup_wallets(
                 bitcoind_url,
                 bitcoin_wallet_name.as_str(),
                 monero_wallet_rpc_url,
@@ -192,30 +171,29 @@ async fn main() -> Result<()> {
             monero_wallet_rpc_url,
             listen_addr,
         }) => {
-            let db_state = if let Swap::Alice(db_state) = db.get_state(swap_id)? {
-                db_state
-            } else {
-                bail!("Swap {} is not sell xmr.", swap_id)
-            };
-
-            let (bitcoin_wallet, monero_wallet) = setup_wallets(
+            let (bitcoin_wallet, monero_wallet, starting_balances) = setup_wallets(
                 bitcoind_url,
                 bitcoin_wallet_name.as_str(),
                 monero_wallet_rpc_url,
                 config,
             )
             .await?;
-            alice_swap(
+
+            let alice_factory = alice::AliceSwapFactory::new(
+                seed,
+                config,
                 swap_id,
-                db_state.into(),
-                listen_addr,
                 bitcoin_wallet,
                 monero_wallet,
-                config,
-                db,
-                seed,
+                starting_balances,
+                db_path,
+                listen_addr,
             )
-            .await?;
+            .await;
+            let (swap, mut event_loop) = alice_factory.recover_alice_from_db().await?;
+
+            tokio::spawn(async move { event_loop.run().await });
+            alice::run(swap).await?;
         }
         Command::Resume(Resume::BuyXmr {
             swap_id,
@@ -231,7 +209,7 @@ async fn main() -> Result<()> {
                 bail!("Swap {} is not buy xmr.", swap_id)
             };
 
-            let (bitcoin_wallet, monero_wallet) = setup_wallets(
+            let (bitcoin_wallet, monero_wallet, _) = setup_wallets(
                 bitcoind_url,
                 bitcoin_wallet_name.as_str(),
                 monero_wallet_rpc_url,
@@ -260,7 +238,11 @@ async fn setup_wallets(
     bitcoin_wallet_name: &str,
     monero_wallet_rpc_url: url::Url,
     config: Config,
-) -> Result<(Arc<swap::bitcoin::Wallet>, Arc<swap::monero::Wallet>)> {
+) -> Result<(
+    Arc<swap::bitcoin::Wallet>,
+    Arc<swap::monero::Wallet>,
+    StartingBalances,
+)> {
     let bitcoin_wallet =
         swap::bitcoin::Wallet::new(bitcoin_wallet_name, bitcoind_url, config.bitcoin_network)
             .await?;
@@ -279,44 +261,12 @@ async fn setup_wallets(
     );
     let monero_wallet = Arc::new(monero_wallet);
 
-    Ok((bitcoin_wallet, monero_wallet))
-}
-#[allow(clippy::too_many_arguments)]
-async fn alice_swap(
-    swap_id: Uuid,
-    state: AliceState,
-    listen_addr: Multiaddr,
-    bitcoin_wallet: Arc<swap::bitcoin::Wallet>,
-    monero_wallet: Arc<swap::monero::Wallet>,
-    config: Config,
-    db: Database,
-    seed: Seed,
-) -> Result<AliceState> {
-    let identity = network::Seed::new(seed).derive_libp2p_identity();
-
-    let peer_id = identity.public().into_peer_id();
-
-    let alice_behaviour = alice::Behaviour::default();
-    info!("Own Peer-ID: {}", peer_id);
-    let alice_transport = build(identity)?;
-
-    let (mut event_loop, handle) =
-        alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen_addr, peer_id)?;
-
-    let swap = alice::Swap {
-        state,
-        event_loop_handle: handle,
-        bitcoin_wallet,
-        monero_wallet,
-        config,
-        swap_id,
-        db,
+    let starting_balances = StartingBalances {
+        btc: bitcoin_balance,
+        xmr: monero_balance,
     };
 
-    let swap = alice::swap::run(swap);
-
-    tokio::spawn(async move { event_loop.run().await });
-    swap.await
+    Ok((bitcoin_wallet, monero_wallet, starting_balances))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -300,15 +300,17 @@ async fn alice_swap(
     let (mut event_loop, handle) =
         alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen_addr)?;
 
-    let swap = alice::swap::swap(
+    let swap = alice::Swap {
         state,
-        handle,
-        bitcoin_wallet.clone(),
-        monero_wallet.clone(),
+        event_loop_handle: handle,
+        bitcoin_wallet,
+        monero_wallet,
         config,
         swap_id,
         db,
-    );
+    };
+
+    let swap = alice::swap::run(swap);
 
     tokio::spawn(async move { event_loop.run().await });
     swap.await
@@ -331,15 +333,16 @@ async fn bob_swap(
     let (event_loop, handle) =
         bob::event_loop::EventLoop::new(bob_transport, bob_behaviour, alice_peer_id, alice_addr)?;
 
-    let swap = bob::swap::swap(
+    let swap = bob::Swap {
         state,
-        handle,
+        event_loop_handle: handle,
         db,
-        bitcoin_wallet.clone(),
-        monero_wallet.clone(),
-        OsRng,
+        bitcoin_wallet,
+        monero_wallet,
         swap_id,
-    );
+    };
+
+    let swap = bob::swap::run(swap);
 
     tokio::spawn(event_loop.run());
     swap.await

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
             let swap_id = Uuid::new_v4();
 
             info!(
-                "Swap sending {} and receiving {} starting with ID {}",
+                "Swap sending {} and receiving {} started with ID {}",
                 send_monero, receive_bitcoin, swap_id
             );
 
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
             let swap_id = Uuid::new_v4();
 
             info!(
-                "Swap sending {} and receiving {} starting with ID {}",
+                "Swap sending {} and receiving {} started with ID {}",
                 send_bitcoin, receive_monero, swap_id
             );
 

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -23,9 +23,9 @@ use swap::{
     config::Config,
     database::Database,
     monero,
-    protocol::{alice, bob, bob::SwapFactory},
+    protocol::{alice, bob, bob::SwapFactory, StartingBalances},
     trace::init_tracing,
-    StartingBalances, SwapAmounts,
+    SwapAmounts,
 };
 use tracing::{info, log::LevelFilter};
 use uuid::Uuid;

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -330,11 +330,19 @@ async fn bob_swap(
     alice_addr: Multiaddr,
     seed: Seed,
 ) -> Result<BobState> {
-    let bob_behaviour = bob::Behaviour::new(network::Seed::new(seed));
-    let bob_transport = build(bob_behaviour.identity())?;
+    let identity = network::Seed::new(seed).derive_libp2p_identity();
+    let peer_id = identity.public().into_peer_id();
 
-    let (event_loop, handle) =
-        bob::event_loop::EventLoop::new(bob_transport, bob_behaviour, alice_peer_id, alice_addr)?;
+    let bob_behaviour = bob::Behaviour::default();
+    let bob_transport = build(identity)?;
+
+    let (event_loop, handle) = bob::event_loop::EventLoop::new(
+        bob_transport,
+        bob_behaviour,
+        peer_id,
+        alice_peer_id,
+        alice_addr,
+    )?;
 
     let swap = bob::Swap {
         state,

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -1,2 +1,8 @@
 pub mod alice;
 pub mod bob;
+
+#[derive(Debug, Clone)]
+pub struct StartingBalances {
+    pub xmr: crate::monero::Amount,
+    pub btc: bitcoin::Amount,
+}

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -280,7 +280,7 @@ impl From<message3::OutEvent> for OutEvent {
 }
 
 /// A `NetworkBehaviour` that represents an XMR/BTC swap node as Alice.
-#[derive(NetworkBehaviour)]
+#[derive(NetworkBehaviour, Default)]
 #[behaviour(out_event = "OutEvent", event_process = false)]
 #[allow(missing_debug_implementations)]
 pub struct Behaviour {
@@ -316,18 +316,5 @@ impl Behaviour {
     pub fn send_message2(&mut self, channel: ResponseChannel<AliceToBob>, msg: Message2) {
         self.message2.send(channel, msg);
         debug!("Sent Message2");
-    }
-}
-
-impl Default for Behaviour {
-    fn default() -> Self {
-        Self {
-            pt: PeerTracker::default(),
-            amounts: Amounts::default(),
-            message0: message0::Behaviour::default(),
-            message1: message1::Behaviour::default(),
-            message2: message2::Behaviour::default(),
-            message3: message3::Behaviour::default(),
-        }
     }
 }

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -1,6 +1,6 @@
 //! Run an XMR/BTC swap in the role of Alice.
 //! Alice holds XMR and wishes receive BTC.
-use anyhow::Result;
+use anyhow::{bail, Result};
 use libp2p::{request_response::ResponseChannel, NetworkBehaviour, PeerId};
 use tracing::{debug, info};
 
@@ -131,7 +131,10 @@ impl SwapFactory {
         let resume_state = if let database::Swap::Alice(state) = db.get_state(self.swap_id)? {
             state.into()
         } else {
-            unreachable!()
+            bail!(
+                "Trying to load swap with id {} for the wrong direction.",
+                self.swap_id
+            )
         };
 
         let (event_loop, event_loop_handle) = init_alice_event_loop(

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -50,21 +50,21 @@ pub struct Swap {
     pub db: Database,
 }
 
-pub struct AliceSwapFactory {
-    listen_address: Multiaddr,
+pub struct SwapFactory {
+    swap_id: Uuid,
     identity: Keypair,
     peer_id: PeerId,
-
     db_path: PathBuf,
-    swap_id: Uuid,
+    config: Config,
+
+    listen_address: Multiaddr,
 
     pub bitcoin_wallet: Arc<bitcoin::Wallet>,
     pub monero_wallet: Arc<monero::Wallet>,
-    config: Config,
     pub starting_balances: StartingBalances,
 }
 
-impl AliceSwapFactory {
+impl SwapFactory {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         seed: Seed,
@@ -81,14 +81,14 @@ impl AliceSwapFactory {
         let peer_id = PeerId::from(identity.public());
 
         Self {
-            listen_address,
+            swap_id,
             identity,
             peer_id,
             db_path,
-            swap_id,
+            config,
+            listen_address,
             bitcoin_wallet,
             monero_wallet,
-            config,
             starting_balances,
         }
     }

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -12,7 +12,7 @@ use crate::{
         Seed as NetworkSeed,
     },
     protocol::bob,
-    StartingBalances, SwapAmounts,
+    SwapAmounts,
 };
 
 pub use self::{
@@ -24,7 +24,10 @@ pub use self::{
     state::*,
     swap::{run, run_until},
 };
-use crate::{config::Config, database::Database, network::transport::build, seed::Seed};
+use crate::{
+    config::Config, database::Database, network::transport::build, protocol::StartingBalances,
+    seed::Seed,
+};
 use libp2p::{core::Multiaddr, identity::Keypair};
 use rand::rngs::OsRng;
 use std::{path::PathBuf, sync::Arc};

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -9,6 +9,7 @@ use libp2p::{
 use tracing::{debug, info};
 
 use crate::{
+    bitcoin, monero,
     network::{
         peer_tracker::{self, PeerTracker},
         request_response::AliceToBob,
@@ -26,8 +27,11 @@ pub use self::{
     message1::Message1,
     message2::Message2,
     state::*,
-    swap::{run_until, swap},
+    swap::{run, run_until},
 };
+use crate::{config::Config, database::Database};
+use std::sync::Arc;
+use uuid::Uuid;
 
 mod amounts;
 pub mod event_loop;
@@ -38,6 +42,16 @@ mod message3;
 pub mod state;
 mod steps;
 pub mod swap;
+
+pub struct Swap {
+    pub state: AliceState,
+    pub event_loop_handle: EventLoopHandle,
+    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub monero_wallet: Arc<monero::Wallet>,
+    pub config: Config,
+    pub swap_id: Uuid,
+    pub db: Database,
+}
 
 pub type Swarm = libp2p::Swarm<Behaviour>;
 

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -206,8 +206,6 @@ fn init_alice_event_loop(
     EventLoop::new(alice_transport, alice_behaviour, listen, peer_id)
 }
 
-pub type Swarm = libp2p::Swarm<Behaviour>;
-
 #[derive(Debug)]
 pub enum OutEvent {
     ConnectionEstablished(PeerId),

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -1,16 +1,18 @@
 //! Run an XMR/BTC swap in the role of Alice.
 //! Alice holds XMR and wishes receive BTC.
+use anyhow::Result;
 use libp2p::{request_response::ResponseChannel, NetworkBehaviour, PeerId};
 use tracing::{debug, info};
 
 use crate::{
-    bitcoin, monero,
+    bitcoin, database, monero,
     network::{
         peer_tracker::{self, PeerTracker},
         request_response::AliceToBob,
+        Seed as NetworkSeed,
     },
     protocol::bob,
-    SwapAmounts,
+    StartingBalances, SwapAmounts,
 };
 
 pub use self::{
@@ -22,8 +24,10 @@ pub use self::{
     state::*,
     swap::{run, run_until},
 };
-use crate::{config::Config, database::Database};
-use std::sync::Arc;
+use crate::{config::Config, database::Database, network::transport::build, seed::Seed};
+use libp2p::{core::Multiaddr, identity::Keypair};
+use rand::rngs::OsRng;
+use std::{path::PathBuf, sync::Arc};
 use uuid::Uuid;
 
 mod amounts;
@@ -44,6 +48,162 @@ pub struct Swap {
     pub config: Config,
     pub swap_id: Uuid,
     pub db: Database,
+}
+
+pub struct AliceSwapFactory {
+    listen_address: Multiaddr,
+    identity: Keypair,
+    peer_id: PeerId,
+
+    db_path: PathBuf,
+    swap_id: Uuid,
+
+    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub monero_wallet: Arc<monero::Wallet>,
+    config: Config,
+    pub starting_balances: StartingBalances,
+}
+
+impl AliceSwapFactory {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        seed: Seed,
+        config: Config,
+        swap_id: Uuid,
+        bitcoin_wallet: Arc<bitcoin::Wallet>,
+        monero_wallet: Arc<monero::Wallet>,
+        starting_balances: StartingBalances,
+        db_path: PathBuf,
+        listen_address: Multiaddr,
+    ) -> Self {
+        let network_seed = NetworkSeed::new(seed);
+        let identity = network_seed.derive_libp2p_identity();
+        let peer_id = PeerId::from(identity.public());
+
+        Self {
+            listen_address,
+            identity,
+            peer_id,
+            db_path,
+            swap_id,
+            bitcoin_wallet,
+            monero_wallet,
+            config,
+            starting_balances,
+        }
+    }
+
+    pub async fn new_swap_as_alice(&self, swap_amounts: SwapAmounts) -> Result<(Swap, EventLoop)> {
+        let initial_state = init_alice_state(
+            swap_amounts.btc,
+            swap_amounts.xmr,
+            self.bitcoin_wallet.clone(),
+            self.config,
+        )
+        .await?;
+
+        let (event_loop, event_loop_handle) = init_alice_event_loop(
+            self.listen_address.clone(),
+            self.identity.clone(),
+            self.peer_id.clone(),
+        )?;
+
+        let db = Database::open(self.db_path.as_path())?;
+
+        Ok((
+            Swap {
+                event_loop_handle,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                config: self.config,
+                db,
+                state: initial_state,
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        ))
+    }
+
+    pub async fn recover_alice_from_db(&self) -> Result<(Swap, EventLoop)> {
+        // reopen the existing database
+        let db = Database::open(self.db_path.clone().as_path())?;
+
+        let resume_state = if let database::Swap::Alice(state) = db.get_state(self.swap_id)? {
+            state.into()
+        } else {
+            unreachable!()
+        };
+
+        let (event_loop, event_loop_handle) = init_alice_event_loop(
+            self.listen_address.clone(),
+            self.identity.clone(),
+            self.peer_id.clone(),
+        )?;
+
+        Ok((
+            Swap {
+                state: resume_state,
+                event_loop_handle,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                config: self.config,
+                swap_id: self.swap_id,
+                db,
+            },
+            event_loop,
+        ))
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id.clone()
+    }
+
+    pub fn listen_address(&self) -> Multiaddr {
+        self.listen_address.clone()
+    }
+}
+
+async fn init_alice_state(
+    btc_to_swap: bitcoin::Amount,
+    xmr_to_swap: monero::Amount,
+    alice_btc_wallet: Arc<bitcoin::Wallet>,
+    config: Config,
+) -> Result<AliceState> {
+    let rng = &mut OsRng;
+
+    let amounts = SwapAmounts {
+        btc: btc_to_swap,
+        xmr: xmr_to_swap,
+    };
+
+    let a = bitcoin::SecretKey::new_random(rng);
+    let s_a = cross_curve_dleq::Scalar::random(rng);
+    let v_a = monero::PrivateViewKey::new_random(rng);
+    let redeem_address = alice_btc_wallet.as_ref().new_address().await?;
+    let punish_address = redeem_address.clone();
+    let state0 = State0::new(
+        a,
+        s_a,
+        v_a,
+        amounts.btc,
+        amounts.xmr,
+        config.bitcoin_cancel_timelock,
+        config.bitcoin_punish_timelock,
+        redeem_address,
+        punish_address,
+    );
+
+    Ok(AliceState::Started { amounts, state0 })
+}
+
+fn init_alice_event_loop(
+    listen: Multiaddr,
+    identity: Keypair,
+    peer_id: PeerId,
+) -> Result<(EventLoop, EventLoopHandle)> {
+    let alice_behaviour = Behaviour::default();
+    let alice_transport = build(identity)?;
+    EventLoop::new(alice_transport, alice_behaviour, listen, peer_id)
 }
 
 pub type Swarm = libp2p::Swarm<Behaviour>;

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -148,10 +148,9 @@ impl EventLoop {
         transport: SwapTransport,
         behaviour: Behaviour,
         listen: Multiaddr,
+        peer_id: PeerId,
     ) -> Result<(Self, EventLoopHandle)> {
-        let local_peer_id = behaviour.peer_id();
-
-        let mut swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, local_peer_id)
+        let mut swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, peer_id)
             .executor(Box::new(TokioExecutor {
                 handle: tokio::runtime::Handle::current(),
             }))
@@ -248,9 +247,5 @@ impl EventLoop {
                 },
             }
         }
-    }
-
-    pub fn peer_id(&self) -> PeerId {
-        self.swarm.peer_id()
     }
 }

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -360,8 +360,10 @@ pub async fn run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, Swap::Alice(db_state))
                             .await?;
-                        swap(
+
+                        run_until(
                             state,
+                            is_target_state,
                             event_loop_handle,
                             bitcoin_wallet.clone(),
                             monero_wallet,

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -72,7 +72,7 @@ pub async fn run_until(
     swap: alice::Swap,
     is_target_state: fn(&AliceState) -> bool,
 ) -> Result<AliceState> {
-    do_run_until(
+    run_until_internal(
         swap.state,
         is_target_state,
         swap.event_loop_handle,
@@ -88,7 +88,7 @@ pub async fn run_until(
 // State machine driver for swap execution
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]
-async fn do_run_until(
+async fn run_until_internal(
     state: AliceState,
     is_target_state: fn(&AliceState) -> bool,
     mut event_loop_handle: EventLoopHandle,
@@ -116,7 +116,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -159,7 +159,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -200,7 +200,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -238,7 +238,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -276,7 +276,7 @@ async fn do_run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                             .await?;
-                        return do_run_until(
+                        return run_until_internal(
                             state,
                             is_target_state,
                             event_loop_handle,
@@ -304,7 +304,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -331,7 +331,7 @@ async fn do_run_until(
                 let db_state = (&state).into();
                 db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                     .await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -365,7 +365,7 @@ async fn do_run_until(
                         db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                             .await?;
 
-                        do_run_until(
+                        run_until_internal(
                             state,
                             is_target_state,
                             event_loop_handle,
@@ -390,7 +390,7 @@ async fn do_run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                             .await?;
-                        do_run_until(
+                        run_until_internal(
                             state,
                             is_target_state,
                             event_loop_handle,
@@ -445,7 +445,7 @@ async fn do_run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                             .await?;
-                        do_run_until(
+                        run_until_internal(
                             state,
                             is_target_state,
                             event_loop_handle,
@@ -469,7 +469,7 @@ async fn do_run_until(
                         let db_state = (&state).into();
                         db.insert_latest_state(swap_id, database::Swap::Alice(db_state))
                             .await?;
-                        do_run_until(
+                        run_until_internal(
                             state,
                             is_target_state,
                             event_loop_handle,

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -44,8 +44,6 @@ pub struct Swap {
     pub swap_id: Uuid,
 }
 
-pub type Swarm = libp2p::Swarm<Behaviour>;
-
 #[derive(Debug, Clone)]
 pub enum OutEvent {
     ConnectionEstablished(PeerId),

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -1,6 +1,6 @@
 //! Run an XMR/BTC swap in the role of Bob.
 //! Bob holds BTC and wishes receive XMR.
-use anyhow::Result;
+use anyhow::{bail, Result};
 use libp2p::{core::Multiaddr, NetworkBehaviour, PeerId};
 use tracing::{debug, info};
 
@@ -133,7 +133,10 @@ impl SwapFactory {
         let resume_state = if let database::Swap::Bob(state) = db.get_state(self.swap_id)? {
             state.into()
         } else {
-            unreachable!()
+            bail!(
+                "Trying to load swap with id {} for the wrong direction.",
+                self.swap_id
+            )
         };
 
         let (event_loop, event_loop_handle) = init_bob_event_loop(

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -10,7 +10,7 @@ use crate::{
     database, monero, network,
     network::peer_tracker::{self, PeerTracker},
     protocol::{alice, bob},
-    StartingBalances, SwapAmounts,
+    SwapAmounts,
 };
 
 pub use self::{
@@ -23,7 +23,10 @@ pub use self::{
     state::*,
     swap::{run, run_until},
 };
-use crate::{config::Config, database::Database, network::transport::build, seed::Seed};
+use crate::{
+    config::Config, database::Database, network::transport::build, protocol::StartingBalances,
+    seed::Seed,
+};
 use libp2p::identity::Keypair;
 use rand::rngs::OsRng;
 use std::{path::PathBuf, sync::Arc};

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -8,7 +8,9 @@ use libp2p::{
 use tracing::{debug, info};
 
 use crate::{
+    bitcoin,
     bitcoin::EncryptedSignature,
+    monero,
     network::{
         peer_tracker::{self, PeerTracker},
         transport::SwapTransport,
@@ -26,8 +28,11 @@ pub use self::{
     message2::Message2,
     message3::Message3,
     state::*,
-    swap::{run_until, swap},
+    swap::{run, run_until},
 };
+use crate::database::Database;
+use std::sync::Arc;
+use uuid::Uuid;
 
 mod amounts;
 pub mod event_loop;
@@ -37,6 +42,15 @@ mod message2;
 mod message3;
 pub mod state;
 pub mod swap;
+
+pub struct Swap {
+    pub state: BobState,
+    pub event_loop_handle: bob::EventLoopHandle,
+    pub db: Database,
+    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub monero_wallet: Arc<monero::Wallet>,
+    pub swap_id: Uuid,
+}
 
 pub type Swarm = libp2p::Swarm<Behaviour>;
 

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -47,23 +47,22 @@ pub struct Swap {
     pub swap_id: Uuid,
 }
 
-pub struct BobSwapFactory {
+pub struct SwapFactory {
+    swap_id: Uuid,
     identity: Keypair,
     peer_id: PeerId,
-
     db_path: PathBuf,
-    swap_id: Uuid,
-
-    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
-    pub monero_wallet: Arc<monero::Wallet>,
     config: Config,
-    pub starting_balances: StartingBalances,
 
     alice_connect_address: Multiaddr,
     alice_connect_peer_id: PeerId,
+
+    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub monero_wallet: Arc<monero::Wallet>,
+    pub starting_balances: StartingBalances,
 }
 
-impl BobSwapFactory {
+impl SwapFactory {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         seed: Seed,
@@ -80,16 +79,16 @@ impl BobSwapFactory {
         let peer_id = identity.public().into_peer_id();
 
         Self {
+            swap_id,
             identity,
             peer_id,
             db_path,
-            swap_id,
-            bitcoin_wallet,
-            monero_wallet,
             config,
-            starting_balances,
             alice_connect_address,
             alice_connect_peer_id,
+            bitcoin_wallet,
+            monero_wallet,
+            starting_balances,
         }
     }
 

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -1,15 +1,16 @@
 //! Run an XMR/BTC swap in the role of Bob.
 //! Bob holds BTC and wishes receive XMR.
+use anyhow::Result;
 use libp2p::{core::Multiaddr, NetworkBehaviour, PeerId};
 use tracing::{debug, info};
 
 use crate::{
     bitcoin,
     bitcoin::EncryptedSignature,
-    monero,
+    database, monero, network,
     network::peer_tracker::{self, PeerTracker},
     protocol::{alice, bob},
-    SwapAmounts,
+    StartingBalances, SwapAmounts,
 };
 
 pub use self::{
@@ -22,8 +23,10 @@ pub use self::{
     state::*,
     swap::{run, run_until},
 };
-use crate::database::Database;
-use std::sync::Arc;
+use crate::{config::Config, database::Database, network::transport::build, seed::Seed};
+use libp2p::identity::Keypair;
+use rand::rngs::OsRng;
+use std::{path::PathBuf, sync::Arc};
 use uuid::Uuid;
 
 mod amounts;
@@ -42,6 +45,160 @@ pub struct Swap {
     pub bitcoin_wallet: Arc<bitcoin::Wallet>,
     pub monero_wallet: Arc<monero::Wallet>,
     pub swap_id: Uuid,
+}
+
+pub struct BobSwapFactory {
+    identity: Keypair,
+    peer_id: PeerId,
+
+    db_path: PathBuf,
+    swap_id: Uuid,
+
+    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub monero_wallet: Arc<monero::Wallet>,
+    config: Config,
+    pub starting_balances: StartingBalances,
+
+    alice_connect_address: Multiaddr,
+    alice_connect_peer_id: PeerId,
+}
+
+impl BobSwapFactory {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        seed: Seed,
+        db_path: PathBuf,
+        swap_id: Uuid,
+        bitcoin_wallet: Arc<bitcoin::Wallet>,
+        monero_wallet: Arc<monero::Wallet>,
+        config: Config,
+        starting_balances: StartingBalances,
+        alice_connect_address: Multiaddr,
+        alice_connect_peer_id: PeerId,
+    ) -> Self {
+        let identity = network::Seed::new(seed).derive_libp2p_identity();
+        let peer_id = identity.public().into_peer_id();
+
+        Self {
+            identity,
+            peer_id,
+            db_path,
+            swap_id,
+            bitcoin_wallet,
+            monero_wallet,
+            config,
+            starting_balances,
+            alice_connect_address,
+            alice_connect_peer_id,
+        }
+    }
+
+    pub async fn new_swap_as_bob(
+        &self,
+        swap_amounts: SwapAmounts,
+    ) -> Result<(bob::Swap, bob::EventLoop)> {
+        let initial_state = init_bob_state(
+            swap_amounts.btc,
+            swap_amounts.xmr,
+            self.bitcoin_wallet.clone(),
+            self.config,
+        )
+        .await?;
+
+        let (event_loop, event_loop_handle) = init_bob_event_loop(
+            self.identity.clone(),
+            self.peer_id.clone(),
+            self.alice_connect_peer_id.clone(),
+            self.alice_connect_address.clone(),
+        )?;
+
+        let db = Database::open(self.db_path.as_path())?;
+
+        Ok((
+            Swap {
+                state: initial_state,
+                event_loop_handle,
+                db,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        ))
+    }
+
+    pub async fn recover_bob_from_db(&self) -> Result<(bob::Swap, bob::EventLoop)> {
+        // reopen the existing database
+        let db = Database::open(self.db_path.clone().as_path())?;
+
+        let resume_state = if let database::Swap::Bob(state) = db.get_state(self.swap_id)? {
+            state.into()
+        } else {
+            unreachable!()
+        };
+
+        let (event_loop, event_loop_handle) = init_bob_event_loop(
+            self.identity.clone(),
+            self.peer_id.clone(),
+            self.alice_connect_peer_id.clone(),
+            self.alice_connect_address.clone(),
+        )?;
+
+        Ok((
+            Swap {
+                state: resume_state,
+                event_loop_handle,
+                db,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        ))
+    }
+}
+
+async fn init_bob_state(
+    btc_to_swap: bitcoin::Amount,
+    xmr_to_swap: monero::Amount,
+    bob_btc_wallet: Arc<bitcoin::Wallet>,
+    config: Config,
+) -> Result<BobState> {
+    let amounts = SwapAmounts {
+        btc: btc_to_swap,
+        xmr: xmr_to_swap,
+    };
+
+    let refund_address = bob_btc_wallet.new_address().await?;
+    let state0 = bob::State0::new(
+        &mut OsRng,
+        btc_to_swap,
+        xmr_to_swap,
+        config.bitcoin_cancel_timelock,
+        config.bitcoin_punish_timelock,
+        refund_address,
+        config.monero_finality_confirmations,
+    );
+
+    Ok(BobState::Started { state0, amounts })
+}
+
+fn init_bob_event_loop(
+    identity: Keypair,
+    peer_id: PeerId,
+    alice_peer_id: PeerId,
+    alice_addr: Multiaddr,
+) -> Result<(bob::event_loop::EventLoop, bob::event_loop::EventLoopHandle)> {
+    let bob_behaviour = bob::Behaviour::default();
+    let bob_transport = build(identity)?;
+
+    bob::event_loop::EventLoop::new(
+        bob_transport,
+        bob_behaviour,
+        peer_id,
+        alice_peer_id,
+        alice_addr,
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -261,7 +261,7 @@ impl From<message3::OutEvent> for OutEvent {
 }
 
 /// A `NetworkBehaviour` that represents an XMR/BTC swap node as Bob.
-#[derive(NetworkBehaviour)]
+#[derive(NetworkBehaviour, Default)]
 #[behaviour(out_event = "OutEvent", event_process = false)]
 #[allow(missing_debug_implementations)]
 pub struct Behaviour {
@@ -309,18 +309,5 @@ impl Behaviour {
     /// Add a known address for the given peer
     pub fn add_address(&mut self, peer_id: PeerId, address: Multiaddr) {
         self.pt.add_address(peer_id, address)
-    }
-}
-
-impl Default for Behaviour {
-    fn default() -> Behaviour {
-        Self {
-            pt: PeerTracker::default(),
-            amounts: Amounts::default(),
-            message0: message0::Behaviour::default(),
-            message1: message1::Behaviour::default(),
-            message2: message2::Behaviour::default(),
-            message3: message3::Behaviour::default(),
-        }
     }
 }

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -131,12 +131,11 @@ impl EventLoop {
     pub fn new(
         transport: SwapTransport,
         behaviour: Behaviour,
+        peer_id: PeerId,
         alice_peer_id: PeerId,
         alice_addr: Multiaddr,
     ) -> Result<(Self, EventLoopHandle)> {
-        let local_peer_id = behaviour.peer_id();
-
-        let mut swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, local_peer_id)
+        let mut swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, peer_id)
             .executor(Box::new(TokioExecutor {
                 handle: tokio::runtime::Handle::current(),
             }))

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use async_recursion::async_recursion;
-use rand::{CryptoRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 use std::sync::Arc;
 use tokio::select;
 use tracing::{debug, info};
@@ -13,7 +13,6 @@ use crate::{
     protocol::bob::{self, event_loop::EventLoopHandle, state::*},
     ExpiredTimelocks, SwapAmounts,
 };
-use ecdsa_fun::fun::rand_core::OsRng;
 
 pub fn is_complete(state: &BobState) -> bool {
     matches!(

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -46,7 +46,7 @@ pub async fn run_until(
     swap: bob::Swap,
     is_target_state: fn(&BobState) -> bool,
 ) -> Result<BobState> {
-    do_run_until(
+    run_until_internal(
         swap.state,
         is_target_state,
         swap.event_loop_handle,
@@ -62,7 +62,7 @@ pub async fn run_until(
 // State machine driver for swap execution
 #[allow(clippy::too_many_arguments)]
 #[async_recursion]
-async fn do_run_until<R>(
+async fn run_until_internal<R>(
     state: BobState,
     is_target_state: fn(&BobState) -> bool,
     mut event_loop_handle: EventLoopHandle,
@@ -95,7 +95,7 @@ where
                 let state = BobState::Negotiated(state2);
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -116,7 +116,7 @@ where
                 let state = BobState::BtcLocked(state3);
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -181,7 +181,7 @@ where
                 };
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -222,7 +222,7 @@ where
                 };
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -257,7 +257,7 @@ where
 
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -278,7 +278,7 @@ where
                 };
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -303,7 +303,7 @@ where
                 db.insert_latest_state(swap_id, Swap::Bob(state.clone().into()))
                     .await?;
 
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,
@@ -332,7 +332,7 @@ where
 
                 let db_state = state.clone().into();
                 db.insert_latest_state(swap_id, Swap::Bob(db_state)).await?;
-                do_run_until(
+                run_until_internal(
                     state,
                     is_target_state,
                     event_loop_handle,

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -7,17 +7,17 @@ pub mod testutils;
 
 #[tokio::test]
 async fn happy_path() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
 
         let bob = bob::run(bob_swap);
         let (alice_state, bob_state) = join!(alice, bob);
 
-        test.assert_alice_redeemed(alice_state.unwrap()).await;
-        test.assert_bob_redeemed(bob_state.unwrap()).await;
+        ctx.assert_alice_redeemed(alice_state.unwrap()).await;
+        ctx.assert_bob_redeemed(bob_state.unwrap()).await;
     })
     .await;
 }

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -7,7 +7,7 @@ pub mod testutils;
 
 #[tokio::test]
 async fn happy_path() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -4,7 +4,7 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -4,9 +4,9 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let bob = bob::run(bob_swap);
         let bob_handle = tokio::spawn(bob);
@@ -16,15 +16,15 @@ async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
             .unwrap();
         assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
 
-        let alice_swap = test.recover_alice_from_db().await;
+        let alice_swap = ctx.recover_alice_from_db().await;
         assert!(matches!(alice_swap.state, AliceState::EncSigLearned {..}));
 
         let alice_state = alice::run(alice_swap).await.unwrap();
 
-        test.assert_alice_redeemed(alice_state).await;
+        ctx.assert_alice_redeemed(alice_state).await;
 
         let bob_state = bob_handle.await.unwrap();
-        test.assert_bob_redeemed(bob_state.unwrap()).await
+        ctx.assert_bob_redeemed(bob_state.unwrap()).await
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,58 +1,30 @@
-use rand::rngs::OsRng;
 use swap::protocol::{alice, alice::AliceState, bob};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {
-    testutils::test(|alice_harness, bob_harness| async move {
-        let alice = alice_harness.new_alice().await;
-        let bob = bob_harness.new_bob().await;
+    testutils::init(|test| async move {
+        let alice_swap = test.new_swap_as_alice().await;
+        let bob_swap = test.new_swap_as_bob().await;
 
-        let bob_swap = bob::swap(
-            bob.state,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        );
-        let bob_swap_handle = tokio::spawn(bob_swap);
+        let bob = bob::run(bob_swap);
+        let bob_handle = tokio::spawn(bob);
 
-        let alice_state = alice::run_until(
-            alice.state,
-            alice::swap::is_encsig_learned,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        )
-        .await
-        .unwrap();
+        let alice_state = alice::run_until(alice_swap, alice::swap::is_encsig_learned)
+            .await
+            .unwrap();
         assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
 
-        let alice = alice_harness.recover_alice_from_db().await;
-        assert!(matches!(alice.state, AliceState::EncSigLearned {..}));
+        let alice_swap = test.recover_alice_from_db().await;
+        assert!(matches!(alice_swap.state, AliceState::EncSigLearned {..}));
 
-        let alice_state = alice::swap(
-            alice.state,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        )
-        .await
-        .unwrap();
+        let alice_state = alice::run(alice_swap).await.unwrap();
 
-        alice_harness.assert_redeemed(alice_state).await;
+        test.assert_alice_redeemed(alice_state).await;
 
-        let bob_state = bob_swap_handle.await.unwrap();
-        bob_harness.assert_redeemed(bob_state.unwrap()).await
+        let bob_state = bob_handle.await.unwrap();
+        test.assert_bob_redeemed(bob_state.unwrap()).await
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -4,9 +4,9 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
         let alice_handle = tokio::spawn(alice);
@@ -17,15 +17,15 @@ async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
 
         assert!(matches!(bob_state, BobState::EncSigSent {..}));
 
-        let bob_swap = test.recover_bob_from_db().await;
+        let bob_swap = ctx.recover_bob_from_db().await;
         assert!(matches!(bob_swap.state, BobState::EncSigSent {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();
 
-        test.assert_bob_redeemed(bob_state).await;
+        ctx.assert_bob_redeemed(bob_state).await;
 
         let alice_state = alice_handle.await.unwrap();
-        test.assert_alice_redeemed(alice_state.unwrap()).await;
+        ctx.assert_alice_redeemed(alice_state.unwrap()).await;
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -4,7 +4,7 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -1,59 +1,31 @@
-use rand::rngs::OsRng;
 use swap::protocol::{alice, bob, bob::BobState};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {
-    testutils::test(|alice_harness, bob_harness| async move {
-        let alice = alice_harness.new_alice().await;
-        let bob = bob_harness.new_bob().await;
+    testutils::init(|test| async move {
+        let alice_swap = test.new_swap_as_alice().await;
+        let bob_swap = test.new_swap_as_bob().await;
 
-        let alice_swap = alice::swap(
-            alice.state,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        );
-        let alice_swap_handle = tokio::spawn(alice_swap);
+        let alice = alice::run(alice_swap);
+        let alice_handle = tokio::spawn(alice);
 
-        let bob_state = bob::run_until(
-            bob.state,
-            bob::swap::is_encsig_sent,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run_until(bob_swap, bob::swap::is_encsig_sent)
+            .await
+            .unwrap();
 
         assert!(matches!(bob_state, BobState::EncSigSent {..}));
 
-        let bob = bob_harness.recover_bob_from_db().await;
-        assert!(matches!(bob.state, BobState::EncSigSent {..}));
+        let bob_swap = test.recover_bob_from_db().await;
+        assert!(matches!(bob_swap.state, BobState::EncSigSent {..}));
 
-        let bob_state = bob::swap(
-            bob.state,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run(bob_swap).await.unwrap();
 
-        bob_harness.assert_redeemed(bob_state).await;
+        test.assert_bob_redeemed(bob_state).await;
 
-        let alice_state = alice_swap_handle.await.unwrap();
-        alice_harness.assert_redeemed(alice_state.unwrap()).await;
+        let alice_state = alice_handle.await.unwrap();
+        test.assert_alice_redeemed(alice_state.unwrap()).await;
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -7,9 +7,9 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let alice_handle = alice::run(alice_swap);
         let alice_swap_handle = tokio::spawn(alice_handle);
@@ -18,15 +18,15 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked {..}));
 
-        let bob_swap = test.recover_bob_from_db().await;
+        let bob_swap = ctx.recover_bob_from_db().await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();
 
-        test.assert_bob_redeemed(bob_state).await;
+        ctx.assert_bob_redeemed(bob_state).await;
 
         let alice_state = alice_swap_handle.await.unwrap();
-        test.assert_alice_redeemed(alice_state.unwrap()).await;
+        ctx.assert_alice_redeemed(alice_state.unwrap()).await;
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -7,7 +7,7 @@ pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,59 +1,32 @@
-use rand::rngs::OsRng;
-use swap::protocol::{alice, bob, bob::BobState};
+use swap::protocol::{
+    alice, bob,
+    bob::{swap::is_xmr_locked, BobState},
+};
 
 pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
-    testutils::test(|alice_harness, bob_harness| async move {
-        let alice = alice_harness.new_alice().await;
-        let bob = bob_harness.new_bob().await;
+    testutils::init(|test| async move {
+        let alice_swap = test.new_swap_as_alice().await;
+        let bob_swap = test.new_swap_as_bob().await;
 
-        let alice_swap = alice::swap(
-            alice.state,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        );
-        let alice_swap_handle = tokio::spawn(alice_swap);
+        let alice_handle = alice::run(alice_swap);
+        let alice_swap_handle = tokio::spawn(alice_handle);
 
-        let bob_state = bob::run_until(
-            bob.state,
-            bob::swap::is_xmr_locked,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run_until(bob_swap, is_xmr_locked).await.unwrap();
 
         assert!(matches!(bob_state, BobState::XmrLocked {..}));
 
-        let bob = bob_harness.recover_bob_from_db().await;
-        assert!(matches!(bob.state, BobState::XmrLocked {..}));
+        let bob_swap = test.recover_bob_from_db().await;
+        assert!(matches!(bob_swap.state, BobState::XmrLocked {..}));
 
-        let bob_state = bob::swap(
-            bob.state,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run(bob_swap).await.unwrap();
 
-        bob_harness.assert_redeemed(bob_state).await;
+        test.assert_bob_redeemed(bob_state).await;
 
         let alice_state = alice_swap_handle.await.unwrap();
-        alice_harness.assert_redeemed(alice_state.unwrap()).await;
+        test.assert_alice_redeemed(alice_state.unwrap()).await;
     })
     .await;
 }

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -9,9 +9,9 @@ pub mod testutils;
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let alice = alice::run(alice_swap);
         let alice_handle = tokio::spawn(alice);
@@ -21,16 +21,16 @@ async fn alice_punishes_if_bob_never_acts_after_fund() {
         assert!(matches!(bob_state, BobState::BtcLocked {..}));
 
         let alice_state = alice_handle.await.unwrap();
-        test.assert_alice_punished(alice_state.unwrap()).await;
+        ctx.assert_alice_punished(alice_state.unwrap()).await;
 
         // Restart Bob after Alice punished to ensure Bob transitions to
         // punished and does not run indefinitely
-        let bob_swap = test.recover_bob_from_db().await;
+        let bob_swap = ctx.recover_bob_from_db().await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked {..}));
 
         let bob_state = bob::run(bob_swap).await.unwrap();
 
-        test.assert_bob_punished(bob_state).await;
+        ctx.assert_bob_punished(bob_state).await;
     })
     .await;
 }

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -9,7 +9,7 @@ pub mod testutils;
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,5 +1,7 @@
-use rand::rngs::OsRng;
-use swap::protocol::{alice, bob, bob::BobState};
+use swap::protocol::{
+    alice, bob,
+    bob::{swap::is_btc_locked, BobState},
+};
 
 pub mod testutils;
 
@@ -7,57 +9,28 @@ pub mod testutils;
 /// the encsig and fail to refund or redeem. Alice punishes.
 #[tokio::test]
 async fn alice_punishes_if_bob_never_acts_after_fund() {
-    testutils::test(|alice_harness, bob_harness| async move {
-        let alice = alice_harness.new_alice().await;
-        let bob = bob_harness.new_bob().await;
+    testutils::init(|test| async move {
+        let alice_swap = test.new_swap_as_alice().await;
+        let bob_swap = test.new_swap_as_bob().await;
 
-        let alice_swap = alice::swap(
-            alice.state,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        );
-        let alice_swap_handle = tokio::spawn(alice_swap);
+        let alice = alice::run(alice_swap);
+        let alice_handle = tokio::spawn(alice);
 
-        let bob_state = bob::run_until(
-            bob.state,
-            bob::swap::is_btc_locked,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run_until(bob_swap, is_btc_locked).await.unwrap();
 
         assert!(matches!(bob_state, BobState::BtcLocked {..}));
 
-        let alice_state = alice_swap_handle.await.unwrap();
-        alice_harness.assert_punished(alice_state.unwrap()).await;
+        let alice_state = alice_handle.await.unwrap();
+        test.assert_alice_punished(alice_state.unwrap()).await;
 
         // Restart Bob after Alice punished to ensure Bob transitions to
         // punished and does not run indefinitely
-        let bob = bob_harness.recover_bob_from_db().await;
-        assert!(matches!(bob.state, BobState::BtcLocked {..}));
+        let bob_swap = test.recover_bob_from_db().await;
+        assert!(matches!(bob_swap.state, BobState::BtcLocked {..}));
 
-        let bob_state = bob::swap(
-            bob.state,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        )
-        .await
-        .unwrap();
+        let bob_state = bob::run(bob_swap).await.unwrap();
 
-        bob_harness.assert_punished(bob_state).await;
+        test.assert_bob_punished(bob_state).await;
     })
     .await;
 }

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -6,7 +6,7 @@ pub mod testutils;
 /// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
-    testutils::init(|test| async move {
+    testutils::setup_test(|test| async move {
         let alice_swap = test.new_swap_as_alice().await;
         let bob_swap = test.new_swap_as_bob().await;
 

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,4 +1,3 @@
-use rand::rngs::OsRng;
 use swap::protocol::{alice, alice::AliceState, bob};
 
 pub mod testutils;
@@ -7,60 +6,33 @@ pub mod testutils;
 /// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
-    testutils::test(|alice_harness, bob_harness| async move {
-        let alice = alice_harness.new_alice().await;
-        let bob = bob_harness.new_bob().await;
+    testutils::init(|test| async move {
+        let alice_swap = test.new_swap_as_alice().await;
+        let bob_swap = test.new_swap_as_bob().await;
 
-        let bob_swap = bob::swap(
-            bob.state,
-            bob.event_loop_handle,
-            bob.db,
-            bob.bitcoin_wallet.clone(),
-            bob.monero_wallet.clone(),
-            OsRng,
-            bob.swap_id,
-        );
-        let bob_swap_handle = tokio::spawn(bob_swap);
+        let bob = bob::run(bob_swap);
+        let bob_handle = tokio::spawn(bob);
 
-        let alice_state = alice::run_until(
-            alice.state,
-            alice::swap::is_xmr_locked,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        )
-        .await
-        .unwrap();
+        let alice_state = alice::run_until(alice_swap, alice::swap::is_xmr_locked)
+            .await
+            .unwrap();
         assert!(matches!(alice_state, AliceState::XmrLocked {..}));
 
         // Alice does not act, Bob refunds
-        let bob_state = bob_swap_handle.await.unwrap();
+        let bob_state = bob_handle.await.unwrap();
 
         // Once bob has finished Alice is restarted and refunds as well
-        let alice = alice_harness.recover_alice_from_db().await;
-        assert!(matches!(alice.state, AliceState::XmrLocked {..}));
+        let alice_swap = test.recover_alice_from_db().await;
+        assert!(matches!(alice_swap.state, AliceState::XmrLocked {..}));
 
-        let alice_state = alice::swap(
-            alice.state,
-            alice.event_loop_handle,
-            alice.bitcoin_wallet.clone(),
-            alice.monero_wallet.clone(),
-            alice.config,
-            alice.swap_id,
-            alice.db,
-        )
-        .await
-        .unwrap();
+        let alice_state = alice::run(alice_swap).await.unwrap();
 
         // TODO: The test passes like this, but the assertion should be done after Bob
         // refunded, not at the end because this can cause side-effects!
         //  We have to properly wait for the refund tx's finality inside the assertion,
         // which requires storing the refund_tx_id in the the state!
-        bob_harness.assert_refunded(bob_state.unwrap()).await;
-        alice_harness.assert_refunded(alice_state).await;
+        test.assert_bob_refunded(bob_state.unwrap()).await;
+        test.assert_alice_refunded(alice_state).await;
     })
     .await;
 }

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -6,9 +6,9 @@ pub mod testutils;
 /// then also refunds.
 #[tokio::test]
 async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
-    testutils::setup_test(|test| async move {
-        let alice_swap = test.new_swap_as_alice().await;
-        let bob_swap = test.new_swap_as_bob().await;
+    testutils::setup_test(|ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
 
         let bob = bob::run(bob_swap);
         let bob_handle = tokio::spawn(bob);
@@ -22,7 +22,7 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         let bob_state = bob_handle.await.unwrap();
 
         // Once bob has finished Alice is restarted and refunds as well
-        let alice_swap = test.recover_alice_from_db().await;
+        let alice_swap = ctx.recover_alice_from_db().await;
         assert!(matches!(alice_swap.state, AliceState::XmrLocked {..}));
 
         let alice_state = alice::run(alice_swap).await.unwrap();
@@ -31,8 +31,8 @@ async fn given_alice_restarts_after_xmr_is_locked_abort_swap() {
         // refunded, not at the end because this can cause side-effects!
         //  We have to properly wait for the refund tx's finality inside the assertion,
         // which requires storing the refund_tx_id in the the state!
-        test.assert_bob_refunded(bob_state.unwrap()).await;
-        test.assert_alice_refunded(alice_state).await;
+        ctx.assert_bob_refunded(bob_state.unwrap()).await;
+        ctx.assert_alice_refunded(alice_state).await;
     })
     .await;
 }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -9,12 +9,7 @@ use swap::{
     bitcoin,
     config::Config,
     monero,
-    protocol::{
-        alice,
-        alice::{AliceState, AliceSwapFactory},
-        bob,
-        bob::{BobState, BobSwapFactory},
-    },
+    protocol::{alice, alice::AliceState, bob, bob::BobState},
     seed::Seed,
     StartingBalances, SwapAmounts,
 };
@@ -27,8 +22,8 @@ use uuid::Uuid;
 pub struct Test {
     swap_amounts: SwapAmounts,
 
-    alice_swap_factory: AliceSwapFactory,
-    bob_swap_factory: BobSwapFactory,
+    alice_swap_factory: alice::SwapFactory,
+    bob_swap_factory: bob::SwapFactory,
 }
 
 impl Test {
@@ -344,7 +339,7 @@ where
     )
     .await;
 
-    let alice_swap_factory = AliceSwapFactory::new(
+    let alice_swap_factory = alice::SwapFactory::new(
         Seed::random().unwrap(),
         config,
         Uuid::new_v4(),
@@ -370,7 +365,7 @@ where
     )
     .await;
 
-    let bob_swap_factory = BobSwapFactory::new(
+    let bob_swap_factory = bob::SwapFactory::new(
         Seed::random().unwrap(),
         tempdir().unwrap().path().to_path_buf(),
         Uuid::new_v4(),

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -22,9 +22,285 @@ use tracing_core::dispatcher::DefaultGuard;
 use tracing_log::LogTracer;
 use uuid::Uuid;
 
-pub async fn test<T, F>(testfn: T)
+pub struct Test {
+    swap_amounts: SwapAmounts,
+
+    alice_swap_factory: AliceSwapFactory,
+    bob_swap_factory: BobSwapFactory,
+}
+
+impl Test {
+    pub async fn new_swap_as_alice(&self) -> alice::Swap {
+        let (swap, mut event_loop) = self
+            .alice_swap_factory
+            .new_swap_as_alice(self.swap_amounts)
+            .await;
+
+        tokio::spawn(async move { event_loop.run().await });
+
+        swap
+    }
+
+    pub async fn new_swap_as_bob(&self) -> bob::Swap {
+        let (swap, event_loop) = self
+            .bob_swap_factory
+            .new_swap_as_bob(self.swap_amounts)
+            .await;
+
+        tokio::spawn(async move { event_loop.run().await });
+
+        swap
+    }
+
+    pub async fn recover_alice_from_db(&self) -> alice::Swap {
+        let (swap, mut event_loop) = self.alice_swap_factory.recover_alice_from_db().await;
+
+        tokio::spawn(async move { event_loop.run().await });
+
+        swap
+    }
+
+    pub async fn recover_bob_from_db(&self) -> bob::Swap {
+        let (swap, event_loop) = self.bob_swap_factory.recover_bob_from_db().await;
+
+        tokio::spawn(async move { event_loop.run().await });
+
+        swap
+    }
+
+    pub async fn assert_alice_redeemed(&self, state: AliceState) {
+        assert!(matches!(state, AliceState::BtcRedeemed));
+
+        let btc_balance_after_swap = self
+            .alice_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            btc_balance_after_swap,
+            self.alice_swap_factory.starting_balances.btc + self.swap_amounts.btc
+                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+        );
+
+        let xmr_balance_after_swap = self
+            .alice_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert!(
+            xmr_balance_after_swap
+                <= self.alice_swap_factory.starting_balances.xmr - self.swap_amounts.xmr
+        );
+    }
+
+    pub async fn assert_alice_refunded(&self, state: AliceState) {
+        assert!(matches!(state, AliceState::XmrRefunded));
+
+        let btc_balance_after_swap = self
+            .alice_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            btc_balance_after_swap,
+            self.alice_swap_factory.starting_balances.btc
+        );
+
+        // Ensure that Alice's balance is refreshed as we use a newly created wallet
+        self.alice_swap_factory
+            .monero_wallet
+            .as_ref()
+            .inner
+            .refresh()
+            .await
+            .unwrap();
+        let xmr_balance_after_swap = self
+            .alice_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert_eq!(xmr_balance_after_swap, self.swap_amounts.xmr);
+    }
+
+    pub async fn assert_alice_punished(&self, state: AliceState) {
+        assert!(matches!(state, AliceState::BtcPunished));
+
+        let btc_balance_after_swap = self
+            .alice_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            btc_balance_after_swap,
+            self.alice_swap_factory.starting_balances.btc + self.swap_amounts.btc
+                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE)
+        );
+
+        let xmr_balance_after_swap = self
+            .alice_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert!(
+            xmr_balance_after_swap
+                <= self.alice_swap_factory.starting_balances.xmr - self.swap_amounts.xmr
+        );
+    }
+
+    pub async fn assert_bob_redeemed(&self, state: BobState) {
+        let lock_tx_id = if let BobState::XmrRedeemed { tx_lock_id } = state {
+            tx_lock_id
+        } else {
+            panic!("Bob in unexpected state");
+        };
+
+        let lock_tx_bitcoin_fee = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .transaction_fee(lock_tx_id)
+            .await
+            .unwrap();
+
+        let btc_balance_after_swap = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            btc_balance_after_swap,
+            self.bob_swap_factory.starting_balances.btc
+                - self.swap_amounts.btc
+                - lock_tx_bitcoin_fee
+        );
+
+        // Ensure that Bob's balance is refreshed as we use a newly created wallet
+        self.bob_swap_factory
+            .monero_wallet
+            .as_ref()
+            .inner
+            .refresh()
+            .await
+            .unwrap();
+        let xmr_balance_after_swap = self
+            .bob_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            xmr_balance_after_swap,
+            self.bob_swap_factory.starting_balances.xmr + self.swap_amounts.xmr
+        );
+    }
+
+    pub async fn assert_bob_refunded(&self, state: BobState) {
+        let lock_tx_id = if let BobState::BtcRefunded(state4) = state {
+            state4.tx_lock_id()
+        } else {
+            panic!("Bob in unexpected state");
+        };
+        let lock_tx_bitcoin_fee = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .transaction_fee(lock_tx_id)
+            .await
+            .unwrap();
+
+        let btc_balance_after_swap = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+
+        let alice_submitted_cancel = btc_balance_after_swap
+            == self.bob_swap_factory.starting_balances.btc
+                - lock_tx_bitcoin_fee
+                - bitcoin::Amount::from_sat(bitcoin::TX_FEE);
+
+        let bob_submitted_cancel = btc_balance_after_swap
+            == self.bob_swap_factory.starting_balances.btc
+                - lock_tx_bitcoin_fee
+                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE);
+
+        // The cancel tx can be submitted by both Alice and Bob.
+        // Since we cannot be sure who submitted it we have to assert accordingly
+        assert!(alice_submitted_cancel || bob_submitted_cancel);
+
+        let xmr_balance_after_swap = self
+            .bob_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            xmr_balance_after_swap,
+            self.bob_swap_factory.starting_balances.xmr
+        );
+    }
+
+    pub async fn assert_bob_punished(&self, state: BobState) {
+        let lock_tx_id = if let BobState::BtcPunished { tx_lock_id } = state {
+            tx_lock_id
+        } else {
+            panic!("Bob in unexpected state");
+        };
+
+        let lock_tx_bitcoin_fee = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .transaction_fee(lock_tx_id)
+            .await
+            .unwrap();
+
+        let btc_balance_after_swap = self
+            .bob_swap_factory
+            .bitcoin_wallet
+            .as_ref()
+            .balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            btc_balance_after_swap,
+            self.bob_swap_factory.starting_balances.btc
+                - self.swap_amounts.btc
+                - lock_tx_bitcoin_fee
+        );
+
+        let xmr_balance_after_swap = self
+            .bob_swap_factory
+            .monero_wallet
+            .as_ref()
+            .get_balance()
+            .await
+            .unwrap();
+        assert_eq!(
+            xmr_balance_after_swap,
+            self.bob_swap_factory.starting_balances.xmr
+        );
+    }
+}
+
+pub async fn init<T, F>(testfn: T)
 where
-    T: Fn(AliceHarness, BobHarness) -> F,
+    T: Fn(Test) -> F,
     F: Future<Output = ()>,
 {
     let cli = Cli::default();
@@ -44,9 +320,8 @@ where
         xmr: swap_amounts.xmr * 10,
         btc: bitcoin::Amount::ZERO,
     };
-    let alice_harness = AliceHarness::new(
+    let alice_swap_factory = AliceSwapFactory::new(
         config,
-        swap_amounts,
         Uuid::new_v4(),
         &monero,
         &containers.bitcoind,
@@ -59,32 +334,27 @@ where
         btc: swap_amounts.btc * 10,
     };
 
-    let bob_harness = BobHarness::new(
+    let bob_swap_factory = BobSwapFactory::new(
         config,
-        swap_amounts,
         Uuid::new_v4(),
         &monero,
         &containers.bitcoind,
         bob_starting_balances,
-        alice_harness.listen_address(),
-        alice_harness.peer_id(),
+        alice_swap_factory.listen_address(),
+        alice_swap_factory.peer_id(),
     )
     .await;
 
-    testfn(alice_harness, bob_harness).await
+    let test = Test {
+        swap_amounts,
+        alice_swap_factory,
+        bob_swap_factory,
+    };
+
+    testfn(test).await
 }
 
-pub struct Alice {
-    pub state: AliceState,
-    pub event_loop_handle: alice::EventLoopHandle,
-    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
-    pub monero_wallet: Arc<monero::Wallet>,
-    pub config: Config,
-    pub swap_id: Uuid,
-    pub db: Database,
-}
-
-pub struct AliceHarness {
+pub struct AliceSwapFactory {
     listen_address: Multiaddr,
     peer_id: PeerId,
 
@@ -92,17 +362,15 @@ pub struct AliceHarness {
     db_path: PathBuf,
     swap_id: Uuid,
 
-    swap_amounts: SwapAmounts,
     bitcoin_wallet: Arc<bitcoin::Wallet>,
     monero_wallet: Arc<monero::Wallet>,
     config: Config,
     starting_balances: StartingBalances,
 }
 
-impl AliceHarness {
+impl AliceSwapFactory {
     async fn new(
         config: Config,
-        swap_amounts: SwapAmounts,
         swap_id: Uuid,
         monero: &Monero,
         bitcoind: &Bitcoind<'_>,
@@ -132,7 +400,6 @@ impl AliceHarness {
             listen_address,
             peer_id,
             swap_id,
-            swap_amounts,
             bitcoin_wallet,
             monero_wallet,
             config,
@@ -140,39 +407,37 @@ impl AliceHarness {
         }
     }
 
-    pub async fn new_alice(&self) -> Alice {
+    pub async fn new_swap_as_alice(
+        &self,
+        swap_amounts: SwapAmounts,
+    ) -> (alice::Swap, alice::EventLoop) {
         let initial_state = init_alice_state(
-            self.swap_amounts.btc,
-            self.swap_amounts.xmr,
+            swap_amounts.btc,
+            swap_amounts.xmr,
             self.bitcoin_wallet.clone(),
             self.config,
         )
         .await;
 
-        let (mut event_loop, event_loop_handle) =
+        let (event_loop, event_loop_handle) =
             init_alice_event_loop(self.listen_address.clone(), self.seed);
 
-        tokio::spawn(async move { event_loop.run().await });
-
         let db = Database::open(self.db_path.as_path()).unwrap();
-
-        Alice {
-            event_loop_handle,
-            bitcoin_wallet: self.bitcoin_wallet.clone(),
-            monero_wallet: self.monero_wallet.clone(),
-            config: self.config,
-            db,
-            state: initial_state,
-            swap_id: self.swap_id,
-        }
+        (
+            alice::Swap {
+                event_loop_handle,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                config: self.config,
+                db,
+                state: initial_state,
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        )
     }
 
-    pub async fn recover_alice_from_db(&self) -> Alice {
-        // TODO: "simulated restart" issues:
-        //  - create new wallets instead of reusing (hard because of container
-        //    lifetimes)
-        //  - consider aborting the old event loop (currently just keeps running)
-
+    pub async fn recover_alice_from_db(&self) -> (alice::Swap, alice::EventLoop) {
         // reopen the existing database
         let db = Database::open(self.db_path.clone().as_path()).unwrap();
 
@@ -183,60 +448,21 @@ impl AliceHarness {
                 unreachable!()
             };
 
-        let (mut event_loop, event_loop_handle) =
+        let (event_loop, event_loop_handle) =
             init_alice_event_loop(self.listen_address.clone(), self.seed);
 
-        tokio::spawn(async move { event_loop.run().await });
-
-        Alice {
-            state: resume_state,
-            event_loop_handle,
-            bitcoin_wallet: self.bitcoin_wallet.clone(),
-            monero_wallet: self.monero_wallet.clone(),
-            config: self.config,
-            swap_id: self.swap_id,
-            db,
-        }
-    }
-
-    pub async fn assert_redeemed(&self, state: AliceState) {
-        assert!(matches!(state, AliceState::BtcRedeemed));
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert_eq!(
-            btc_balance_after_swap,
-            self.starting_balances.btc + self.swap_amounts.btc
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
-        );
-
-        let xmr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert!(xmr_balance_after_swap <= self.starting_balances.xmr - self.swap_amounts.xmr);
-    }
-
-    pub async fn assert_refunded(&self, state: AliceState) {
-        assert!(matches!(state, AliceState::XmrRefunded));
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert_eq!(btc_balance_after_swap, self.starting_balances.btc);
-
-        // Ensure that Alice's balance is refreshed as we use a newly created wallet
-        self.monero_wallet.as_ref().inner.refresh().await.unwrap();
-        let xmr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert_eq!(xmr_balance_after_swap, self.swap_amounts.xmr);
-    }
-
-    pub async fn assert_punished(&self, state: AliceState) {
-        assert!(matches!(state, AliceState::BtcPunished));
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert_eq!(
-            btc_balance_after_swap,
-            self.starting_balances.btc + self.swap_amounts.btc
-                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE)
-        );
-
-        let xnr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert!(xnr_balance_after_swap <= self.starting_balances.xmr - self.swap_amounts.xmr);
+        (
+            alice::Swap {
+                state: resume_state,
+                event_loop_handle,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                config: self.config,
+                swap_id: self.swap_id,
+                db,
+            },
+            event_loop,
+        )
     }
 
     pub fn peer_id(&self) -> PeerId {
@@ -248,20 +474,10 @@ impl AliceHarness {
     }
 }
 
-pub struct Bob {
-    pub state: BobState,
-    pub event_loop_handle: bob::EventLoopHandle,
-    pub db: Database,
-    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
-    pub monero_wallet: Arc<monero::Wallet>,
-    pub swap_id: Uuid,
-}
-
-pub struct BobHarness {
+pub struct BobSwapFactory {
     db_path: PathBuf,
     swap_id: Uuid,
 
-    swap_amounts: SwapAmounts,
     bitcoin_wallet: Arc<bitcoin::Wallet>,
     monero_wallet: Arc<monero::Wallet>,
     config: Config,
@@ -271,11 +487,10 @@ pub struct BobHarness {
     alice_connect_peer_id: PeerId,
 }
 
-impl BobHarness {
+impl BobSwapFactory {
     #[allow(clippy::too_many_arguments)]
     async fn new(
         config: Config,
-        swap_amounts: SwapAmounts,
         swap_id: Uuid,
         monero: &Monero,
         bitcoind: &Bitcoind<'_>,
@@ -291,7 +506,6 @@ impl BobHarness {
         Self {
             db_path,
             swap_id,
-            swap_amounts,
             bitcoin_wallet,
             monero_wallet,
             config,
@@ -301,10 +515,10 @@ impl BobHarness {
         }
     }
 
-    pub async fn new_bob(&self) -> Bob {
+    pub async fn new_swap_as_bob(&self, swap_amounts: SwapAmounts) -> (bob::Swap, bob::EventLoop) {
         let initial_state = init_bob_state(
-            self.swap_amounts.btc,
-            self.swap_amounts.xmr,
+            swap_amounts.btc,
+            swap_amounts.xmr,
             self.bitcoin_wallet.clone(),
             self.config,
         )
@@ -315,26 +529,22 @@ impl BobHarness {
             self.alice_connect_address.clone(),
         );
 
-        tokio::spawn(async move { event_loop.run().await });
-
         let db = Database::open(self.db_path.as_path()).unwrap();
 
-        Bob {
-            state: initial_state,
-            event_loop_handle,
-            db,
-            bitcoin_wallet: self.bitcoin_wallet.clone(),
-            monero_wallet: self.monero_wallet.clone(),
-            swap_id: self.swap_id,
-        }
+        (
+            bob::Swap {
+                state: initial_state,
+                event_loop_handle,
+                db,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        )
     }
 
-    pub async fn recover_bob_from_db(&self) -> Bob {
-        // TODO: "simulated restart" issues:
-        //  - create new wallets instead of reusing (hard because of container
-        //    lifetimes)
-        //  - consider aborting the old event loop (currently just keeps running)
-
+    pub async fn recover_bob_from_db(&self) -> (bob::Swap, bob::EventLoop) {
         // reopen the existing database
         let db = Database::open(self.db_path.clone().as_path()).unwrap();
 
@@ -350,99 +560,17 @@ impl BobHarness {
             self.alice_connect_address.clone(),
         );
 
-        tokio::spawn(async move { event_loop.run().await });
-
-        Bob {
-            state: resume_state,
-            event_loop_handle,
-            db,
-            bitcoin_wallet: self.bitcoin_wallet.clone(),
-            monero_wallet: self.monero_wallet.clone(),
-            swap_id: self.swap_id,
-        }
-    }
-
-    pub async fn assert_redeemed(&self, state: BobState) {
-        let lock_tx_id = if let BobState::XmrRedeemed { tx_lock_id } = state {
-            tx_lock_id
-        } else {
-            panic!("Bob in unexpected state");
-        };
-
-        let lock_tx_bitcoin_fee = self
-            .bitcoin_wallet
-            .transaction_fee(lock_tx_id)
-            .await
-            .unwrap();
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert_eq!(
-            btc_balance_after_swap,
-            self.starting_balances.btc - self.swap_amounts.btc - lock_tx_bitcoin_fee
-        );
-
-        // Ensure that Bob's balance is refreshed as we use a newly created wallet
-        self.monero_wallet.as_ref().inner.refresh().await.unwrap();
-        let xmr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert_eq!(
-            xmr_balance_after_swap,
-            self.starting_balances.xmr + self.swap_amounts.xmr
-        );
-    }
-
-    pub async fn assert_refunded(&self, state: BobState) {
-        let lock_tx_id = if let BobState::BtcRefunded(state4) = state {
-            state4.tx_lock_id()
-        } else {
-            panic!("Bob in unexpected state");
-        };
-        let lock_tx_bitcoin_fee = self
-            .bitcoin_wallet
-            .transaction_fee(lock_tx_id)
-            .await
-            .unwrap();
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-
-        let alice_submitted_cancel = btc_balance_after_swap
-            == self.starting_balances.btc
-                - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE);
-
-        let bob_submitted_cancel = btc_balance_after_swap
-            == self.starting_balances.btc
-                - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE);
-
-        // The cancel tx can be submitted by both Alice and Bob.
-        // Since we cannot be sure who submitted it we have to assert accordingly
-        assert!(alice_submitted_cancel || bob_submitted_cancel);
-
-        let xmr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert_eq!(xmr_balance_after_swap, self.starting_balances.xmr);
-    }
-
-    pub async fn assert_punished(&self, state: BobState) {
-        let lock_tx_id = if let BobState::BtcPunished { tx_lock_id } = state {
-            tx_lock_id
-        } else {
-            panic!("Bob in unexpected state");
-        };
-
-        let lock_tx_bitcoin_fee = self
-            .bitcoin_wallet
-            .transaction_fee(lock_tx_id)
-            .await
-            .unwrap();
-
-        let btc_balance_after_swap = self.bitcoin_wallet.as_ref().balance().await.unwrap();
-        assert_eq!(
-            btc_balance_after_swap,
-            self.starting_balances.btc - self.swap_amounts.btc - lock_tx_bitcoin_fee
-        );
-
-        let xmr_balance_after_swap = self.monero_wallet.as_ref().get_balance().await.unwrap();
-        assert_eq!(xmr_balance_after_swap, self.starting_balances.xmr);
+        (
+            bob::Swap {
+                state: resume_state,
+                event_loop_handle,
+                db,
+                bitcoin_wallet: self.bitcoin_wallet.clone(),
+                monero_wallet: self.monero_wallet.clone(),
+                swap_id: self.swap_id,
+            },
+            event_loop,
+        )
     }
 }
 

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -666,9 +666,13 @@ fn init_alice_event_loop(
     alice::event_loop::EventLoop,
     alice::event_loop::EventLoopHandle,
 ) {
-    let alice_behaviour = alice::Behaviour::new(network::Seed::new(seed));
-    let alice_transport = build(alice_behaviour.identity()).unwrap();
-    alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen).unwrap()
+    let identity = network::Seed::new(seed).derive_libp2p_identity();
+
+    let peer_id = identity.public().into_peer_id();
+
+    let alice_behaviour = alice::Behaviour::default();
+    let alice_transport = build(identity).unwrap();
+    alice::event_loop::EventLoop::new(alice_transport, alice_behaviour, listen, peer_id).unwrap()
 }
 
 async fn init_bob_state(

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -19,14 +19,14 @@ use tracing_core::dispatcher::DefaultGuard;
 use tracing_log::LogTracer;
 use uuid::Uuid;
 
-pub struct Test {
+pub struct TestContext {
     swap_amounts: SwapAmounts,
 
     alice_swap_factory: alice::SwapFactory,
     bob_swap_factory: bob::SwapFactory,
 }
 
-impl Test {
+impl TestContext {
     pub async fn new_swap_as_alice(&self) -> alice::Swap {
         let (swap, mut event_loop) = self
             .alice_swap_factory
@@ -303,7 +303,7 @@ impl Test {
 
 pub async fn setup_test<T, F>(testfn: T)
 where
-    T: Fn(Test) -> F,
+    T: Fn(TestContext) -> F,
     F: Future<Output = ()>,
 {
     let cli = Cli::default();
@@ -377,7 +377,7 @@ where
         alice_swap_factory.peer_id(),
     );
 
-    let test = Test {
+    let test = TestContext {
         swap_amounts,
         alice_swap_factory,
         bob_swap_factory,

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -9,9 +9,9 @@ use swap::{
     bitcoin,
     config::Config,
     monero,
-    protocol::{alice, alice::AliceState, bob, bob::BobState},
+    protocol::{alice, alice::AliceState, bob, bob::BobState, StartingBalances},
     seed::Seed,
-    StartingBalances, SwapAmounts,
+    SwapAmounts,
 };
 use tempfile::tempdir;
 use testcontainers::{clients::Cli, Container};


### PR DESCRIPTION
Follow up of https://github.com/comit-network/xmr-btc-swap/pull/144

Took a bit more than expected, but this is really neat now!
The commits should be well-contained for reviewing, but https://github.com/comit-network/xmr-btc-swap/commit/00835baa154ddc278194fd9b98ffbfd8225e1c76 is quite big. 

I changed the abstraction on the way - out methods are finally named `run` and `run_until` which both take a swap - which makes way more sense I think :)

Also had to change the abstraction layers in `testutils` and introduced `Test` which specifies the swap amounts (that would usually come from the commandline and should not live in the factory as they are irrelevant for resumed swaps).