### PR TITLE
Alice sweeps refunded funds into default wallet

### DIFF
--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -164,18 +164,16 @@ async fn init_wallets(
         bitcoin_balance
     );
 
-    let monero_wallet = monero::Wallet::new(
+    let monero_wallet = monero::Wallet::open_or_create(
         config.monero.wallet_rpc_url.clone(),
         DEFAULT_WALLET_NAME.to_string(),
         env_config,
-    );
-
-    // Setup the Monero wallet
-    monero_wallet.open_or_create().await?;
+    )
+    .await?;
 
     let balance = monero_wallet.get_balance().await?;
     if balance == Amount::ZERO {
-        let deposit_address = monero_wallet.get_main_address().await?;
+        let deposit_address = monero_wallet.get_main_address();
         warn!(
             "The Monero balance is 0, make sure to deposit funds at: {}",
             deposit_address

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -295,18 +295,12 @@ async fn init_monero_wallet(
         .run(network, monero_daemon_host.as_str())
         .await?;
 
-    let monero_wallet = monero::Wallet::new(
+    let monero_wallet = monero::Wallet::open_or_create(
         monero_wallet_rpc_process.endpoint(),
         MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME.to_string(),
         env_config,
-    );
-
-    monero_wallet.open_or_create().await?;
-
-    let _test_wallet_connection = monero_wallet
-        .block_height()
-        .await
-        .context("Failed to validate connection to monero-wallet-rpc")?;
+    )
+    .await?;
 
     Ok((monero_wallet, monero_wallet_rpc_process))
 }

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -2,7 +2,8 @@ use crate::bitcoin::{
     current_epoch, CancelTimelock, ExpiredTimelocks, PunishTimelock, TxCancel, TxPunish, TxRefund,
 };
 use crate::env::Config;
-use crate::monero::wallet::TransferRequest;
+use crate::monero::wallet::{TransferRequest, WatchRequest};
+use crate::monero::TransferProof;
 use crate::protocol::alice::{Message1, Message3};
 use crate::protocol::bob::{Message0, Message2, Message4};
 use crate::protocol::CROSS_CURVE_PROOF_SYSTEM;
@@ -354,6 +355,24 @@ impl State3 {
             public_spend_key,
             public_view_key,
             amount: self.xmr,
+        }
+    }
+
+    pub fn lock_xmr_watch_request(
+        &self,
+        transfer_proof: TransferProof,
+        conf_target: u32,
+    ) -> WatchRequest {
+        let S_a = monero::PublicKey::from_private_key(&monero::PrivateKey { scalar: self.s_a });
+
+        let public_spend_key = S_a + self.S_b_monero;
+        let public_view_key = self.v.public();
+        WatchRequest {
+            public_spend_key,
+            public_view_key,
+            transfer_proof,
+            conf_target,
+            expected: self.xmr,
         }
     }
 

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -97,13 +97,20 @@ async fn run_until_internal(
                 .transfer(state3.lock_xmr_transfer_request())
                 .await?;
 
-            // TODO(Franck): Wait for Monero to be confirmed once
-            //  Waiting for XMR confirmations should not be done in here, but in a separate
+            monero_wallet
+                .watch_for_transfer(state3.lock_xmr_watch_request(transfer_proof.clone(), 1))
+                .await?;
+
+            // TODO: Waiting for XMR confirmations should be done in a separate
             //  state! We have to record that Alice has already sent the transaction.
             //  Otherwise Alice might publish the lock tx twice!
 
             event_loop_handle
-                .send_transfer_proof(transfer_proof)
+                .send_transfer_proof(transfer_proof.clone())
+                .await?;
+
+            monero_wallet
+                .watch_for_transfer(state3.lock_xmr_watch_request(transfer_proof, 10))
                 .await?;
 
             AliceState::XmrLocked {

--- a/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
+++ b/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
@@ -12,7 +12,7 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
-        let _ = tokio::spawn(alice::run(alice_swap));
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
 
         let bob_state = bob_swap.await??;
         assert!(matches!(bob_state, BobState::BtcLocked { .. }));
@@ -55,6 +55,9 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
         .await??;
 
         ctx.assert_bob_refunded(bob_state).await;
+
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_refunded(alice_state).await;
 
         Ok(())
     })


### PR DESCRIPTION
Alice's refund scenario starts with generating the temporary wallet
from keys to claim the XMR which results in Alice' unloading the wallet.
Alice then loads her original wallet to be able to handle more swaps.
Since Alice is in the role of the long running daemon handling concurrent
swaps, the operation to close, claim and re-open her default wallet must
be atomic.
This PR adds an additional step, that sweeps all the refunded XMR back into
the default wallet. In order to ensure that this is possible, Alice has to
ensure that the locked XMR got enough confirmations.
These changes allow us to assert Alice's balance after refunding.