### PR TITLE
Switch to public stagenet node that works

### DIFF
--- a/swap/src/bin/swap_cli.rs
+++ b/swap/src/bin/swap_cli.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
     let monero_wallet_rpc = monero::WalletRpc::new(config.data.dir.join("monero")).await?;
 
     let monero_wallet_rpc_process = monero_wallet_rpc
-        .run(monero_network, "stagenet.community.xmr.to")
+        .run(monero_network, "monero-stagenet.exan.tech")
         .await?;
 
     match args.cmd {


### PR DESCRIPTION
The xmr.to node has been unreliable lately. The exan.tech node seems to
working.

@da-kami is following up with making this configurable. Lets get this in so we can get a release on Friday.