### PR TITLE
Allow ASB to be configured with max BTC buy amount

### DIFF
--- a/swap/src/asb/command.rs
+++ b/swap/src/asb/command.rs
@@ -1,5 +1,5 @@
-use crate::monero::Amount;
-use anyhow::Result;
+use crate::bitcoin::Amount;
+use bitcoin::{util::amount::ParseAmountError, Denomination};
 use std::path::PathBuf;
 
 #[derive(structopt::StructOpt, Debug)]
@@ -19,13 +19,12 @@ pub struct Arguments {
 #[structopt(name = "xmr_btc-swap", about = "XMR BTC atomic swap")]
 pub enum Command {
     Start {
-        #[structopt(long = "max-sell-xmr", help = "The maximum amount of XMR the ASB is willing to sell.", default_value="0.5", parse(try_from_str = parse_xmr))]
-        max_sell: Amount,
+        #[structopt(long = "max-buy-btc", help = "The maximum amount of BTC the ASB is willing to buy.", default_value="0.005", parse(try_from_str = parse_btc))]
+        max_buy: Amount,
     },
     History,
 }
 
-fn parse_xmr(str: &str) -> Result<Amount> {
-    let amount = Amount::parse_monero(str)?;
-    Ok(amount)
+fn parse_btc(s: &str) -> Result<Amount, ParseAmountError> {
+    Amount::from_str_in(s, Denomination::Bitcoin)
 }

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
     let wallet_data_dir = config.data.dir.join("wallet");
 
     match opt.cmd {
-        Command::Start { max_sell } => {
+        Command::Start { max_buy } => {
             let seed = Seed::from_file_or_generate(&config.data.dir)
                 .expect("Could not retrieve/initialize seed");
 
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
                 Arc::new(monero_wallet),
                 Arc::new(db),
                 rate_service,
-                max_sell,
+                max_buy,
             )
             .unwrap();
 

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -4,7 +4,7 @@ use crate::{
     database::Database,
     execution_params::ExecutionParams,
     monero,
-    monero::{Amount, BalanceTooLow},
+    monero::BalanceTooLow,
     network::{transport, TokioExecutor},
     protocol::{
         alice,
@@ -86,7 +86,7 @@ pub struct EventLoop<RS> {
     monero_wallet: Arc<monero::Wallet>,
     db: Arc<Database>,
     rate_service: RS,
-    max_sell: Amount,
+    max_buy: bitcoin::Amount,
 
     recv_encrypted_signature: broadcast::Sender<EncryptedSignature>,
     send_transfer_proof: mpsc::Receiver<(PeerId, TransferProof)>,
@@ -110,7 +110,7 @@ where
         monero_wallet: Arc<monero::Wallet>,
         db: Arc<Database>,
         rate_service: RS,
-        max_sell: Amount,
+        max_buy: bitcoin::Amount,
     ) -> Result<(Self, mpsc::Receiver<RemoteHandle<Result<AliceState>>>)> {
         let identity = seed.derive_libp2p_identity();
         let behaviour = Behaviour::default();
@@ -142,7 +142,7 @@ where
             send_transfer_proof: send_transfer_proof.receiver,
             send_transfer_proof_sender: send_transfer_proof.sender,
             swap_handle_sender: swap_handle.sender,
-            max_sell,
+            max_buy,
         };
         Ok((event_loop, swap_handle.receiver))
     }
@@ -215,17 +215,17 @@ where
             .context("Failed to get latest rate")?;
 
         let btc_amount = quote_request.btc_amount;
-        let xmr_amount = rate.sell_quote(btc_amount)?;
 
-        if xmr_amount > self.max_sell {
-            bail!(MaximumSellAmountExceeded {
-                actual: xmr_amount,
-                max_sell: self.max_sell
+        if btc_amount > self.max_buy {
+            bail!(MaximumBuyAmountExceeded {
+                actual: btc_amount,
+                max: self.max_buy
             })
         }
 
         let xmr_balance = monero_wallet.get_balance().await?;
         let xmr_lock_fees = monero_wallet.static_tx_fee_estimate();
+        let xmr_amount = rate.sell_quote(btc_amount)?;
 
         if xmr_balance < xmr_amount + xmr_lock_fees {
             bail!(BalanceTooLow {
@@ -299,8 +299,8 @@ where
 }
 
 #[derive(Debug, Clone, Copy, thiserror::Error)]
-#[error("The amount {actual} exceeds the configured maximum sell amount of {max_sell} XMR")]
-pub struct MaximumSellAmountExceeded {
-    pub max_sell: Amount,
-    pub actual: Amount,
+#[error("Refusing to buy {actual} because the maximum configured limit is {max}")]
+pub struct MaximumBuyAmountExceeded {
+    pub max: bitcoin::Amount,
+    pub actual: bitcoin::Amount,
 }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -394,7 +394,7 @@ where
         alice_monero_wallet.clone(),
         alice_db,
         fixed_rate::RateService::default(),
-        alice_starting_balances.xmr,
+        bitcoin::Amount::ONE_BTC,
     )
     .unwrap();
 


### PR DESCRIPTION
This will make it easier to also configure the CLI to display an appropriate max amount the user has to deal with.

This is the first step in working towards https://github.com/comit-network/xmr-btc-swap/issues/255.