### PR TITLE
Wait for wallet to catch up instead of block generation

### DIFF
--- a/monero-harness/tests/wallet.rs
+++ b/monero-harness/tests/wallet.rs
@@ -1,8 +1,9 @@
 use crate::testutils::init_tracing;
 use monero_harness::{Monero, MoneroWalletRpc};
 use spectral::prelude::*;
-use std::{thread::sleep, time::Duration};
+use std::time::Duration;
 use testcontainers::clients::Cli;
+use tokio::time::sleep;
 
 mod testutils;
 
@@ -67,6 +68,6 @@ async fn wait_for_wallet_to_catch_up(wallet: &MoneroWalletRpc, expected_balance:
         if balance == expected_balance || max_retry == retry {
             break;
         }
-        sleep(Duration::from_secs(1));
+        sleep(Duration::from_secs(1)).await;
     }
 }


### PR DESCRIPTION
The monero harness wallet always starts a miner that mines new blocks every second.
This can conflict with additionally triggering block generation  and cause this error:

```
monero_rpc::rpc::monerod: generate blocks response: {
  "error": {
    "code": -7,
    "message": "Block not accepted"
  },
  "id": "1",
  "jsonrpc": "2.0"
}
```

See error in CI run here: https://github.com/comit-network/xmr-btc-swap/runs/2001131193

Since the miner is generating blocks anyway we can wait for the wallet to catch up.
Refresh is done upon querying the balance, thus the refresh calls were removed.

---

Note: we could also opt for starting the miner optionally. This would make this test more efficient, but is a more intrusive change, thus I opted for this fix for now. 