### PR TITLE
Update Cargo.lock for new version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,7 +3570,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "swap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-compression",


### PR DESCRIPTION
I forgot about this in the last commit ...