### PR TITLE
Fix Alice redeem scenario

### DIFF
--- a/swap/src/protocol/alice/steps.rs
+++ b/swap/src/protocol/alice/steps.rs
@@ -191,19 +191,16 @@ pub fn build_bitcoin_redeem_transaction(
 pub async fn publish_bitcoin_redeem_transaction<W>(
     redeem_tx: bitcoin::Transaction,
     bitcoin_wallet: Arc<W>,
-    config: Config,
-) -> Result<()>
+) -> Result<::bitcoin::Txid>
 where
     W: BroadcastSignedTransaction + WaitForTransactionFinality,
 {
     info!("Attempting to publish bitcoin redeem txn");
-    let tx_id = bitcoin_wallet
+    let txid = bitcoin_wallet
         .broadcast_signed_transaction(redeem_tx)
         .await?;
 
-    bitcoin_wallet
-        .wait_for_transaction_finality(tx_id, config)
-        .await
+    Ok(txid)
 }
 
 pub async fn publish_cancel_transaction<W>(

--- a/swap/tests/refund_restart_alice_cancelled.rs
+++ b/swap/tests/refund_restart_alice_cancelled.rs
@@ -1,0 +1,35 @@
+use swap::protocol::{alice, alice::AliceState, bob};
+
+pub mod testutils;
+
+/// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
+/// is forced to refund even though she learned the secret and would be able to
+/// redeem had the timelock not expired.
+#[tokio::test]
+async fn given_alice_restarts_after_enc_sig_learned_and_bob_already_cancelled_refund_swap() {
+    testutils::setup_test(|mut ctx| async move {
+        let alice_swap = ctx.new_swap_as_alice().await;
+        let bob_swap = ctx.new_swap_as_bob().await;
+
+        let bob = bob::run(bob_swap);
+        let bob_handle = tokio::spawn(bob);
+
+        let alice_state = alice::run_until(alice_swap, alice::swap::is_encsig_learned)
+            .await
+            .unwrap();
+        assert!(matches!(alice_state, AliceState::EncSigLearned {..}));
+
+        // Wait for Bob to refund, because Alice does not act
+        let bob_state = bob_handle.await.unwrap();
+        ctx.assert_bob_refunded(bob_state.unwrap()).await;
+
+        // Once bob has finished Alice is restarted and refunds as well
+        let alice_swap = ctx.recover_alice_from_db().await;
+        assert!(matches!(alice_swap.state, AliceState::EncSigLearned {..}));
+
+        let alice_state = alice::run(alice_swap).await.unwrap();
+
+        ctx.assert_alice_refunded(alice_state).await;
+    })
+    .await;
+}


### PR DESCRIPTION
Follow up of #144, partial fix of https://github.com/comit-network/xmr-btc-swap/issues/137

 Fix Alice redeem scenario

- Properly check the timelocks before trying to redeem
- Distinguish different failure scenarios and reactions to it.
    - if we fail to construct the redeem transaction: wait for cancel.
    - if we fail to publish the redeem transaction: wait for cancel but let the user know that restarting the application will result in retrying to publish the tx.
    - if we succeed to publish the tx but then fail when waiting for finality, print error to the user (secreat already leaked, the user has to check manually if the tx was included)

