### PR TITLE
Allow ASB users to use custom Monero wallet by specyfying wallet name and password

### DIFF
--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -228,7 +228,7 @@ impl<'c> MoneroWalletRpc {
 
         // create new wallet
         wallet::Client::localhost(wallet_rpc_port)
-            .create_wallet(name)
+            .create_wallet(name, "")
             .await
             .unwrap();
 

--- a/monero-rpc/src/rpc/wallet.rs
+++ b/monero-rpc/src/rpc/wallet.rs
@@ -121,9 +121,10 @@ impl Client {
     }
 
     /// Opens a wallet using `filename`.
-    pub async fn open_wallet(&self, filename: &str) -> Result<()> {
+    pub async fn open_wallet(&self, filename: &str, password: &str) -> Result<()> {
         let params = OpenWalletParams {
-            filename: filename.to_owned(),
+            filename: filename.to_string(),
+            password: password.to_string(),
         };
         let request = Request::new("open_wallet", params);
 
@@ -170,10 +171,11 @@ impl Client {
     }
 
     /// Creates a wallet using `filename`.
-    pub async fn create_wallet(&self, filename: &str) -> Result<()> {
+    pub async fn create_wallet(&self, filename: &str, password: &str) -> Result<()> {
         let params = CreateWalletParams {
-            filename: filename.to_owned(),
-            language: "English".to_owned(),
+            filename: filename.to_string(),
+            password: password.to_string(),
+            language: "English".to_string(),
         };
         let request = Request::new("create_wallet", params);
 
@@ -419,11 +421,13 @@ pub struct SubAddressAccount {
 #[derive(Serialize, Debug, Clone)]
 struct OpenWalletParams {
     filename: String,
+    password: String,
 }
 
 #[derive(Serialize, Debug, Clone)]
 struct CreateWalletParams {
     filename: String,
+    password: String,
     language: String,
 }
 

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -37,8 +37,6 @@ use tracing_subscriber::filter::LevelFilter;
 #[macro_use]
 extern crate prettytable;
 
-const DEFAULT_WALLET_NAME: &str = "asb-wallet";
-
 #[tokio::main]
 async fn main() -> Result<()> {
     init_tracing(LevelFilter::DEBUG).expect("initialize tracing");
@@ -166,7 +164,8 @@ async fn init_wallets(
 
     let monero_wallet = monero::Wallet::open_or_create(
         config.monero.wallet_rpc_url.clone(),
-        DEFAULT_WALLET_NAME.to_string(),
+        config.monero.wallet_name,
+        Some(config.monero.wallet_password),
         env_config,
     )
     .await?;

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -298,6 +298,7 @@ async fn init_monero_wallet(
     let monero_wallet = monero::Wallet::open_or_create(
         monero_wallet_rpc_process.endpoint(),
         MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME.to_string(),
+        None,
         env_config,
     )
     .await?;

--- a/swap/tests/testutils/mod.rs
+++ b/swap/tests/testutils/mod.rs
@@ -598,6 +598,7 @@ async fn init_test_wallets(
     let xmr_wallet = swap::monero::Wallet::connect(
         monero.wallet(name).unwrap().client(),
         name.to_string(),
+        String::new(),
         env_config,
     )
     .await


### PR DESCRIPTION
Fixes #352 

Upon initial setup one can specify a wallet name and password to be used.
This allows the user to re-use an existing wallet.

If the given wallet is not found in the Monero RPC wallet folder it will be created with the given password.