### PR TITLE
Make lock_xmr "idempotent"

### DIFF
--- a/swap/src/protocol/alice/steps.rs
+++ b/swap/src/protocol/alice/steps.rs
@@ -7,6 +7,7 @@ use crate::protocol::alice::TransferProof;
 use crate::{bitcoin, monero};
 use anyhow::{bail, Context, Result};
 use futures::pin_mut;
+use std::time::Duration;
 
 pub async fn lock_xmr(
     state3: alice::State3,
@@ -18,20 +19,25 @@ pub async fn lock_xmr(
     let public_spend_key = S_a + state3.S_b_monero;
     let public_view_key = state3.v.public();
 
-    let transfer_proof = monero_wallet
-        .transfer(public_spend_key, public_view_key, state3.xmr)
-        .await?;
+    if !monero_wallet
+        .transfer_in_flight_or_confirmed(public_spend_key, public_view_key, state3.xmr)
+        .await?
+    {
+        let transfer_proof = monero_wallet
+            .transfer(public_spend_key, public_view_key, state3.xmr)
+            .await?;
 
-    // TODO(Franck): Wait for Monero to be confirmed once
-    //  Waiting for XMR confirmations should not be done in here, but in a separate
-    //  state! We have to record that Alice has already sent the transaction.
-    //  Otherwise Alice might publish the lock tx twice!
+        // TODO(Franck): Wait for Monero to be confirmed once
+        //  Waiting for XMR confirmations should not be done in here, but in a separate
+        //  state! We have to record that Alice has already sent the transaction.
+        //  Otherwise Alice might publish the lock tx twice!
 
-    event_loop_handle
-        .send_transfer_proof(TransferProof {
-            tx_lock_proof: transfer_proof,
-        })
-        .await?;
+        event_loop_handle
+            .send_transfer_proof(TransferProof {
+                tx_lock_proof: transfer_proof,
+            })
+            .await?;
+    }
 
     Ok(())
 }

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -664,7 +664,7 @@ pub fn init_tracing() -> DefaultGuard {
 
     use tracing_subscriber::util::SubscriberInitExt as _;
     tracing_subscriber::fmt()
-        .with_env_filter("warn,swap=debug,monero_harness=debug,monero_rpc=info,bitcoin_harness=info,testcontainers=info")
+        .with_env_filter("warn,swap=debug,monero_harness=debug,monero_rpc=debug,bitcoin_harness=info,testcontainers=info")
         .set_default()
 }
 


### PR DESCRIPTION
Alice checks if xmr has already been locked (or in the process of being
locked) before locking xmr. This change means we no longer have to keep
track of whether we have locked xmr or not. We check the status of lock
xmr by looking for confirmed outgoing, pending or mempool transfers that
 match the shared public spend key and the amount.