### PR TITLE
Debug log level in monero harness tests to see RPC responses

### DIFF
--- a/monero-harness/tests/testutils/mod.rs
+++ b/monero-harness/tests/testutils/mod.rs
@@ -15,7 +15,7 @@ pub fn init_tracing() -> DefaultGuard {
 
     let global_filter = tracing::Level::WARN;
     let test_filter = tracing::Level::DEBUG;
-    let monero_harness_filter = tracing::Level::INFO;
+    let monero_harness_filter = tracing::Level::DEBUG;
 
     use tracing_subscriber::util::SubscriberInitExt as _;
     tracing_subscriber::fmt()


### PR DESCRIPTION
CI keeps failing when generating blocks, but response is only printed on debug level.
To investigate what is the problem change monero-harness log levels to debug.

Example failure:

https://github.com/comit-network/xmr-btc-swap/runs/1938109584

The failure happened when generating blocks, but without seeing the response error it is impossible to know what happened. Could not reproduce this problem locally. 