### PR TITLE
Update the preview release text

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -30,3 +30,4 @@ jobs:
           release_name: preview
           draft: false
           prerelease: true
+          body: Preview release of `asb` and `swap`


### PR DESCRIPTION
By default, GitHub uses the last commit message as the body text.
This can be a lot of text if the last commit was from dependabot.

Make the preview release more pleasant to look at by adding a
dedicated body.