### PR TITLE
Remodel `EventLoop` as a future instead of as a struct

### DIFF
--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -27,7 +27,7 @@ use swap::env::{Config, GetConfig};
 use swap::network::quote::BidQuote;
 use swap::network::swarm;
 use swap::protocol::bob;
-use swap::protocol::bob::{Behaviour, Builder, EventLoop};
+use swap::protocol::bob::{event_loop, Behaviour, Builder};
 use swap::seed::Seed;
 use swap::{bitcoin, cli, env, monero};
 use tracing::{debug, error, info, warn};
@@ -81,8 +81,8 @@ async fn main() -> Result<()> {
 
             let swap_id = Uuid::new_v4();
             let (event_loop, mut event_loop_handle) =
-                EventLoop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
-            let event_loop = tokio::spawn(event_loop.run());
+                event_loop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
+            let event_loop = tokio::spawn(event_loop);
 
             let send_bitcoin = determine_btc_to_swap(
                 event_loop_handle.request_quote(),
@@ -175,8 +175,8 @@ async fn main() -> Result<()> {
             swarm.add_address(alice_peer_id, alice_multiaddr);
 
             let (event_loop, event_loop_handle) =
-                EventLoop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
-            let handle = tokio::spawn(event_loop.run());
+                event_loop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
+            let handle = tokio::spawn(event_loop);
 
             let swap = Builder::new(
                 db,

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -192,12 +192,6 @@ pub struct InsufficientFunds {
     pub actual: Amount,
 }
 
-#[derive(Debug, Clone, Copy, thiserror::Error)]
-#[error("The balance is too low, current balance: {balance}")]
-pub struct BalanceTooLow {
-    pub balance: Amount,
-}
-
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[error("Overflow, cannot convert {0} to u64")]
 pub struct OverflowError(pub String);

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub use self::behaviour::{Behaviour, OutEvent};
-pub use self::event_loop::{EventLoop, EventLoopHandle};
+pub use self::event_loop::EventLoopHandle;
 pub use self::state::*;
 pub use self::swap::{run, run_until};
 

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub use self::cancel::cancel;
-pub use self::event_loop::{EventLoop, EventLoopHandle};
+pub use self::event_loop::EventLoopHandle;
 pub use self::refund::refund;
 pub use self::state::*;
 pub use self::swap::{run, run_until};

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -4,8 +4,10 @@ use crate::network::{encrypted_signature, spot_price};
 use crate::protocol::bob::{Behaviour, OutEvent, State0, State2};
 use crate::{bitcoin, monero};
 use anyhow::{Context, Result};
-use futures::future::OptionFuture;
+use bmrng::{RequestReceiverStream, RequestSender};
+use futures::future::{BoxFuture, OptionFuture};
 use futures::{FutureExt, StreamExt};
+use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{PeerId, Swarm};
 use std::collections::HashMap;
@@ -20,38 +22,9 @@ pub fn new(
     alice_peer_id: PeerId,
     bitcoin_wallet: Arc<bitcoin::Wallet>,
 ) -> Result<(impl Future<Output = ()>, EventLoopHandle)> {
-    let execution_setup = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-    let (transfer_proof_sender, transfer_proof_receiver) =
-        bmrng::channel_with_timeout(1, Duration::from_secs(30));
-    let encrypted_signature = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-    let spot_price = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-    let quote = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-
-    let mut spot_price_requests = spot_price.1.into_stream();
-    let mut quote_requests = quote.1.into_stream();
-    let mut execution_setup_requests = execution_setup.1.into_stream();
-    let mut encrypted_signature_requests = encrypted_signature.1.into_stream();
+    let (mut state, handle) = State::new();
 
     let event_loop = async move {
-        // these represents requests that are currently in-flight.
-        // once we get a response to a matching [`RequestId`], we will use the responder
-        // to relay the response.
-        let mut inflight_spot_price_requests =
-            HashMap::<_, bmrng::Responder<spot_price::Response>>::new();
-        let mut inflight_quote_requests = HashMap::<_, bmrng::Responder<BidQuote>>::new();
-        let mut inflight_encrypted_signature_requests = HashMap::<_, bmrng::Responder<()>>::new();
-        let mut inflight_execution_setup = Option::<bmrng::Responder<Result<State2>>>::None;
-
-        // The future representing the successful handling of an incoming
-        // transfer proof.
-        //
-        // Once we've sent a transfer proof to the ongoing swap, this future
-        // waits until the swap took it "out" of the `EventLoopHandle`.
-        // As this future resolves, we use the `ResponseChannel`
-        // returned from it to send an ACK to Alice that we have
-        // successfully processed the transfer proof.
-        let mut pending_transfer_proof = OptionFuture::from(None);
-
         let _ = Swarm::dial(&mut swarm, &alice_peer_id);
 
         loop {
@@ -62,22 +35,22 @@ pub fn new(
                 swarm_event = swarm.next_event().fuse() => {
                     match swarm_event {
                         SwarmEvent::Behaviour(OutEvent::SpotPriceReceived { id, response }) => {
-                            if let Some(responder) = inflight_spot_price_requests.remove(&id) {
+                            if let Some(responder) = state.inflight_spot_price_requests.remove(&id) {
                                 let _ = responder.respond(response);
                             }
                         }
                         SwarmEvent::Behaviour(OutEvent::QuoteReceived { id, response }) => {
-                            if let Some(responder) = inflight_quote_requests.remove(&id) {
+                            if let Some(responder) = state.inflight_quote_requests.remove(&id) {
                                 let _ = responder.respond(response);
                             }
                         }
                         SwarmEvent::Behaviour(OutEvent::ExecutionSetupDone(response)) => {
-                            if let Some(responder) = inflight_execution_setup.take() {
+                            if let Some(responder) = state.inflight_execution_setup.take() {
                                 let _ = responder.respond(*response);
                             }
                         }
                         SwarmEvent::Behaviour(OutEvent::EncryptedSignatureAcknowledged { id }) => {
-                            if let Some(responder) = inflight_encrypted_signature_requests.remove(&id) {
+                            if let Some(responder) = state.inflight_encrypted_signature_requests.remove(&id) {
                                 let _ = responder.respond(());
                             }
                         }
@@ -92,7 +65,7 @@ pub fn new(
                                 continue;
                             }
 
-                            let mut responder = match transfer_proof_sender.send(msg.tx_lock_proof).await {
+                            let mut responder = match state.transfer_proof_sender.send(msg.tx_lock_proof).await {
                                 Ok(responder) => responder,
                                 Err(e) => {
                                     tracing::warn!("Failed to pass on transfer proof: {:#}", e);
@@ -100,7 +73,7 @@ pub fn new(
                                 }
                             };
 
-                            pending_transfer_proof = OptionFuture::from(Some(async move {
+                            state.pending_transfer_proof = OptionFuture::from(Some(async move {
                                 let _ = responder.recv().await;
 
                                 channel
@@ -144,45 +117,103 @@ pub fn new(
 
                 // Handle to-be-sent requests for all our network protocols.
                 // Use `is_connected_to_alice` as a guard to "buffer" requests until we are connected.
-                Some((request, responder)) = spot_price_requests.next().fuse(), if is_connected_to_alice => {
+                Some((request, responder)) = state.spot_price_requests.next().fuse(), if is_connected_to_alice => {
                     let id = swarm.spot_price.send_request(&alice_peer_id, request);
-                    inflight_spot_price_requests.insert(id, responder);
+                    state.inflight_spot_price_requests.insert(id, responder);
                 },
-                Some(((), responder)) = quote_requests.next().fuse(), if is_connected_to_alice => {
+                Some(((), responder)) = state.quote_requests.next().fuse(), if is_connected_to_alice => {
                     let id = swarm.quote.send_request(&alice_peer_id, ());
-                    inflight_quote_requests.insert(id, responder);
+                    state.inflight_quote_requests.insert(id, responder);
                 },
-                Some((request, responder)) = execution_setup_requests.next().fuse(), if is_connected_to_alice => {
+                Some((request, responder)) = state.execution_setup_requests.next().fuse(), if is_connected_to_alice => {
                     swarm.execution_setup.run(alice_peer_id, request, bitcoin_wallet.clone());
-                    inflight_execution_setup = Some(responder);
+                    state.inflight_execution_setup = Some(responder);
                 },
-                Some((tx_redeem_encsig, responder)) = encrypted_signature_requests.next().fuse(), if is_connected_to_alice => {
+                Some((tx_redeem_encsig, responder)) = state.encrypted_signature_requests.next().fuse(), if is_connected_to_alice => {
                     let request = encrypted_signature::Request {
                         swap_id,
                         tx_redeem_encsig
                     };
                     let id = swarm.encrypted_signature.send_request(&alice_peer_id, request);
-                    inflight_encrypted_signature_requests.insert(id, responder);
+                    state.inflight_encrypted_signature_requests.insert(id, responder);
                 },
 
-                Some(response_channel) = &mut pending_transfer_proof => {
+                Some(response_channel) = &mut state.pending_transfer_proof => {
                     let _ = swarm.transfer_proof.send_response(response_channel, ());
 
-                    pending_transfer_proof = OptionFuture::from(None);
+                    state.pending_transfer_proof = OptionFuture::from(None);
                 }
             }
         }
     };
 
-    let handle = EventLoopHandle {
-        execution_setup: execution_setup.0,
-        transfer_proof: transfer_proof_receiver,
-        encrypted_signature: encrypted_signature.0,
-        spot_price: spot_price.0,
-        quote: quote.0,
-    };
-
     Ok((event_loop, handle))
+}
+
+/// Holds the event-loop state.
+///
+/// All fields within this struct could also just be local variables in the
+/// event loop. Bundling them up in a struct allows us to add documentation to
+/// some of the fields which makes it clearer what they are used for.
+struct State {
+    // these represents requests that are currently in-flight.
+    // once we get a response to a matching [`RequestId`], we will use the responder
+    // to relay the response.
+    inflight_spot_price_requests: HashMap<RequestId, bmrng::Responder<spot_price::Response>>,
+    inflight_quote_requests: HashMap<RequestId, bmrng::Responder<BidQuote>>,
+    inflight_encrypted_signature_requests: HashMap<RequestId, bmrng::Responder<()>>,
+    inflight_execution_setup: Option<bmrng::Responder<Result<State2>>>,
+
+    spot_price_requests: RequestReceiverStream<spot_price::Request, spot_price::Response>,
+    quote_requests: RequestReceiverStream<(), BidQuote>,
+    execution_setup_requests: RequestReceiverStream<State0, Result<State2>>,
+    encrypted_signature_requests: RequestReceiverStream<bitcoin::EncryptedSignature, ()>,
+
+    /// The future representing the successful handling of an incoming
+    /// transfer proof.
+    ///
+    /// Once we've sent a transfer proof to the ongoing swap, this future
+    /// waits until the swap took it "out" of the `EventLoopHandle`.
+    /// As this future resolves, we use the `ResponseChannel`
+    /// returned from it to send an ACK to Alice that we have
+    /// successfully processed the transfer proof.
+    pending_transfer_proof: OptionFuture<BoxFuture<'static, ResponseChannel<()>>>,
+
+    transfer_proof_sender: RequestSender<monero::TransferProof, ()>,
+}
+
+impl State {
+    fn new() -> (Self, EventLoopHandle) {
+        let execution_setup = bmrng::channel_with_timeout(1, Duration::from_secs(30));
+        let (transfer_proof_sender, transfer_proof_receiver) =
+            bmrng::channel_with_timeout(1, Duration::from_secs(30));
+        let encrypted_signature = bmrng::channel_with_timeout(1, Duration::from_secs(30));
+        let spot_price = bmrng::channel_with_timeout(1, Duration::from_secs(30));
+        let quote = bmrng::channel_with_timeout(1, Duration::from_secs(30));
+
+        let state = State {
+            inflight_spot_price_requests: Default::default(),
+            inflight_quote_requests: Default::default(),
+            inflight_encrypted_signature_requests: Default::default(),
+            inflight_execution_setup: None,
+            spot_price_requests: spot_price.1.into(),
+            quote_requests: quote.1.into(),
+            execution_setup_requests: execution_setup.1.into(),
+            encrypted_signature_requests: encrypted_signature.1.into(),
+            pending_transfer_proof: OptionFuture::from(None),
+            transfer_proof_sender,
+        };
+
+        let handle = EventLoopHandle {
+            execution_setup: execution_setup.0,
+            transfer_proof: transfer_proof_receiver,
+            encrypted_signature: encrypted_signature.0,
+            spot_price: spot_price.0,
+            quote: quote.0,
+        };
+
+        (state, handle)
+    }
 }
 
 #[derive(Debug)]

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -141,9 +141,6 @@ impl EventLoop {
                                 let _ = responder.respond(());
                             }
                         }
-                        SwarmEvent::Behaviour(OutEvent::ResponseSent) => {
-
-                        }
                         SwarmEvent::Behaviour(OutEvent::CommunicationError(error)) => {
                             tracing::warn!("Communication error: {:#}", error);
                             return;

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -114,11 +114,14 @@ impl BobParams {
         ))
     }
 
-    pub fn new_eventloop(&self, swap_id: Uuid) -> Result<(bob::EventLoop, bob::EventLoopHandle)> {
+    pub fn new_eventloop(
+        &self,
+        swap_id: Uuid,
+    ) -> Result<(impl Future<Output = ()>, bob::EventLoopHandle)> {
         let mut swarm = swarm::new::<bob::Behaviour>(&self.seed)?;
         swarm.add_address(self.alice_peer_id, self.alice_address.clone());
 
-        bob::EventLoop::new(
+        bob::event_loop::new(
             swap_id,
             swarm,
             self.alice_peer_id,
@@ -208,7 +211,7 @@ impl TestContext {
         // ensure the wallet is up to date for concurrent swap tests
         swap.bitcoin_wallet.sync().await.unwrap();
 
-        let join_handle = tokio::spawn(event_loop.run());
+        let join_handle = tokio::spawn(event_loop);
 
         (swap, BobApplicationHandle(join_handle))
     }
@@ -230,7 +233,7 @@ impl TestContext {
             .build()
             .unwrap();
 
-        let join_handle = tokio::spawn(event_loop.run());
+        let join_handle = tokio::spawn(event_loop);
 
         (swap, BobApplicationHandle(join_handle))
     }


### PR DESCRIPTION
TODO: Commits need re-ordering / squashing before this can go in. Too many things changed with the latest rebase. Converted to draft for now.

After some discussions in the libp2p repo [here](https://github.com/libp2p/rust-libp2p/discussions/2024), I thought this design might actually be easier to understand because it involves less state in a way by moving things to local variables.

The naming is also slightly more accurate IMO because the variables `event_loop` now actually contains a `Future` that contains a loop! Before it was a struct that you had to call `run` on.