### PR TITLE
Remove newlines from import statements to avoid problems

### DIFF
--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -24,11 +24,6 @@
 pub mod image;
 pub mod rpc;
 
-use anyhow::{anyhow, bail, Result};
-use std::time::Duration;
-use testcontainers::{clients::Cli, core::Port, Container, Docker, RunArgs};
-use tokio::time;
-
 use crate::{
     image::{
         MONEROD_DAEMON_CONTAINER_NAME, MONEROD_DEFAULT_NETWORK, MONEROD_RPC_PORT, WALLET_RPC_PORT,
@@ -38,6 +33,10 @@ use crate::{
         wallet::{self, GetAddress, Refreshed, Transfer},
     },
 };
+use anyhow::{anyhow, bail, Result};
+use std::time::Duration;
+use testcontainers::{clients::Cli, core::Port, Container, Docker, RunArgs};
+use tokio::time;
 
 /// How often we mine a block.
 const BLOCK_TIME_SECS: u64 = 1;

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -20,7 +20,6 @@
 //! every BLOCK_TIME_SECS seconds.
 //!
 //! Also provides standalone JSON RPC clients for monerod and monero-wallet-rpc.
-
 pub mod image;
 pub mod rpc;
 

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -1,7 +1,15 @@
+pub mod timelocks;
+pub mod transactions;
+pub mod wallet;
+
 pub use crate::bitcoin::{
     timelocks::Timelock,
     transactions::{TxCancel, TxLock, TxPunish, TxRedeem, TxRefund},
 };
+pub use ::bitcoin::{util::amount::Amount, Address, Network, Transaction, Txid};
+pub use ecdsa_fun::{adaptor::EncryptedSignature, fun::Scalar, Signature};
+pub use wallet::Wallet;
+
 use crate::{bitcoin::timelocks::BlockHeight, config::Config, ExpiredTimelocks};
 use ::bitcoin::{
     hashes::{hex::ToHex, Hash},
@@ -9,21 +17,14 @@ use ::bitcoin::{
     util::psbt::PartiallySignedTransaction,
     SigHash,
 };
-pub use ::bitcoin::{util::amount::Amount, Address, Network, Transaction, Txid};
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use ecdsa_fun::{adaptor::Adaptor, fun::Point, nonce::Deterministic, ECDSA};
-pub use ecdsa_fun::{adaptor::EncryptedSignature, fun::Scalar, Signature};
 use miniscript::{Descriptor, Segwitv0};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
-pub use wallet::Wallet;
-
-pub mod timelocks;
-pub mod transactions;
-pub mod wallet;
 
 // TODO: Configurable tx-fee (note: parties have to agree prior to swapping)
 // Current reasoning:

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -1,26 +1,24 @@
+pub use crate::bitcoin::{
+    timelocks::Timelock,
+    transactions::{TxCancel, TxLock, TxPunish, TxRedeem, TxRefund},
+};
+use crate::{bitcoin::timelocks::BlockHeight, config::Config, ExpiredTimelocks};
 use ::bitcoin::{
     hashes::{hex::ToHex, Hash},
     secp256k1,
     util::psbt::PartiallySignedTransaction,
     SigHash,
 };
+pub use ::bitcoin::{util::amount::Amount, Address, Network, Transaction, Txid};
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use ecdsa_fun::{adaptor::Adaptor, fun::Point, nonce::Deterministic, ECDSA};
+pub use ecdsa_fun::{adaptor::EncryptedSignature, fun::Scalar, Signature};
 use miniscript::{Descriptor, Segwitv0};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
-
-use crate::{bitcoin::timelocks::BlockHeight, config::Config, ExpiredTimelocks};
-
-pub use crate::bitcoin::{
-    timelocks::Timelock,
-    transactions::{TxCancel, TxLock, TxPunish, TxRedeem, TxRefund},
-};
-pub use ::bitcoin::{util::amount::Amount, Address, Network, Transaction, Txid};
-pub use ecdsa_fun::{adaptor::EncryptedSignature, fun::Scalar, Signature};
 pub use wallet::Wallet;
 
 pub mod timelocks;

--- a/swap/src/bitcoin/transactions.rs
+++ b/swap/src/bitcoin/transactions.rs
@@ -1,3 +1,7 @@
+use crate::bitcoin::{
+    build_shared_output_descriptor, timelocks::Timelock, verify_sig, Address, Amount,
+    BuildTxLockPsbt, GetNetwork, PublicKey, Transaction, TX_FEE,
+};
 use ::bitcoin::{
     util::{bip143::SigHashCache, psbt::PartiallySignedTransaction},
     OutPoint, SigHash, SigHashType, TxIn, TxOut, Txid,
@@ -7,11 +11,6 @@ use ecdsa_fun::Signature;
 use miniscript::{Descriptor, NullCtx};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::bitcoin::{
-    build_shared_output_descriptor, timelocks::Timelock, verify_sig, Address, Amount,
-    BuildTxLockPsbt, GetNetwork, PublicKey, Transaction, TX_FEE,
-};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TxLock {

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -1,12 +1,3 @@
-use ::bitcoin::{util::psbt::PartiallySignedTransaction, Txid};
-use anyhow::{Context, Result};
-use async_trait::async_trait;
-use backoff::{backoff::Constant as ConstantBackoff, future::FutureOperation as _};
-use bitcoin_harness::{bitcoind_rpc::PsbtBase64, BitcoindRpcApi};
-use reqwest::Url;
-use std::time::Duration;
-use tokio::time::interval;
-
 use crate::{
     bitcoin::{
         timelocks::BlockHeight, Address, Amount, BroadcastSignedTransaction, BuildTxLockPsbt,
@@ -15,6 +6,14 @@ use crate::{
     },
     config::Config,
 };
+use ::bitcoin::{util::psbt::PartiallySignedTransaction, Txid};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use backoff::{backoff::Constant as ConstantBackoff, future::FutureOperation as _};
+use bitcoin_harness::{bitcoind_rpc::PsbtBase64, BitcoindRpcApi};
+use reqwest::Url;
+use std::time::Duration;
+use tokio::time::interval;
 
 #[derive(Debug)]
 pub struct Wallet {

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -1,8 +1,7 @@
+use crate::{bitcoin, monero};
 use libp2p::{core::Multiaddr, PeerId};
 use url::Url;
 use uuid::Uuid;
-
-use crate::{bitcoin, monero};
 
 #[derive(structopt::StructOpt, Debug)]
 pub struct Options {

--- a/swap/src/config.rs
+++ b/swap/src/config.rs
@@ -1,5 +1,4 @@
 pub mod seed;
-
 use crate::bitcoin::Timelock;
 use conquer_once::Lazy;
 use std::time::Duration;

--- a/swap/src/config.rs
+++ b/swap/src/config.rs
@@ -1,4 +1,5 @@
 pub mod seed;
+
 use crate::bitcoin::Timelock;
 use conquer_once::Lazy;
 use std::time::Duration;

--- a/swap/src/database.rs
+++ b/swap/src/database.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 
 mod alice;
 mod bob;
-
 pub use alice::Alice;
 pub use bob::Bob;
 

--- a/swap/src/database.rs
+++ b/swap/src/database.rs
@@ -1,3 +1,6 @@
+pub use alice::Alice;
+pub use bob::Bob;
+
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Display, path::Path};
@@ -5,8 +8,6 @@ use uuid::Uuid;
 
 mod alice;
 mod bob;
-pub use alice::Alice;
-pub use bob::Bob;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum Swap {

--- a/swap/src/lib.rs
+++ b/swap/src/lib.rs
@@ -16,18 +16,19 @@
     missing_copy_implementations
 )]
 
-use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
-
 pub mod bitcoin;
 pub mod config;
 pub mod database;
-mod fs;
 pub mod monero;
 pub mod network;
 pub mod protocol;
 pub mod seed;
 pub mod trace;
+
+mod fs;
+
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
 
 pub type Never = std::convert::Infallible;
 

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -12,6 +12,7 @@
 )]
 #![forbid(unsafe_code)]
 #![allow(non_snake_case)]
+
 use crate::cli::{Command, Options, Resume};
 use anyhow::{Context, Result};
 use prettytable::{row, Table};

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -12,7 +12,6 @@
 )]
 #![forbid(unsafe_code)]
 #![allow(non_snake_case)]
-
 use crate::cli::{Command, Options, Resume};
 use anyhow::{Context, Result};
 use prettytable::{row, Table};

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -1,11 +1,13 @@
 pub mod wallet;
 
+pub use ::monero::{Network, PrivateKey, PublicKey};
+pub use curve25519_dalek::scalar::Scalar;
+pub use wallet::Wallet;
+
 use crate::bitcoin;
 use ::bitcoin::hashes::core::fmt::Formatter;
-pub use ::monero::{Network, PrivateKey, PublicKey};
 use anyhow::Result;
 use async_trait::async_trait;
-pub use curve25519_dalek::scalar::Scalar;
 use rand::{CryptoRng, RngCore};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
@@ -17,7 +19,6 @@ use std::{
     ops::{Add, Mul, Sub},
     str::FromStr,
 };
-pub use wallet::Wallet;
 
 pub const PICONERO_OFFSET: u64 = 1_000_000_000_000;
 

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -1,8 +1,11 @@
 pub mod wallet;
 
+use crate::bitcoin;
 use ::bitcoin::hashes::core::fmt::Formatter;
+pub use ::monero::{Network, PrivateKey, PublicKey};
 use anyhow::Result;
 use async_trait::async_trait;
+pub use curve25519_dalek::scalar::Scalar;
 use rand::{CryptoRng, RngCore};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
@@ -14,11 +17,6 @@ use std::{
     ops::{Add, Mul, Sub},
     str::FromStr,
 };
-
-use crate::bitcoin;
-
-pub use ::monero::{Network, PrivateKey, PublicKey};
-pub use curve25519_dalek::scalar::Scalar;
 pub use wallet::Wallet;
 
 pub const PICONERO_OFFSET: u64 = 1_000_000_000_000;

--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -1,3 +1,7 @@
+use crate::monero::{
+    Amount, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicViewKey, Transfer,
+    TransferProof, TxHash, WatchForTransfer,
+};
 use ::monero::{Address, Network, PrivateKey, PublicKey};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -11,11 +15,6 @@ use std::{
 };
 use tracing::info;
 use url::Url;
-
-use crate::monero::{
-    Amount, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicViewKey, Transfer,
-    TransferProof, TxHash, WatchForTransfer,
-};
 
 #[derive(Debug)]
 pub struct Wallet {

--- a/swap/src/network.rs
+++ b/swap/src/network.rs
@@ -1,13 +1,13 @@
+pub mod peer_tracker;
+pub mod request_response;
+pub mod transport;
+
 use crate::seed::SEED_LENGTH;
 use bitcoin::hashes::{sha256, Hash, HashEngine};
 use futures::prelude::*;
 use libp2p::{core::Executor, identity::ed25519};
 use std::pin::Pin;
 use tokio::runtime::Handle;
-
-pub mod peer_tracker;
-pub mod request_response;
-pub mod transport;
 
 #[allow(missing_debug_implementations)]
 pub struct TokioExecutor {

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -1,5 +1,14 @@
 //! Run an XMR/BTC swap in the role of Alice.
 //! Alice holds XMR and wishes receive BTC.
+pub use self::{
+    event_loop::{EventLoop, EventLoopHandle},
+    message0::Message0,
+    message1::Message1,
+    message2::Message2,
+    state::*,
+    swap::{run, run_until},
+    swap_response::*,
+};
 use crate::{
     bitcoin,
     config::Config,
@@ -24,16 +33,6 @@ use rand::rngs::OsRng;
 use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, info};
 use uuid::Uuid;
-
-pub use self::{
-    event_loop::{EventLoop, EventLoopHandle},
-    message0::Message0,
-    message1::Message1,
-    message2::Message2,
-    state::*,
-    swap::{run, run_until},
-    swap_response::*,
-};
 
 pub mod event_loop;
 mod message0;

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -1,10 +1,3 @@
-use anyhow::{anyhow, Context, Result};
-use futures::FutureExt;
-use libp2p::{
-    core::Multiaddr, futures::StreamExt, request_response::ResponseChannel, PeerId, Swarm,
-};
-use tokio::sync::mpsc::{Receiver, Sender};
-
 use crate::{
     network::{request_response::AliceToBob, transport::SwapTransport, TokioExecutor},
     protocol::{
@@ -13,6 +6,12 @@ use crate::{
         bob,
     },
 };
+use anyhow::{anyhow, Context, Result};
+use futures::FutureExt;
+use libp2p::{
+    core::Multiaddr, futures::StreamExt, request_response::ResponseChannel, PeerId, Swarm,
+};
+use tokio::sync::mpsc::{Receiver, Sender};
 
 #[allow(missing_debug_implementations)]
 pub struct Channels<T> {

--- a/swap/src/protocol/alice/message0.rs
+++ b/swap/src/protocol/alice/message0.rs
@@ -1,3 +1,8 @@
+use crate::{
+    bitcoin, monero,
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT},
+    protocol::bob,
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -13,12 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    bitcoin, monero,
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT},
-    protocol::bob,
-};
 
 #[derive(Debug)]
 pub enum OutEvent {

--- a/swap/src/protocol/alice/message1.rs
+++ b/swap/src/protocol/alice/message1.rs
@@ -1,3 +1,7 @@
+use crate::{
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message1Protocol, TIMEOUT},
+    protocol::bob,
+};
 use ecdsa_fun::{adaptor::EncryptedSignature, Signature};
 use libp2p::{
     request_response::{
@@ -14,11 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message1Protocol, TIMEOUT},
-    protocol::bob,
-};
 
 #[derive(Debug)]
 pub enum OutEvent {

--- a/swap/src/protocol/alice/message2.rs
+++ b/swap/src/protocol/alice/message2.rs
@@ -1,3 +1,8 @@
+use crate::{
+    monero,
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message2Protocol, TIMEOUT},
+    protocol::bob,
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -13,12 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    monero,
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message2Protocol, TIMEOUT},
-    protocol::bob,
-};
 
 #[derive(Debug)]
 pub enum OutEvent {

--- a/swap/src/protocol/alice/message3.rs
+++ b/swap/src/protocol/alice/message3.rs
@@ -1,3 +1,7 @@
+use crate::{
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message3Protocol, TIMEOUT},
+    protocol::bob,
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -12,11 +16,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message3Protocol, TIMEOUT},
-    protocol::bob,
-};
 
 #[derive(Debug)]
 pub enum OutEvent {

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -1,15 +1,3 @@
-use anyhow::{anyhow, Context, Result};
-use ecdsa_fun::{
-    adaptor::{Adaptor, EncryptedSignature},
-    nonce::Deterministic,
-};
-use libp2p::request_response::ResponseChannel;
-use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
-use sha2::Sha256;
-use std::fmt;
-use tracing::info;
-
 use crate::{
     bitcoin,
     bitcoin::{
@@ -22,6 +10,17 @@ use crate::{
     protocol::{alice, bob},
     ExpiredTimelocks, SwapAmounts,
 };
+use anyhow::{anyhow, Context, Result};
+use ecdsa_fun::{
+    adaptor::{Adaptor, EncryptedSignature},
+    nonce::Deterministic,
+};
+use libp2p::request_response::ResponseChannel;
+use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::fmt;
+use tracing::info;
 
 #[derive(Debug)]
 pub enum AliceState {

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -1,16 +1,5 @@
 //! Run an XMR/BTC swap in the role of Alice.
 //! Alice holds XMR and wishes receive BTC.
-use anyhow::{bail, Result};
-use async_recursion::async_recursion;
-use futures::{
-    future::{select, Either},
-    pin_mut,
-};
-use rand::{CryptoRng, RngCore};
-use std::sync::Arc;
-use tracing::{error, info};
-use uuid::Uuid;
-
 use crate::{
     bitcoin,
     bitcoin::{TransactionBlockHeight, WaitForTransactionFinality, WatchForRawTransaction},
@@ -35,6 +24,16 @@ use crate::{
     },
     ExpiredTimelocks,
 };
+use anyhow::{bail, Result};
+use async_recursion::async_recursion;
+use futures::{
+    future::{select, Either},
+    pin_mut,
+};
+use rand::{CryptoRng, RngCore};
+use std::sync::Arc;
+use tracing::{error, info};
+use uuid::Uuid;
 
 trait Rng: RngCore + CryptoRng + Send {}
 

--- a/swap/src/protocol/bob/message0.rs
+++ b/swap/src/protocol/bob/message0.rs
@@ -1,3 +1,8 @@
+use crate::{
+    bitcoin, monero,
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT},
+    protocol::{alice, bob},
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -13,12 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    bitcoin, monero,
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message0Protocol, TIMEOUT},
-    protocol::{alice, bob},
-};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message0 {

--- a/swap/src/protocol/bob/message1.rs
+++ b/swap/src/protocol/bob/message1.rs
@@ -1,3 +1,8 @@
+use crate::{
+    bitcoin,
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message1Protocol, TIMEOUT},
+    protocol::alice,
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -13,12 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    bitcoin,
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message1Protocol, TIMEOUT},
-    protocol::alice,
-};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message1 {

--- a/swap/src/protocol/bob/message2.rs
+++ b/swap/src/protocol/bob/message2.rs
@@ -1,3 +1,7 @@
+use crate::{
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message2Protocol, TIMEOUT},
+    protocol::alice,
+};
 use ecdsa_fun::Signature;
 use libp2p::{
     request_response::{
@@ -14,11 +18,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error};
-
-use crate::{
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message2Protocol, TIMEOUT},
-    protocol::alice,
-};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message2 {

--- a/swap/src/protocol/bob/message3.rs
+++ b/swap/src/protocol/bob/message3.rs
@@ -1,3 +1,7 @@
+use crate::{
+    bitcoin::EncryptedSignature,
+    network::request_response::{AliceToBob, BobToAlice, Codec, Message3Protocol, TIMEOUT},
+};
 use libp2p::{
     request_response::{
         handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
@@ -13,11 +17,6 @@ use std::{
     time::Duration,
 };
 use tracing::error;
-
-use crate::{
-    bitcoin::EncryptedSignature,
-    network::request_response::{AliceToBob, BobToAlice, Codec, Message3Protocol, TIMEOUT},
-};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message3 {

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -1,14 +1,3 @@
-use anyhow::{anyhow, Result};
-use ecdsa_fun::{
-    adaptor::{Adaptor, EncryptedSignature},
-    nonce::Deterministic,
-    Signature,
-};
-use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
-use sha2::Sha256;
-use std::fmt;
-
 use crate::{
     bitcoin::{
         self, current_epoch, timelocks::Timelock, wait_for_cancel_timelock_to_expire,
@@ -21,6 +10,16 @@ use crate::{
     protocol::{alice, bob},
     ExpiredTimelocks, SwapAmounts,
 };
+use anyhow::{anyhow, Result};
+use ecdsa_fun::{
+    adaptor::{Adaptor, EncryptedSignature},
+    nonce::Deterministic,
+    Signature,
+};
+use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum BobState {

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -1,11 +1,3 @@
-use anyhow::{bail, Result};
-use async_recursion::async_recursion;
-use rand::{rngs::OsRng, CryptoRng, RngCore};
-use std::sync::Arc;
-use tokio::select;
-use tracing::{debug, info};
-use uuid::Uuid;
-
 use crate::{
     bitcoin,
     config::Config,
@@ -14,6 +6,13 @@ use crate::{
     protocol::bob::{self, event_loop::EventLoopHandle, state::*, SwapRequest},
     ExpiredTimelocks, SwapAmounts,
 };
+use anyhow::{bail, Result};
+use async_recursion::async_recursion;
+use rand::{rngs::OsRng, CryptoRng, RngCore};
+use std::sync::Arc;
+use tokio::select;
+use tracing::{debug, info};
+use uuid::Uuid;
 
 pub fn is_complete(state: &BobState) -> bool {
     matches!(

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,7 +1,7 @@
+pub mod testutils;
+
 use swap::protocol::{alice, bob};
 use tokio::join;
-
-pub mod testutils;
 
 /// Run the following tests with RUST_MIN_STACK=10000000
 

--- a/swap/tests/happy_path_restart_alice.rs
+++ b/swap/tests/happy_path_restart_alice.rs
@@ -1,6 +1,6 @@
-use swap::protocol::{alice, alice::AliceState, bob};
-
 pub mod testutils;
+
+use swap::protocol::{alice, alice::AliceState, bob};
 
 #[tokio::test]
 async fn given_alice_restarts_after_encsig_is_learned_resume_swap() {

--- a/swap/tests/happy_path_restart_bob_after_comm.rs
+++ b/swap/tests/happy_path_restart_bob_after_comm.rs
@@ -1,6 +1,6 @@
-use swap::protocol::{alice, bob, bob::BobState};
-
 pub mod testutils;
+
+use swap::protocol::{alice, bob, bob::BobState};
 
 #[tokio::test]
 async fn given_bob_restarts_after_encsig_is_sent_resume_swap() {

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,9 +1,9 @@
+pub mod testutils;
+
 use swap::protocol::{
     alice, bob,
     bob::{swap::is_xmr_locked, BobState},
 };
-
-pub mod testutils;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,9 +1,9 @@
+pub mod testutils;
+
 use swap::protocol::{
     alice, bob,
     bob::{swap::is_btc_locked, BobState},
 };
-
-pub mod testutils;
 
 /// Bob locks Btc and Alice locks Xmr. Bob does not act; he fails to send Alice
 /// the encsig and fail to refund or redeem. Alice punishes.

--- a/swap/tests/refund_restart_alice.rs
+++ b/swap/tests/refund_restart_alice.rs
@@ -1,6 +1,6 @@
-use swap::protocol::{alice, alice::AliceState, bob};
-
 pub mod testutils;
+
+use swap::protocol::{alice, alice::AliceState, bob};
 
 /// Bob locks btc and Alice locks xmr. Alice fails to act so Bob refunds. Alice
 /// then also refunds.


### PR DESCRIPTION
Rust fmt automatically groups the imports (from top to bottom) as `pub use` `use crate` and `use`.
There is no need to introduce sections which cause annoyance when auto importing using the IDE.