### PR TITLE
Wait for Bob's refund finality

### DIFF
--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -135,11 +135,9 @@ async fn main() -> Result<()> {
                 Arc::new(monero_wallet),
                 alice_addr,
                 alice_peer_id,
+                config,
             );
-            let (swap, event_loop) = bob_factory
-                .with_init_params(swap_amounts, config)
-                .build()
-                .await?;
+            let (swap, event_loop) = bob_factory.with_init_params(swap_amounts).build().await?;
 
             tokio::spawn(async move { event_loop.run().await });
             bob::run(swap).await?;
@@ -212,6 +210,7 @@ async fn main() -> Result<()> {
                 Arc::new(monero_wallet),
                 alice_addr,
                 alice_peer_id,
+                config,
             );
             let (swap, event_loop) = bob_factory.build().await?;
 

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     bitcoin,
+    config::Config,
     database::{Database, Swap},
     monero,
     protocol::bob::{self, event_loop::EventLoopHandle, state::*},
@@ -54,6 +55,7 @@ pub async fn run_until(
         swap.monero_wallet,
         OsRng,
         swap.swap_id,
+        swap.config,
     )
     .await
 }
@@ -70,6 +72,7 @@ async fn run_until_internal<R>(
     monero_wallet: Arc<monero::Wallet>,
     mut rng: R,
     swap_id: Uuid,
+    config: Config,
 ) -> Result<BobState>
 where
     R: RngCore + CryptoRng + Send,
@@ -103,6 +106,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -124,6 +128,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -189,6 +194,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -230,6 +236,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -265,6 +272,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -286,6 +294,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -311,6 +320,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }
@@ -321,7 +331,7 @@ where
                         bail!("Internal error: canceled state reached before cancel timelock was expired");
                     }
                     ExpiredTimelocks::Cancel => {
-                        state.refund_btc(bitcoin_wallet.as_ref()).await?;
+                        state.refund_btc(bitcoin_wallet.as_ref(), config).await?;
                         BobState::BtcRefunded(state)
                     }
                     ExpiredTimelocks::Punish => BobState::BtcPunished {
@@ -340,6 +350,7 @@ where
                     monero_wallet,
                     rng,
                     swap_id,
+                    config,
                 )
                 .await
             }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -62,6 +62,7 @@ struct BobParams {
     monero_wallet: Arc<monero::Wallet>,
     alice_address: Multiaddr,
     alice_peer_id: PeerId,
+    config: Config,
 }
 
 impl BobParams {
@@ -74,6 +75,7 @@ impl BobParams {
             self.monero_wallet.clone(),
             self.alice_address.clone(),
             self.alice_peer_id.clone(),
+            self.config,
         )
     }
 }
@@ -112,7 +114,7 @@ impl TestContext {
         let (swap, event_loop) = self
             .bob_params
             .builder()
-            .with_init_params(self.swap_amounts, Config::regtest())
+            .with_init_params(self.swap_amounts)
             .build()
             .await
             .unwrap();
@@ -357,6 +359,7 @@ where
         monero_wallet: bob_monero_wallet.clone(),
         alice_address: alice_params.listen_address.clone(),
         alice_peer_id: alice_params.peer_id().await,
+        config,
     };
 
     let test = TestContext {


### PR DESCRIPTION
For Alice we ensure to wait for redeem/punish finality, so it should be the same for Bob on Bitcoin.

Notes:
Arguably we could also skip this and transition to `Redeemed` once we have the tx in the mempool. (so the user does not have to wait for the confirmations but monitors the tx finality himself.) 
But if we opt for that resume won't trigger the transaction again. Additionally we should not have different behavior for Alice and Bob I feel.