### PR TITLE
Watch only tmp monero wallet

### DIFF
--- a/monero-harness/src/rpc/wallet.rs
+++ b/monero-harness/src/rpc/wallet.rs
@@ -1,6 +1,6 @@
 use crate::rpc::{Request, Response};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -139,6 +139,10 @@ impl Client {
             .await?;
 
         debug!("create wallet RPC response: {}", response);
+
+        if response.contains("error") {
+            bail!("Failed to create wallet")
+        }
 
         Ok(())
     }

--- a/monero-harness/src/rpc/wallet.rs
+++ b/monero-harness/src/rpc/wallet.rs
@@ -121,6 +121,33 @@ impl Client {
         Ok(r.result)
     }
 
+    /// Opens a wallet using `filename`.
+    pub async fn open_wallet(&self, filename: &str) -> Result<()> {
+        let params = OpenWalletParams {
+            filename: filename.to_owned(),
+        };
+        let request = Request::new("open_wallet", params);
+
+        let response = self
+            .inner
+            .post(self.url.clone())
+            .json(&request)
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        debug!("open wallet RPC response: {}", response);
+
+        // TODO: Proper error handling once switching to https://github.com/thomaseizinger/rust-jsonrpc-client/
+        //  Currently blocked by https://github.com/thomaseizinger/rust-jsonrpc-client/issues/20
+        if response.contains("error") {
+            bail!("Failed to open wallet")
+        }
+
+        Ok(())
+    }
+
     /// Creates a wallet using `filename`.
     pub async fn create_wallet(&self, filename: &str) -> Result<()> {
         let params = CreateWalletParams {
@@ -350,6 +377,11 @@ pub struct SubAddressAccount {
     pub label: String,
     pub tag: String,
     pub unlocked_balance: u64,
+}
+
+#[derive(Serialize, Debug, Clone)]
+struct OpenWalletParams {
+    filename: String,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/monero-harness/src/rpc/wallet.rs
+++ b/monero-harness/src/rpc/wallet.rs
@@ -1,5 +1,4 @@
 use crate::rpc::{Request, Response};
-
 use anyhow::{bail, Result};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};

--- a/swap/src/main.rs
+++ b/swap/src/main.rs
@@ -50,7 +50,7 @@ mod serde_peer_id;
 #[macro_use]
 extern crate prettytable;
 
-const MONERO_WATCH_ONLY_TEMP_WALLET_NAME: &str = "swap-tool-watch-only-tmp-wallet";
+const MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME: &str = "swap-tool-blockchain-monitoring-wallet";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -332,27 +332,27 @@ async fn init_wallets(
     let monero_wallet = monero::Wallet::new(config.monero.wallet_rpc_url.clone(), monero_network);
 
     // Setup the temporary Monero wallet necessary for monitoring the blockchain
-    let open_tmp_wallet_response = monero_wallet
-        .open_wallet(MONERO_WATCH_ONLY_TEMP_WALLET_NAME)
+    let open_monitoring_wallet_response = monero_wallet
+        .open_wallet(MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME)
         .await;
-    if open_tmp_wallet_response.is_err() {
+    if open_monitoring_wallet_response.is_err() {
         monero_wallet
-            .create_wallet(MONERO_WATCH_ONLY_TEMP_WALLET_NAME)
+            .create_wallet(MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME)
             .await
             .context(format!(
-                "Unable to create temporary Monero wallet.\
+                "Unable to create Monero wallet for blockchain monitoring.\
              Please ensure that the monero-wallet-rpc is available at {}",
                 config.monero.wallet_rpc_url
             ))?;
 
         info!(
-            "Created temporary Monero wallet {}",
-            MONERO_WATCH_ONLY_TEMP_WALLET_NAME
+            "Created Monero wallet for blockchain monitoring with name {}",
+            MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME
         );
     } else {
         info!(
-            "Opened temporary Monero wallet {}",
-            MONERO_WATCH_ONLY_TEMP_WALLET_NAME
+            "Opened Monero wallet for blockchain monitoring with name {}",
+            MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME
         );
     }
 

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -208,6 +208,11 @@ pub trait CreateWalletForOutput {
 }
 
 #[async_trait]
+pub trait OpenWallet {
+    async fn open_wallet(&self, file_name: &str) -> anyhow::Result<()>;
+}
+
+#[async_trait]
 pub trait CreateWallet {
     async fn create_wallet(&self, file_name: &str) -> anyhow::Result<()>;
 }

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -207,6 +207,11 @@ pub trait CreateWalletForOutput {
     ) -> anyhow::Result<()>;
 }
 
+#[async_trait]
+pub trait CreateWallet {
+    async fn create_wallet(&self, file_name: &str) -> anyhow::Result<()>;
+}
+
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[error("Overflow, cannot convert {0} to u64")]
 pub struct OverflowError(pub String);

--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -1,6 +1,6 @@
 use crate::monero::{
-    Amount, CreateWallet, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicViewKey,
-    Transfer, TransferProof, TxHash, WatchForTransfer,
+    Amount, CreateWallet, CreateWalletForOutput, InsufficientFunds, OpenWallet, PrivateViewKey,
+    PublicViewKey, Transfer, TransferProof, TxHash, WatchForTransfer,
 };
 use ::monero::{Address, Network, PrivateKey, PublicKey};
 use anyhow::Result;
@@ -90,6 +90,14 @@ impl CreateWalletForOutput for Wallet {
             )
             .await?;
 
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl OpenWallet for Wallet {
+    async fn open_wallet(&self, file_name: &str) -> Result<()> {
+        self.inner.open_wallet(file_name).await?;
         Ok(())
     }
 }

--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -1,6 +1,6 @@
 use crate::monero::{
-    Amount, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicViewKey, Transfer,
-    TransferProof, TxHash, WatchForTransfer,
+    Amount, CreateWallet, CreateWalletForOutput, InsufficientFunds, PrivateViewKey, PublicViewKey,
+    Transfer, TransferProof, TxHash, WatchForTransfer,
 };
 use ::monero::{Address, Network, PrivateKey, PublicKey};
 use anyhow::Result;
@@ -90,6 +90,14 @@ impl CreateWalletForOutput for Wallet {
             )
             .await?;
 
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CreateWallet for Wallet {
+    async fn create_wallet(&self, file_name: &str) -> Result<()> {
+        self.inner.create_wallet(file_name).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
When initializing Monero wallet, try to open temporary wallet, if opening errors then try to create it. If creating errors then fail with message asking the user to configure the wallet RPC.
If opening / creation succeeds get the block_height to verify that connection to wallet works, then proceed to swap. 

Note: RPC error handling is hacky, but I don't see the value of investing time into that at this point. The problem is, that we don't deal with the json rpc errors properly for calls were we don't serialize the result into an object (because the response is empty). Eventually we should switch to using https://github.com/thomaseizinger/rust-jsonrpc-client but that does not support parameters `by-name` yet, see: https://github.com/thomaseizinger/rust-jsonrpc-client/issues/20