### PR TITLE
Remove misplaced wallet sync call

### DIFF
--- a/swap/src/bin/nectar.rs
+++ b/swap/src/bin/nectar.rs
@@ -140,6 +140,12 @@ async fn init_wallets(
         private_key,
     )
     .await?;
+
+    bitcoin_wallet
+        .sync_wallet()
+        .await
+        .expect("Could not sync btc wallet");
+
     let bitcoin_balance = bitcoin_wallet.balance().await?;
     info!(
         "Connection to Bitcoin wallet succeeded, balance: {}",

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -119,7 +119,6 @@ impl BuildTxLockPsbt for Wallet {
         output_amount: Amount,
     ) -> Result<PartiallySignedTransaction> {
         tracing::debug!("building tx lock");
-        self.sync_wallet().await?;
         let (psbt, _details) = self.inner.lock().await.create_tx(
             bdk::TxBuilder::with_recipients(vec![(
                 output_address.script_pubkey(),


### PR DESCRIPTION
These bdk wallet sync calls must of gotten lost during a rebase. Removed the call in build TxLock and added one when nectar starts up