### PR TITLE
Re-word changelog entry for bad readiness check of monero-wallet-rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Make monero_wallet_rpc readiness check language agnostic. The readiness check was
-  failing on non-english language systems preventing users from starting the swap-cli
-  and asb.
+- An [issue](https://github.com/comit-network/xmr-btc-swap/issues/353) where the `swap` CLI would fail on systems that were set to a locale different than English.
+  A bad readiness check when waiting for `monero-wallet-rpc` to be ready caused the CLI to hang forever, preventing users from perform a swap.
 
 ### Security
 


### PR DESCRIPTION
Fix the formatting to be one line per sentence and re-word to focus on what didn't work for the user.