### PR TITLE
Alice spawns swaps outside the event loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             bob_refunds_using_cancel_and_refund_command,
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired,
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force,
+            punish
         ]
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -10,5 +10,6 @@ status = [
     "docker_tests (happy_path_restart_bob_before_comm)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force)",
-    "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired)"
+    "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired)",
+    "docker_tests (punish)"
 ]

--- a/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
+++ b/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
@@ -1,17 +1,20 @@
 pub mod testutils;
 
-use swap::protocol::bob;
 use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
 use testutils::bob_run_until::is_btc_locked;
 use testutils::FastCancelConfig;
 
 #[tokio::test]
 async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
     testutils::setup_test(FastCancelConfig, |mut ctx| async move {
-        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
-        let bob_state = bob::run_until(bob_swap, is_btc_locked).await.unwrap();
+        let alice_swap = ctx.alice_next_swap().await;
+        let _ = tokio::spawn(alice::run(alice_swap));
 
+        let bob_state = bob_swap.await??;
         assert!(matches!(bob_state, BobState::BtcLocked { .. }));
 
         let (bob_swap, bob_join_handle) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
@@ -20,8 +23,7 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
         if let BobState::BtcLocked(state3) = bob_swap.state.clone() {
             state3
                 .wait_for_cancel_timelock_to_expire(bob_swap.bitcoin_wallet.as_ref())
-                .await
-                .unwrap();
+                .await?;
         } else {
             panic!("Bob in unexpected state {}", bob_swap.state);
         }
@@ -35,9 +37,7 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
             bob_swap.db,
             false,
         )
-        .await
-        .unwrap()
-        .unwrap();
+        .await??;
         assert!(matches!(state, BobState::BtcCancelled { .. }));
 
         let (bob_swap, bob_join_handle) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
@@ -53,11 +53,11 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
             bob_swap.db,
             false,
         )
-        .await
-        .unwrap()
-        .unwrap();
+        .await??;
 
         ctx.assert_bob_refunded(bob_state).await;
+
+        Ok(())
     })
-    .await;
+    .await
 }

--- a/swap/tests/bob_refunds_using_cancel_and_refund_command_timelock_not_expired.rs
+++ b/swap/tests/bob_refunds_using_cancel_and_refund_command_timelock_not_expired.rs
@@ -1,17 +1,21 @@
 pub mod testutils;
 
 use bob::cancel::Error;
-use swap::protocol::bob;
 use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
 use testutils::bob_run_until::is_btc_locked;
 use testutils::SlowCancelConfig;
 
 #[tokio::test]
 async fn given_bob_manually_cancels_when_timelock_not_expired_errors() {
     testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
-        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
-        let bob_state = bob::run_until(bob_swap, is_btc_locked).await.unwrap();
+        let alice_swap = ctx.alice_next_swap().await;
+        let _ = tokio::spawn(alice::run(alice_swap));
+
+        let bob_state = bob_swap.await??;
         assert!(matches!(bob_state, BobState::BtcLocked { .. }));
 
         let (bob_swap, bob_join_handle) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
@@ -25,8 +29,7 @@ async fn given_bob_manually_cancels_when_timelock_not_expired_errors() {
             bob_swap.db,
             false,
         )
-        .await
-        .unwrap()
+        .await?
         .err()
         .unwrap();
 
@@ -44,13 +47,14 @@ async fn given_bob_manually_cancels_when_timelock_not_expired_errors() {
             bob_swap.db,
             false,
         )
-        .await
-        .unwrap()
+        .await?
         .err()
         .unwrap();
 
         let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
+
+        Ok(())
     })
     .await;
 }

--- a/swap/tests/bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force.rs
+++ b/swap/tests/bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force.rs
@@ -1,16 +1,20 @@
 pub mod testutils;
 
-use swap::protocol::bob;
 use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
 use testutils::bob_run_until::is_btc_locked;
 use testutils::SlowCancelConfig;
 
 #[tokio::test]
 async fn given_bob_manually_forces_cancel_when_timelock_not_expired_errors() {
     testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
-        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
-        let bob_state = bob::run_until(bob_swap, is_btc_locked).await.unwrap();
+        let alice_swap = ctx.alice_next_swap().await;
+        let _ = tokio::spawn(alice::run(alice_swap));
+
+        let bob_state = bob_swap.await??;
         assert!(matches!(bob_state, BobState::BtcLocked { .. }));
 
         let (bob_swap, bob_join_handle) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
@@ -47,6 +51,8 @@ async fn given_bob_manually_forces_cancel_when_timelock_not_expired_errors() {
         assert!(is_error);
         let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
+
+        Ok(())
     })
     .await;
 }

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -1,19 +1,26 @@
 pub mod testutils;
 
-use swap::protocol::bob;
+use swap::protocol::{alice, bob};
 use testutils::SlowCancelConfig;
+use tokio::join;
 
 /// Run the following tests with RUST_MIN_STACK=10000000
 
 #[tokio::test]
 async fn happy_path() {
     testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
-        let (bob_swap, _) = ctx.new_swap_as_bob().await;
+        let (bob_swap, _) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run(bob_swap));
 
-        let bob_state = bob::run(bob_swap).await;
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
 
-        ctx.assert_alice_redeemed().await;
-        ctx.assert_bob_redeemed(bob_state.unwrap()).await;
+        let (bob_state, alice_state) = join!(bob_swap, alice_swap);
+
+        ctx.assert_alice_redeemed(alice_state??).await;
+        ctx.assert_bob_redeemed(bob_state??).await;
+
+        Ok(())
     })
     .await;
 }

--- a/swap/tests/happy_path_restart_bob_before_comm.rs
+++ b/swap/tests/happy_path_restart_bob_before_comm.rs
@@ -1,27 +1,34 @@
 pub mod testutils;
 
-use swap::protocol::bob;
 use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
 use testutils::bob_run_until::is_xmr_locked;
 use testutils::SlowCancelConfig;
 
 #[tokio::test]
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     testutils::setup_test(SlowCancelConfig, |mut ctx| async move {
-        let (bob_swap, bob_join_handle) = ctx.new_swap_as_bob().await;
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_xmr_locked));
 
-        let bob_state = bob::run_until(bob_swap, is_xmr_locked).await.unwrap();
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
+
+        let bob_state = bob_swap.await??;
 
         assert!(matches!(bob_state, BobState::XmrLocked { .. }));
 
         let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked { .. }));
 
-        let bob_state = bob::run(bob_swap).await.unwrap();
+        let bob_state = bob::run(bob_swap).await?;
 
         ctx.assert_bob_redeemed(bob_state).await;
 
-        ctx.assert_alice_redeemed().await;
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_redeemed(alice_state).await;
+
+        Ok(())
     })
     .await;
 }

--- a/swap/tests/punish.rs
+++ b/swap/tests/punish.rs
@@ -1,0 +1,37 @@
+pub mod testutils;
+
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+use testutils::bob_run_until::is_btc_locked;
+use testutils::FastPunishConfig;
+
+/// Bob locks Btc and Alice locks Xmr. Bob does not act; he fails to send Alice
+/// the encsig and fail to refund or redeem. Alice punishes.
+#[tokio::test]
+async fn alice_punishes_if_bob_never_acts_after_fund() {
+    testutils::setup_test(FastPunishConfig, |mut ctx| async move {
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
+
+        let bob_state = bob_swap.await??;
+        assert!(matches!(bob_state, BobState::BtcLocked { .. }));
+
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_punished(alice_state).await;
+
+        // Restart Bob after Alice punished to ensure Bob transitions to
+        // punished and does not run indefinitely
+        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
+
+        let bob_state = bob::run(bob_swap).await?;
+
+        ctx.assert_bob_punished(bob_state).await;
+
+        Ok(())
+    })
+    .await;
+}


### PR DESCRIPTION
Instead of spawning the swap inside the event loop we send the swap back
to the caller to be spawned. This means we no longer need the remote handle
that was only used in the tests.
This now properly logs the swap results in production.
It also gives us more control over Alice's swap in the tests.