### PR TITLE
ASB resumes unfinished swaps after startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired,
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force,
             punish,
-            alice_punishes_after_restart_punish_timelock_expired
+            alice_punishes_after_restart_punish_timelock_expired,
+            alice_refunds_after_restart_bob_refunded
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,12 @@ jobs:
             happy_path,
             happy_path_restart_bob_after_xmr_locked,
             happy_path_restart_bob_before_xmr_locked,
+            happy_path_restart_alice_after_xmr_locked,
             bob_refunds_using_cancel_and_refund_command,
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired,
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force,
-            punish
+            punish,
+            alice_punishes_after_restart_punish_timelock_expired
         ]
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `resume` command of the `swap` CLI no longer require the `--seller-peer-id` parameter.
+  This information is now saved in the database.
+
 ### Added
 
 - A changelog file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - A changelog file.
+- Automatic resume of unfinished swaps for the `asb` upon startup.
+  Unfinished swaps from earlier versions will be skipped.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,7 +2556,7 @@ checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools",
+ "itertools 0.9.0",
  "log 0.4.14",
  "multimap",
  "petgraph",
@@ -2564,7 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3522,6 +3531,7 @@ dependencies = [
  "futures",
  "get-port",
  "hyper 0.14.5",
+ "itertools 0.10.0",
  "libp2p",
  "libp2p-async-await",
  "miniscript",

--- a/bors.toml
+++ b/bors.toml
@@ -8,9 +8,11 @@ status = [
     "test (macos-latest)",
     "docker_tests (happy_path)",
     "docker_tests (happy_path_restart_bob_after_xmr_locked)",
+    "docker_tests (happy_path_restart_alice_after_xmr_locked)",
     "docker_tests (happy_path_restart_bob_before_xmr_locked)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired)",
-    "docker_tests (punish)"
+    "docker_tests (punish)",
+    "docker_tests (alice_punishes_after_restart_punish_timelock_expired)"
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -14,5 +14,6 @@ status = [
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force)",
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired)",
     "docker_tests (punish)",
-    "docker_tests (alice_punishes_after_restart_punish_timelock_expired)"
+    "docker_tests (alice_punishes_after_restart_punish_timelock_expired)",
+    "docker_tests (alice_refunds_after_restart_bob_refunded)"
 ]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -25,6 +25,7 @@ dialoguer = "0.8"
 directories-next = "2"
 ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", features = ["libsecp_compat", "serde"] }
 futures = { version = "0.3", default-features = false }
+itertools = "0.10"
 libp2p = { version = "0.36", default-features = false, features = ["tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "request-response"] }
 libp2p-async-await = { git = "https://github.com/comit-network/rust-libp2p-async-await" }
 miniscript = { version = "5", features = ["serde"] }

--- a/swap/src/asb/fixed_rate.rs
+++ b/swap/src/asb/fixed_rate.rs
@@ -1,6 +1,6 @@
 use crate::asb::Rate;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct FixedRate(Rate);
 
 impl FixedRate {

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
 
             table.add_row(row!["SWAP ID", "STATE"]);
 
-            for (swap_id, state) in db.all()? {
+            for (swap_id, state) in db.all_alice()? {
                 table.add_row(row![swap_id, state]);
             }
 

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
 
             table.add_row(row!["SWAP ID", "STATE"]);
 
-            for (swap_id, state) in db.all()? {
+            for (swap_id, state) in db.all_bob()? {
                 table.add_row(row![swap_id, state]);
             }
 

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -37,8 +37,15 @@ pub struct Arguments {
 pub enum Command {
     /// Start a XMR for BTC swap
     BuyXmr {
+        #[structopt(
+        long = "seller-peer-id",
+        default_value = DEFAULT_ALICE_PEER_ID,
+        help = "The peer id of a specific swap partner can be optionally provided"
+        )]
+        alice_peer_id: PeerId,
+
         #[structopt(flatten)]
-        connect_params: AliceConnectParams,
+        alice_multi_addr: AliceMultiaddress,
 
         #[structopt(long = "electrum-rpc",
         help = "Provide the Bitcoin Electrum RPC URL",
@@ -60,7 +67,7 @@ pub enum Command {
         swap_id: Uuid,
 
         #[structopt(flatten)]
-        connect_params: AliceConnectParams,
+        alice_multi_addr: AliceMultiaddress,
 
         #[structopt(long = "electrum-rpc",
         help = "Provide the Bitcoin Electrum RPC URL",
@@ -108,14 +115,7 @@ pub enum Command {
 }
 
 #[derive(structopt::StructOpt, Debug)]
-pub struct AliceConnectParams {
-    #[structopt(
-        long = "seller-peer-id",
-        default_value = DEFAULT_ALICE_PEER_ID,
-        help = "The peer id of a specific swap partner can be optionally provided"
-    )]
-    pub peer_id: PeerId,
-
+pub struct AliceMultiaddress {
     #[structopt(
         long = "seller-addr",
         default_value = DEFAULT_ALICE_MULTIADDR,

--- a/swap/src/database/alice.rs
+++ b/swap/src/database/alice.rs
@@ -30,27 +30,33 @@ pub enum Alice {
     },
     XmrLockTransferProofSent {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: alice::State3,
     },
     EncSigLearned {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         encrypted_signature: EncryptedSignature,
         state3: alice::State3,
     },
     CancelTimelockExpired {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: alice::State3,
     },
     BtcCancelled {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: alice::State3,
     },
     BtcPunishable {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: alice::State3,
     },
     BtcRefunded {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: alice::State3,
         #[serde(with = "monero_private_key")]
         spend_key: monero::PrivateKey,
@@ -95,52 +101,62 @@ impl From<&AliceState> for Alice {
             },
             AliceState::XmrLockTransferProofSent {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => Alice::XmrLockTransferProofSent {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 state3: state3.as_ref().clone(),
             },
             AliceState::EncSigLearned {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
                 encrypted_signature,
             } => Alice::EncSigLearned {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 state3: state3.as_ref().clone(),
                 encrypted_signature: *encrypted_signature.clone(),
             },
             AliceState::BtcRedeemed => Alice::Done(AliceEndState::BtcRedeemed),
             AliceState::BtcCancelled {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
-                ..
             } => Alice::BtcCancelled {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 state3: state3.as_ref().clone(),
             },
             AliceState::BtcRefunded {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 spend_key,
                 state3,
             } => Alice::BtcRefunded {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 spend_key: *spend_key,
                 state3: state3.as_ref().clone(),
             },
             AliceState::BtcPunishable {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
-                ..
             } => Alice::BtcPunishable {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 state3: state3.as_ref().clone(),
             },
             AliceState::XmrRefunded => Alice::Done(AliceEndState::XmrRefunded),
             AliceState::CancelTimelockExpired {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => Alice::CancelTimelockExpired {
                 monero_wallet_restore_blockheight: *monero_wallet_restore_blockheight,
+                transfer_proof: transfer_proof.clone(),
                 state3: state3.as_ref().clone(),
             },
             AliceState::BtcPunished => Alice::Done(AliceEndState::BtcPunished),
@@ -178,48 +194,60 @@ impl From<Alice> for AliceState {
             },
             Alice::XmrLockTransferProofSent {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => AliceState::XmrLockTransferProofSent {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: Box::new(state3),
             },
             Alice::EncSigLearned {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: state,
                 encrypted_signature,
             } => AliceState::EncSigLearned {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: Box::new(state),
                 encrypted_signature: Box::new(encrypted_signature),
             },
             Alice::CancelTimelockExpired {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => AliceState::CancelTimelockExpired {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: Box::new(state3),
             },
             Alice::BtcCancelled {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => AliceState::BtcCancelled {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: Box::new(state3),
             },
 
             Alice::BtcPunishable {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3,
             } => AliceState::BtcPunishable {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 state3: Box::new(state3),
             },
             Alice::BtcRefunded {
                 monero_wallet_restore_blockheight,
-                state3,
+                transfer_proof,
                 spend_key,
+                state3,
             } => AliceState::BtcRefunded {
                 monero_wallet_restore_blockheight,
+                transfer_proof,
                 spend_key,
                 state3: Box::new(state3),
             },

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -22,7 +22,17 @@ pub enum AliceState {
     BtcLocked {
         state3: Box<State3>,
     },
+    XmrLockTransactionSent {
+        monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
+        state3: Box<State3>,
+    },
     XmrLocked {
+        monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
+        state3: Box<State3>,
+    },
+    XmrLockTransferProofSent {
         monero_wallet_restore_blockheight: BlockHeight,
         state3: Box<State3>,
     },
@@ -59,7 +69,11 @@ impl fmt::Display for AliceState {
         match self {
             AliceState::Started { .. } => write!(f, "started"),
             AliceState::BtcLocked { .. } => write!(f, "btc is locked"),
+            AliceState::XmrLockTransactionSent { .. } => write!(f, "xmr lock transaction sent"),
             AliceState::XmrLocked { .. } => write!(f, "xmr is locked"),
+            AliceState::XmrLockTransferProofSent { .. } => {
+                write!(f, "xmr lock transfer proof sent")
+            }
             AliceState::EncSigLearned { .. } => write!(f, "encrypted signature is learned"),
             AliceState::BtcRedeemed => write!(f, "btc is redeemed"),
             AliceState::BtcCancelled { .. } => write!(f, "btc is cancelled"),

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -34,30 +34,36 @@ pub enum AliceState {
     },
     XmrLockTransferProofSent {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: Box<State3>,
     },
     EncSigLearned {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         encrypted_signature: Box<bitcoin::EncryptedSignature>,
         state3: Box<State3>,
     },
     BtcRedeemed,
     BtcCancelled {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: Box<State3>,
     },
     BtcRefunded {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         spend_key: monero::PrivateKey,
         state3: Box<State3>,
     },
     BtcPunishable {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: Box<State3>,
     },
     XmrRefunded,
     CancelTimelockExpired {
         monero_wallet_restore_blockheight: BlockHeight,
+        transfer_proof: TransferProof,
         state3: Box<State3>,
     },
     BtcPunished,

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -5,6 +5,7 @@ use crate::env::Config;
 use crate::protocol::alice;
 use crate::protocol::alice::event_loop::EventLoopHandle;
 use crate::protocol::alice::AliceState;
+use crate::protocol::alice::AliceState::XmrLockTransferProofSent;
 use crate::{bitcoin, database, monero};
 use anyhow::{bail, Context, Result};
 use rand::{CryptoRng, RngCore};
@@ -88,43 +89,76 @@ async fn next_state(
                 }
             }
         }
-        AliceState::BtcLocked { state3 } => match state3
-            .expired_timelocks(bitcoin_wallet)
-            .await?
-        {
+        AliceState::BtcLocked { state3 } => {
+            match state3.expired_timelocks(bitcoin_wallet).await? {
+                ExpiredTimelocks::None => {
+                    // Record the current monero wallet block height so we don't have to scan from
+                    // block 0 for scenarios where we create a refund wallet.
+                    let monero_wallet_restore_blockheight = monero_wallet.block_height().await?;
+
+                    let transfer_proof = monero_wallet
+                        .transfer(state3.lock_xmr_transfer_request())
+                        .await?;
+
+                    AliceState::XmrLockTransactionSent {
+                        state3,
+                        transfer_proof,
+                        monero_wallet_restore_blockheight,
+                    }
+                }
+                _ => AliceState::SafelyAborted,
+            }
+        }
+        AliceState::XmrLockTransactionSent {
+            monero_wallet_restore_blockheight,
+            transfer_proof,
+            state3,
+        } => match state3.expired_timelocks(bitcoin_wallet).await? {
             ExpiredTimelocks::None => {
-                // Record the current monero wallet block height so we don't have to scan from
-                // block 0 for scenarios where we create a refund wallet.
-                let monero_wallet_restore_blockheight = monero_wallet.block_height().await?;
-
-                let transfer_proof = monero_wallet
-                    .transfer(state3.lock_xmr_transfer_request())
-                    .await?;
-
                 monero_wallet
                     .watch_for_transfer(state3.lock_xmr_watch_request(transfer_proof.clone(), 1))
-                    .await?;
-
-                // TODO: Waiting for XMR confirmations should be done in a separate
-                //  state! We have to record that Alice has already sent the transaction.
-                //  Otherwise Alice might publish the lock tx twice!
-
-                event_loop_handle
-                    .send_transfer_proof(transfer_proof.clone())
-                    .await?;
-
-                monero_wallet
-                    .watch_for_transfer(state3.lock_xmr_watch_request(transfer_proof, 10))
                     .await?;
 
                 AliceState::XmrLocked {
                     state3,
                     monero_wallet_restore_blockheight,
+                    transfer_proof,
                 }
             }
-            _ => AliceState::SafelyAborted,
+            _ => AliceState::CancelTimelockExpired {
+                state3,
+                monero_wallet_restore_blockheight,
+            },
         },
+
         AliceState::XmrLocked {
+            state3,
+            transfer_proof,
+            monero_wallet_restore_blockheight,
+        } => match state3.expired_timelocks(bitcoin_wallet).await? {
+            ExpiredTimelocks::None => {
+                event_loop_handle
+                    .send_transfer_proof(transfer_proof.clone())
+                    .await?;
+
+                // TODO: Handle this upon refund instead.
+                //  Make sure that the balance of the created wallet is unlocked instead of
+                //  watching for transfer.
+                monero_wallet
+                    .watch_for_transfer(state3.lock_xmr_watch_request(transfer_proof, 10))
+                    .await?;
+
+                XmrLockTransferProofSent {
+                    state3,
+                    monero_wallet_restore_blockheight,
+                }
+            }
+            _ => AliceState::CancelTimelockExpired {
+                state3,
+                monero_wallet_restore_blockheight,
+            },
+        },
+        AliceState::XmrLockTransferProofSent {
             state3,
             monero_wallet_restore_blockheight,
         } => {

--- a/swap/src/protocol/bob/cancel.rs
+++ b/swap/src/protocol/bob/cancel.rs
@@ -26,7 +26,14 @@ pub async fn cancel(
         BobState::XmrLocked(state4) => state4.cancel(),
         BobState::EncSigSent(state4) => state4.cancel(),
         BobState::CancelTimelockExpired(state6) => state6,
-        _ => bail!(
+        BobState::Started { .. }
+        | BobState::ExecutionSetupDone(_)
+        | BobState::BtcRedeemed(_)
+        | BobState::BtcCancelled(_)
+        | BobState::BtcRefunded(_)
+        | BobState::XmrRedeemed { .. }
+        | BobState::BtcPunished { .. }
+        | BobState::SafelyAborted => bail!(
             "Cannot cancel swap {} because it is in state {} which is not refundable.",
             swap_id,
             state

--- a/swap/src/protocol/bob/refund.rs
+++ b/swap/src/protocol/bob/refund.rs
@@ -24,7 +24,13 @@ pub async fn refund(
             BobState::EncSigSent(state4) => state4.cancel(),
             BobState::CancelTimelockExpired(state6) => state6,
             BobState::BtcCancelled(state6) => state6,
-            _ => bail!(
+            BobState::Started { .. }
+            | BobState::ExecutionSetupDone(_)
+            | BobState::BtcRedeemed(_)
+            | BobState::BtcRefunded(_)
+            | BobState::XmrRedeemed { .. }
+            | BobState::BtcPunished { .. }
+            | BobState::SafelyAborted => bail!(
                 "Cannot refund swap {} because it is in state {} which is not refundable.",
                 swap_id,
                 state

--- a/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
+++ b/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
@@ -1,0 +1,62 @@
+pub mod harness;
+
+use harness::alice_run_until::is_xmr_lock_transaction_sent;
+use harness::bob_run_until::is_btc_locked;
+use harness::FastPunishConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+/// Bob locks Btc and Alice locks Xmr. Bob does not act; he fails to send Alice
+/// the encsig and fail to refund or redeem. Alice punishes.
+#[tokio::test]
+async fn alice_punishes_after_restart_if_punish_timelock_expired() {
+    harness::setup_test(FastPunishConfig, |mut ctx| async move {
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_bitcoin_wallet = alice_swap.bitcoin_wallet.clone();
+
+        let alice_swap = tokio::spawn(alice::run_until(alice_swap, is_xmr_lock_transaction_sent));
+
+        let bob_state = bob_swap.await??;
+        assert!(matches!(bob_state, BobState::BtcLocked { .. }));
+
+        let alice_state = alice_swap.await??;
+
+        // Ensure punish timelock is expired
+        if let AliceState::XmrLockTransactionSent { state3, .. } = alice_state {
+            alice_bitcoin_wallet
+                .subscribe_to(state3.tx_lock)
+                .await
+                .wait_until_confirmed_with(state3.punish_timelock)
+                .await?;
+        } else {
+            panic!(
+                "\
+            Alice in unexpected state {}",
+                alice_state
+            );
+        }
+
+        ctx.restart_alice().await;
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
+
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_punished(alice_state).await;
+
+        // Restart Bob after Alice punished to ensure Bob transitions to
+        // punished and does not run indefinitely
+        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
+
+        let bob_state = bob::run(bob_swap).await?;
+
+        ctx.assert_bob_punished(bob_state).await;
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/alice_refunds_after_restart_bob_refunded.rs
+++ b/swap/tests/alice_refunds_after_restart_bob_refunded.rs
@@ -1,0 +1,38 @@
+pub mod harness;
+
+use harness::alice_run_until::is_xmr_lock_transaction_sent;
+use harness::FastCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::{alice, bob};
+
+/// Bob locks Btc and Alice locks Xmr. Alice does not act so Bob refunds.
+/// Eventually Alice comes back online and refunds as well.
+#[tokio::test]
+async fn alice_refunds_after_restart_if_bob_already_refunded() {
+    harness::setup_test(FastCancelConfig, |mut ctx| async move {
+        let (bob_swap, _) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run(bob_swap));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run_until(alice_swap, is_xmr_lock_transaction_sent));
+
+        let bob_state = bob_swap.await??;
+        ctx.assert_bob_refunded(bob_state).await;
+
+        let alice_state = alice_swap.await??;
+        assert!(matches!(
+            alice_state,
+            AliceState::XmrLockTransactionSent { .. }
+        ));
+
+        ctx.restart_alice().await;
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap));
+
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_refunded(alice_state).await;
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
+++ b/swap/tests/bob_refunds_using_cancel_and_refund_command.rs
@@ -19,7 +19,7 @@ async fn given_bob_manually_refunds_after_btc_locked_bob_refunds() {
 
         let (bob_swap, bob_join_handle) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
 
-        // Ensure Bob's timelock is expired
+        // Ensure cancel timelock is expired
         if let BobState::BtcLocked(state3) = bob_swap.state.clone() {
             bob_swap
                 .bitcoin_wallet

--- a/swap/tests/happy_path_restart_alice_after_xmr_locked.rs
+++ b/swap/tests/happy_path_restart_alice_after_xmr_locked.rs
@@ -1,0 +1,40 @@
+pub mod harness;
+
+use harness::alice_run_until::is_xmr_lock_transaction_sent;
+use harness::SlowCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::{alice, bob};
+
+#[tokio::test]
+async fn given_alice_restarts_after_xmr_is_locked_resume_swap() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap, _) = ctx.bob_swap().await;
+        let bob_swap = tokio::spawn(bob::run(bob_swap));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run_until(alice_swap, is_xmr_lock_transaction_sent));
+
+        let alice_state = alice_swap.await??;
+
+        assert!(matches!(
+            alice_state,
+            AliceState::XmrLockTransactionSent { .. }
+        ));
+
+        ctx.restart_alice().await;
+        let alice_swap = ctx.alice_next_swap().await;
+        assert!(matches!(
+            alice_swap.state,
+            AliceState::XmrLockTransactionSent { .. }
+        ));
+
+        let alice_state = alice::run(alice_swap).await?;
+        ctx.assert_alice_redeemed(alice_state).await;
+
+        let bob_state = bob_swap.await??;
+        ctx.assert_bob_redeemed(bob_state).await;
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -835,7 +835,7 @@ pub struct FastCancelConfig;
 impl GetConfig for FastCancelConfig {
     fn get_config() -> Config {
         Config {
-            bitcoin_cancel_timelock: CancelTimelock::new(1),
+            bitcoin_cancel_timelock: CancelTimelock::new(10),
             ..env::Regtest::get_config()
         }
     }
@@ -846,7 +846,7 @@ pub struct FastPunishConfig;
 impl GetConfig for FastPunishConfig {
     fn get_config() -> Config {
         Config {
-            bitcoin_cancel_timelock: CancelTimelock::new(1),
+            bitcoin_cancel_timelock: CancelTimelock::new(10),
             bitcoin_punish_timelock: PunishTimelock::new(1),
             ..env::Regtest::get_config()
         }

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -790,8 +790,8 @@ struct Containers<'a> {
 pub mod alice_run_until {
     use swap::protocol::alice::AliceState;
 
-    pub fn is_xmr_locked(state: &AliceState) -> bool {
-        matches!(state, AliceState::XmrLocked { .. })
+    pub fn is_xmr_lock_transaction_sent(state: &AliceState) -> bool {
+        matches!(state, AliceState::XmrLockTransactionSent { .. })
     }
 
     pub fn is_encsig_learned(state: &AliceState) -> bool {


### PR DESCRIPTION
Fixes #374 

- [x] Save Bob peer-id in database for Alice
- [x]  Alice: Wait for `10` Monero confirmations in `BtcRefunded` instead of `XmrLocked` (requires extending the RPC to distinguish locked / unlocked balance)
- [x] Save Alice peer-id in database for Bob ~~(+ multiaddress and remove params from resume)~~
- [ ] ~~Refactor Bob in test setup (handle event-loop in test setup similar to Alice)~~

I decided against refactoring Bob in the test setup, because eventually we might still want to add concurrent swap tests with multiple Bobs. The refactoring I had in mind would not allow such kind of tests. 
Generally, the current state of the changes already contains enough added value to open the PR :)

Follow ups out of scope

- [ ] Parametrize database with role (Alice / Bob) and remove all the (currently useless) mapping between DB and protocol types.
- [ ]  Alice: Wait for transfer proof ack before transitioning to new `XmrLocked`