### PR TITLE
Add reset-config command that allows removing config file

### DIFF
--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -47,6 +47,10 @@ pub enum Command {
     },
     History,
     Resume(Resume),
+    ResetConfig {
+        #[structopt(flatten)]
+        config: Config,
+    },
 }
 
 #[derive(structopt::StructOpt, Debug)]

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -15,7 +15,8 @@
 use crate::{
     cli::{Command, Options, Resume},
     config::{
-        initial_setup, query_user_for_initial_testnet_config, read_config, ConfigNotInitialized,
+        initial_setup, query_user_for_initial_testnet_config, read_config, reset_config,
+        ConfigNotInitialized,
     },
 };
 use anyhow::{Context, Result};
@@ -204,6 +205,7 @@ async fn main() -> Result<()> {
             tokio::spawn(async move { event_loop.run().await });
             bob::run(swap).await?;
         }
+        Command::ResetConfig { config } => reset_config(config.config_path)?,
     };
 
     Ok(())


### PR DESCRIPTION
Note: This PR causes side effects with the data-dir (because the data-dir is defined globally and the seed is always generated), this was fixed in follow up: https://github.com/comit-network/xmr-btc-swap/pull/166