### PR TITLE
Bump tracing-subscriber to 0.2.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",


### PR DESCRIPTION
This release includes a bug-fix that removes an erroneous space
from our logs when running with `--debug`.