### PR TITLE
No Bitcoin deposit for Alice

### DIFF
--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -86,11 +86,6 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            info!(
-                "BTC deposit address: {}",
-                bitcoin_wallet.new_address().await?
-            );
-
             let kraken_rate_updates = kraken::connect()?;
 
             let (event_loop, mut swap_receiver) = EventLoop::new(


### PR DESCRIPTION
The message to deposit Bitcoin only applies to Bob, not Alice.
Alice does not require any initial Bitcoin.