### PR TITLE
Remove default connection details from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic resume of unfinished swaps for the `asb` upon startup.
   Unfinished swaps from earlier versions will be skipped.
 
+### Changed
+
+- Require the buyer to specify the connection details of the peer they wish to swap with.
+  Throughout the public demo phase of this project, the CLI traded with us by default if the peer id and multiaddress of the seller were not specified.
+  Having the defaults made it easy for us to give something to the community that can easily be tested, however it is not aligned with our long-term vision of a decentralised network of sellers.
+  We have removed these defaults forcing the user to specify the seller they wish to trade with.
+
 ### Fixed
 
 - An [issue](https://github.com/comit-network/xmr-btc-swap/issues/353) where the `swap` CLI would fail on systems that were set to a locale different than English.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ More information about the protocol in this [presentation](https://youtu.be/Jj8r
 ## Quick start - CLI
 
 1. Download the [latest `swap` binary release](https://github.com/comit-network/xmr-btc-swap/releases/latest) for your operating system
-2. Run the binary: `./swap buy-xmr --receive-address <YOUR MONERO ADDRESS>`
+2. Run the binary specifying the monero address where you wish to receive monero and the connection details of the seller:
+   `./swap buy-xmr --receive-address <YOUR MONERO ADDRESS> --seller-peer-id <SELLERS PEER ID> --seller-multiaddr <SELLERS MULTIADDRESS>`
+   You can generate a receive address using your monero wallet.
+   The seller will provide you their peer id and multiaddress.
+   We are running an `asb` instance on testnet.
+   You can swap with to get familiar with the `swap` CLI.
+   Our peer id is `12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi` and our multiaddress is `/dns4/xmr-btc-asb.coblox.tech/tcp/9876`
 3. Follow the instructions printed to the terminal
 
 ## Limitations

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use structopt::StructOpt;
 use swap::bitcoin::{Amount, TxLock};
-use swap::cli::command::{AliceMultiaddress, Arguments, Command, Data, MoneroParams};
+use swap::cli::command::{Arguments, Command, Data, MoneroParams};
 use swap::database::Database;
 use swap::env::{Config, GetConfig};
 use swap::network::quote::BidQuote;
@@ -82,10 +82,7 @@ async fn main() -> Result<()> {
     match args.cmd {
         Command::BuyXmr {
             alice_peer_id,
-            alice_multi_addr:
-                AliceMultiaddress {
-                    multiaddr: alice_addr,
-                },
+            alice_multiaddr,
             monero_params:
                 MoneroParams {
                     receive_monero_address,
@@ -108,7 +105,7 @@ async fn main() -> Result<()> {
             let bitcoin_wallet = Arc::new(bitcoin_wallet);
 
             let mut swarm = swarm::new::<Behaviour>(&seed)?;
-            swarm.add_address(alice_peer_id, alice_addr);
+            swarm.add_address(alice_peer_id, alice_multiaddr);
 
             let (event_loop, mut event_loop_handle) =
                 EventLoop::new(swarm, alice_peer_id, bitcoin_wallet.clone())?;
@@ -170,10 +167,7 @@ async fn main() -> Result<()> {
         }
         Command::Resume {
             swap_id,
-            alice_multi_addr:
-                AliceMultiaddress {
-                    multiaddr: alice_addr,
-                },
+            alice_multiaddr,
             monero_params:
                 MoneroParams {
                     receive_monero_address,
@@ -193,7 +187,7 @@ async fn main() -> Result<()> {
 
             let alice_peer_id = db.get_peer_id(swap_id)?;
             let mut swarm = swarm::new::<Behaviour>(&seed)?;
-            swarm.add_address(alice_peer_id, alice_addr);
+            swarm.add_address(alice_peer_id, alice_multiaddr);
 
             let (event_loop, event_loop_handle) =
                 EventLoop::new(swarm, alice_peer_id, bitcoin_wallet.clone())?;

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -7,9 +7,6 @@ use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
 
-pub const DEFAULT_ALICE_MULTIADDR: &str = "/dns4/xmr-btc-asb.coblox.tech/tcp/9876";
-pub const DEFAULT_ALICE_PEER_ID: &str = "12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi";
-
 // Port is assumed to be stagenet standard port 38081
 pub const DEFAULT_STAGENET_MONERO_DAEMON_HOST: &str = "monero-stagenet.exan.tech";
 
@@ -37,18 +34,10 @@ pub struct Arguments {
 pub enum Command {
     /// Start a XMR for BTC swap
     BuyXmr {
-        #[structopt(
-        long = "seller-peer-id",
-        default_value = DEFAULT_ALICE_PEER_ID,
-        help = "The peer id of a specific swap partner can be optionally provided"
-        )]
+        #[structopt(long = "seller-peer-id", help = "The seller's peer id")]
         alice_peer_id: PeerId,
 
-        #[structopt(
-        long = "seller-addr",
-        default_value = DEFAULT_ALICE_MULTIADDR,
-        help = "The multiaddr of a specific swap partner can be optionally provided"
-        )]
+        #[structopt(long = "seller-addr", help = "The seller's multiaddress")]
         alice_multiaddr: Multiaddr,
 
         #[structopt(long = "electrum-rpc",
@@ -70,11 +59,7 @@ pub enum Command {
         )]
         swap_id: Uuid,
 
-        #[structopt(
-        long = "seller-addr",
-        default_value = DEFAULT_ALICE_MULTIADDR,
-        help = "The multiaddr of a specific swap partner can be optionally provided"
-        )]
+        #[structopt(long = "seller-addr", help = "The seller's multiaddress")]
         alice_multiaddr: Multiaddr,
 
         #[structopt(long = "electrum-rpc",
@@ -172,25 +157,4 @@ fn parse_monero_address(s: &str) -> Result<monero::Address> {
             s
         )
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::cli::command::{DEFAULT_ALICE_MULTIADDR, DEFAULT_ALICE_PEER_ID};
-    use libp2p::core::Multiaddr;
-    use libp2p::PeerId;
-
-    #[test]
-    fn parse_default_alice_peer_id_success() {
-        DEFAULT_ALICE_PEER_ID
-            .parse::<PeerId>()
-            .expect("default alice peer id str is a valid PeerId");
-    }
-
-    #[test]
-    fn parse_default_alice_multiaddr_success() {
-        DEFAULT_ALICE_MULTIADDR
-            .parse::<Multiaddr>()
-            .expect("default alice multiaddr str is a valid Multiaddr>");
-    }
 }

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -44,8 +44,12 @@ pub enum Command {
         )]
         alice_peer_id: PeerId,
 
-        #[structopt(flatten)]
-        alice_multi_addr: AliceMultiaddress,
+        #[structopt(
+        long = "seller-addr",
+        default_value = DEFAULT_ALICE_MULTIADDR,
+        help = "The multiaddr of a specific swap partner can be optionally provided"
+        )]
+        alice_multiaddr: Multiaddr,
 
         #[structopt(long = "electrum-rpc",
         help = "Provide the Bitcoin Electrum RPC URL",
@@ -66,8 +70,12 @@ pub enum Command {
         )]
         swap_id: Uuid,
 
-        #[structopt(flatten)]
-        alice_multi_addr: AliceMultiaddress,
+        #[structopt(
+        long = "seller-addr",
+        default_value = DEFAULT_ALICE_MULTIADDR,
+        help = "The multiaddr of a specific swap partner can be optionally provided"
+        )]
+        alice_multiaddr: Multiaddr,
 
         #[structopt(long = "electrum-rpc",
         help = "Provide the Bitcoin Electrum RPC URL",
@@ -112,16 +120,6 @@ pub enum Command {
         )]
         electrum_rpc_url: Url,
     },
-}
-
-#[derive(structopt::StructOpt, Debug)]
-pub struct AliceMultiaddress {
-    #[structopt(
-        long = "seller-addr",
-        default_value = DEFAULT_ALICE_MULTIADDR,
-        help = "The multiaddr of a specific swap partner can be optionally provided"
-    )]
-    pub multiaddr: Multiaddr,
 }
 
 #[derive(structopt::StructOpt, Debug)]


### PR DESCRIPTION
Connecting buyers to us by default is not consistent with our vision of
a decentralised network of sellers.

Closes #395