### PR TITLE
monero-rpc debug log for moner-harness tests 

### DIFF
--- a/monero-harness/tests/testutils/mod.rs
+++ b/monero-harness/tests/testutils/mod.rs
@@ -16,12 +16,13 @@ pub fn init_tracing() -> DefaultGuard {
     let global_filter = tracing::Level::WARN;
     let test_filter = tracing::Level::DEBUG;
     let monero_harness_filter = tracing::Level::DEBUG;
+    let monero_rpc_filter = tracing::Level::DEBUG;
 
     use tracing_subscriber::util::SubscriberInitExt as _;
     tracing_subscriber::fmt()
         .with_env_filter(format!(
-            "{},test={},monero_harness={}",
-            global_filter, test_filter, monero_harness_filter,
+            "{},test={},monero_harness={},monero_rpc={}",
+            global_filter, test_filter, monero_harness_filter, monero_rpc_filter,
         ))
         .set_default()
 }


### PR DESCRIPTION
This allows us to see the response from the monerod client on debug.
When the monero-harness was split up into harness and rpc this was overlooked.
We need the debug logs to investigate the monero harness CI fail bug.