### PR TITLE
Use language agnostic heuristic to check if monero_wallet_rpc is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A changelog file.
 
+### Fixed
+
+- Make monero_wallet_rpc readiness check language agnostic. The readiness check was
+  failing on non-english language systems preventing users from starting the swap-cli
+  and asb.
+
 [Unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/v0.3...HEAD

--- a/monero-rpc/src/rpc/wallet.rs
+++ b/monero-rpc/src/rpc/wallet.rs
@@ -357,6 +357,24 @@ impl Client {
         let r = serde_json::from_str::<Response<SweepAll>>(&response)?;
         Ok(r.result)
     }
+
+    pub async fn get_version(&self) -> Result<Version> {
+        let request = Request::new("get_version", "");
+
+        let response = self
+            .inner
+            .post(self.url.clone())
+            .json(&request)
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        debug!("get_version RPC response: {}", response);
+
+        let r = serde_json::from_str::<Response<Version>>(&response)?;
+        Ok(r.result)
+    }
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -510,6 +528,11 @@ pub struct SweepAll {
     pub tx_hash_list: Vec<String>,
     unsigned_txset: String,
     weight_list: Vec<u32>,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+pub struct Version {
+    version: u32,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Our strategy of searching for a english string to determine if
monero_wallet_rpc is ready is not compatible with languages other than
english. Instead we assume the monero rpc is ready if it has stopped
writing to stdout. We make a json rpc request to confirm this. A better
solution would have been to configure the monero_wallet_rpc to always
output in english but there is not command line argument to configure
the language.

Closes #353.

NOTE: will squash after approved