### PR TITLE
Make bitcoin tx fee configurable

### DIFF
--- a/swap/src/bitcoin/cancel.rs
+++ b/swap/src/bitcoin/cancel.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::{
     build_shared_output_descriptor, Address, Amount, BlockHeight, PublicKey, Transaction, TxLock,
-    TX_FEE,
+    FEE_RATE,
 };
 use ::bitcoin::{util::bip143::SigHashCache, OutPoint, SigHash, SigHashType, TxIn, TxOut, Txid};
 use anyhow::Result;
@@ -77,7 +77,7 @@ impl TxCancel {
         };
 
         let tx_out = TxOut {
-            value: tx_lock.lock_amount().as_sat() - TX_FEE,
+            value: tx_lock.lock_amount().as_sat(),
             script_pubkey: cancel_output_descriptor.script_pubkey(NullCtx),
         };
 
@@ -165,8 +165,11 @@ impl TxCancel {
             witness: Vec::new(),
         };
 
+        let vbytes = self.inner.get_weight() / 4;
+        let tx_fee = vbytes as u64 * FEE_RATE;
+
         let tx_out = TxOut {
-            value: self.amount().as_sat() - TX_FEE,
+            value: self.amount().as_sat() - tx_fee,
             script_pubkey: spend_address.script_pubkey(),
         };
 

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::{
     build_shared_output_descriptor, Address, Amount, BuildTxLockPsbt, GetNetwork, PublicKey,
-    Transaction, TX_FEE,
+    Transaction, FEE_RATE,
 };
 use ::bitcoin::{util::psbt::PartiallySignedTransaction, OutPoint, TxIn, TxOut, Txid};
 use anyhow::Result;
@@ -74,8 +74,11 @@ impl TxLock {
             witness: Vec::new(),
         };
 
+        let vbytes = self.inner.clone().extract_tx().get_weight() / 4;
+        let tx_fee = vbytes as u64 * FEE_RATE;
+
         let tx_out = TxOut {
-            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value - TX_FEE,
+            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value - tx_fee,
             script_pubkey: spend_address.script_pubkey(),
         };
 

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -14,7 +14,6 @@ use bdk::{
     blockchain::{noop_progress, Blockchain, ElectrumBlockchain},
     electrum_client::{self, Client, ElectrumApi},
     miniscript::bitcoin::PrivateKey,
-    FeeRate,
 };
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
@@ -120,14 +119,14 @@ impl BuildTxLockPsbt for Wallet {
     ) -> Result<PartiallySignedTransaction> {
         tracing::debug!("building tx lock");
         self.sync_wallet().await?;
-        let (psbt, _details) = self.inner.lock().await.create_tx(
-            bdk::TxBuilder::with_recipients(vec![(
-                output_address.script_pubkey(),
-                output_amount.as_sat(),
-            )])
-            // todo: get actual fee
-            .fee_rate(FeeRate::from_sat_per_vb(5.0)),
-        )?;
+        let (psbt, _details) =
+            self.inner
+                .lock()
+                .await
+                .create_tx(bdk::TxBuilder::with_recipients(vec![(
+                    output_address.script_pubkey(),
+                    output_amount.as_sat(),
+                )]))?;
         tracing::debug!("tx lock built");
         Ok(psbt)
     }

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -1,5 +1,6 @@
 use crate::{
     bitcoin,
+    bitcoin::FEE_RATE,
     database::Database,
     execution_params::ExecutionParams,
     monero, network,
@@ -202,7 +203,10 @@ impl EventLoop {
         let btc_amount = quote_request.btc_amount;
         let xmr_amount = btc_amount.as_btc() * RATE as f64;
         let xmr_amount = monero::Amount::from_monero(xmr_amount)?;
-        let quote_response = QuoteResponse { xmr_amount };
+        let quote_response = QuoteResponse {
+            xmr_amount,
+            tx_fee_rate: FEE_RATE,
+        };
 
         self.swarm
             .send_quote_response(channel, quote_response)

--- a/swap/src/protocol/alice/quote_response.rs
+++ b/swap/src/protocol/alice/quote_response.rs
@@ -29,6 +29,7 @@ pub enum OutEvent {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct QuoteResponse {
     pub xmr_amount: monero::Amount,
+    pub tx_fee_rate: u64,
 }
 
 impl From<RequestResponseEvent<QuoteRequest, QuoteResponse>> for OutEvent {

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -79,6 +79,7 @@ pub struct State0 {
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     btc: bitcoin::Amount,
     xmr: monero::Amount,
+    btc_fee_rate: u64,
     cancel_timelock: CancelTimelock,
     punish_timelock: PunishTimelock,
     refund_address: bitcoin::Address,
@@ -86,10 +87,12 @@ pub struct State0 {
 }
 
 impl State0 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         btc: bitcoin::Amount,
         xmr: monero::Amount,
+        btc_fee_rate: u64,
         cancel_timelock: CancelTimelock,
         punish_timelock: PunishTimelock,
         refund_address: bitcoin::Address,
@@ -107,6 +110,7 @@ impl State0 {
             v_b,
             btc,
             xmr,
+            btc_fee_rate,
             dleq_proof_s_b,
             cancel_timelock,
             punish_timelock,
@@ -558,6 +562,12 @@ impl State4 {
 
     pub fn tx_lock_id(&self) -> bitcoin::Txid {
         self.tx_lock.txid()
+    }
+
+    pub fn tx_cancel_id(&self) -> bitcoin::Txid {
+        let tx_cancel =
+            bitcoin::TxCancel::new(&self.tx_lock, self.cancel_timelock, self.A, self.b.public());
+        tx_cancel.txid()
     }
 }
 

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -390,6 +390,7 @@ pub async fn request_quote_and_setup(
         &mut OsRng,
         btc_amount,
         quote_response.xmr_amount,
+        quote_response.tx_fee_rate,
         execution_params.bitcoin_cancel_timelock,
         execution_params.bitcoin_punish_timelock,
         bitcoin_refund_address,

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -139,7 +139,7 @@ impl TestContext {
         assert_eq!(
             btc_balance_after_swap,
             self.alice_starting_balances.btc + self.btc_amount
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+                - bitcoin::Amount::from_sat(bitcoin::FEE_RATE)
         );
 
         let xmr_balance_after_swap = self
@@ -193,7 +193,7 @@ impl TestContext {
         assert_eq!(
             btc_balance_after_swap,
             self.alice_starting_balances.btc + self.btc_amount
-                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE)
+                - bitcoin::Amount::from_sat(2 * bitcoin::FEE_RATE)
         );
 
         let xmr_balance_after_swap = self
@@ -265,12 +265,12 @@ impl TestContext {
         let alice_submitted_cancel = btc_balance_after_swap
             == self.bob_starting_balances.btc
                 - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE);
+                - bitcoin::Amount::from_sat(bitcoin::FEE_RATE);
 
         let bob_submitted_cancel = btc_balance_after_swap
             == self.bob_starting_balances.btc
                 - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE);
+                - bitcoin::Amount::from_sat(2 * bitcoin::FEE_RATE);
 
         // The cancel tx can be submitted by both Alice and Bob.
         // Since we cannot be sure who submitted it we have to assert accordingly


### PR DESCRIPTION
NOT READY FOR REVIEW:

Alice specifies the fee rate in the quote response to Bob. Bob's CLI tool should calculate and show the fees (along with the rate) that he will pay for a swap. Bob can decide whether he wishes to proceed with the swap. Currently the fee rate is hardcoded for Alice and the tests are failing because the balance assertions assume fixed tx fees. Remove fee rate from BuildTxLockPsbt as we manually specify the fees in build_spend_transaction().