### PR TITLE
Use Remote handle to access ongoing swaps on Alice

### DIFF
--- a/swap/src/bin/nectar.rs
+++ b/swap/src/bin/nectar.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
 
             let (bitcoin_wallet, monero_wallet) = init_wallets(config.clone()).await?;
 
-            let mut event_loop = EventLoop::new(
+            let (mut event_loop, _) = EventLoop::new(
                 config.network.listen,
                 seed,
                 execution_params,


### PR DESCRIPTION
This helps stabilizing the test as sometimes we were checking Alice state (in the DB) too early.