### PR TITLE
Bob can verify that the XMR lock tx was published

### DIFF
--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -194,10 +194,9 @@ impl Wallet {
 
             if proof.confirmations > confirmations.load(Ordering::SeqCst) {
                 confirmations.store(proof.confirmations, Ordering::SeqCst);
-                info!(
-                    "Monero lock tx received {} out of {} confirmations",
-                    proof.confirmations, expected_confirmations
-                );
+
+                let txid = &transfer_proof.tx_hash.0;
+                info!(%txid, "Monero lock tx has {} out of {} confirmations", proof.confirmations, expected_confirmations);
             }
 
             if proof.confirmations < expected_confirmations {

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -308,7 +308,11 @@ async fn run_until_internal(
                 // Ensure that the generated wallet is synced so we have a proper balance
                 monero_wallet.refresh().await?;
                 // Sweep (transfer all funds) to the given address
-                monero_wallet.sweep_all(receive_monero_address).await?;
+                let tx_hashes = monero_wallet.sweep_all(receive_monero_address).await?;
+
+                for tx_hash in tx_hashes {
+                    tracing::info!("Sent XMR to {} in tx {}", receive_monero_address, tx_hash.0);
+                }
 
                 let state = BobState::XmrRedeemed {
                     tx_lock_id: state.tx_lock_id(),


### PR DESCRIPTION
The Monero `txhash` log was removed. I feel the user should have the possibility to verify that the transaction was actually published so I added the tx-hash to the confirmation output. 

We could potentially print the tx-hash when receiving the transfer proof already, but that might not add much value compared to printing it with the confirmations. 

Additionally we should allow the user to at least know when the XMR can be expected in the user's wallet, otherwise the swap ends like this:

```
2021-03-04 13:49:19   INFO Monero lock tx received 5 out of 5 confirmations
```

This is just not very informative - yes, the final transaction is an implementation detail, but I don't think we should hide the transactions from the user. By printing the tx-hash for spending from the lock-tx into the user wallet we ensure the user knows that the XMR can now be expected in the user wallet. 

--- 

To add context, here the complete log (with debug enabled) **before** this change: 

```
2021-03-04 13:30:46  DEBUG Database and seed will be stored in /Users/dakami/Library/Application Support/xmr-btc-swap
2021-03-04 13:30:46  DEBUG Starting monero-wallet-rpc on port 56145
2021-03-04 13:30:51  DEBUG Requesting quote
2021-03-04 13:30:51   INFO Received quote: 1 XMR = 0.00433500 BTC
2021-03-04 13:30:51   INFO Still got 0.01018746 BTC left in wallet, swapping ...
2021-03-04 13:30:51   INFO Spot price for 0.00500000 BTC is 1.153402537485 XMR
2021-03-04 13:30:52  DEBUG Starting execution setup with 12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi
2021-03-04 13:30:55   INFO Published Bitcoin 3a6690a962191529892318819fb20e7f1ac4625400e64ee734056a9b2a17ad8f transaction as lock
2021-03-04 13:41:13  DEBUG Received Transfer Proof from 12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi
2021-03-04 13:42:11   INFO Monero lock tx received 1 out of 5 confirmations
2021-03-04 13:45:33   INFO Monero lock tx received 2 out of 5 confirmations
2021-03-04 13:47:49   INFO Monero lock tx received 3 out of 5 confirmations
2021-03-04 13:48:56   INFO Monero lock tx received 4 out of 5 confirmations
2021-03-04 13:49:19   INFO Monero lock tx received 5 out of 5 confirmations
2021-03-04 13:49:19  DEBUG Encrypted signature sent
2021-03-04 13:49:19  DEBUG Alice acknowledged encrypted signature
2021-03-04 13:49:19  DEBUG watching for tx: e5569d3f0bcccac95252dffaebe74ead0360c09b76bc762de890aaa0e51afbcf
2021-03-04 13:49:20  DEBUG Received protocol error "missing transaction" from Electrum, retrying...
2021-03-04 13:49:22  DEBUG Received protocol error "missing transaction" from Electrum, retrying...
```

