### PR TITLE
Remove windows from the release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,8 +14,6 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout tagged commit


### PR DESCRIPTION
At the moment windows fails to build. This has to be fixed before it is re-added to the release.