### PR TITLE
Concurrent swaps with same peer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,10 @@ jobs:
             bob_refunds_using_cancel_and_refund_command_timelock_not_expired_force,
             punish,
             alice_punishes_after_restart_punish_timelock_expired,
-            alice_refunds_after_restart_bob_refunded
+            alice_refunds_after_restart_bob_refunded,
+            ensure_same_swap_id,
+            concurrent_bobs_after_xmr_lock_proof_sent,
+            concurrent_bobs_before_xmr_lock_proof_sent
         ]
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow multiple concurrent swaps with the same peer on the ASB.
+  This is a breaking change because the swap ID is now agreed upon between CLI and ASB during swap setup.
+  Resuming swaps started prior to this change can result in unexpected behaviour.
+
 ## [0.4.0] - 2021-04-06
 
 ### Changed

--- a/bors.toml
+++ b/bors.toml
@@ -15,5 +15,8 @@ status = [
     "docker_tests (bob_refunds_using_cancel_and_refund_command_timelock_not_expired)",
     "docker_tests (punish)",
     "docker_tests (alice_punishes_after_restart_punish_timelock_expired)",
-    "docker_tests (alice_refunds_after_restart_bob_refunded)"
+    "docker_tests (alice_refunds_after_restart_bob_refunded)",
+    "docker_tests (ensure_same_swap_id)",
+    "docker_tests (concurrent_bobs_after_xmr_lock_proof_sent)",
+    "docker_tests (concurrent_bobs_before_xmr_lock_proof_sent)"
 ]

--- a/monero-harness/src/image.rs
+++ b/monero-harness/src/image.rs
@@ -75,7 +75,7 @@ impl Image for Monero {
 impl Default for Monero {
     fn default() -> Self {
         Monero {
-            tag: "v0.16.0.3".into(),
+            tag: "v0.17.2.0".into(),
             args: Args::default(),
             entrypoint: Some("".into()),
             wait_for_message: "core RPC server started ok".to_string(),

--- a/monero-harness/tests/monerod.rs
+++ b/monero-harness/tests/monerod.rs
@@ -14,7 +14,7 @@ async fn init_miner_and_mine_to_miner_address() {
     let tc = Cli::default();
     let (monero, _monerod_container) = Monero::new(&tc, vec![]).await.unwrap();
 
-    monero.init(vec![]).await.unwrap();
+    monero.init_and_start_miner().await.unwrap();
 
     let monerod = monero.monerod();
     let miner_wallet = monero.wallet("miner").unwrap();

--- a/monero-harness/tests/wallet.rs
+++ b/monero-harness/tests/wallet.rs
@@ -22,11 +22,10 @@ async fn fund_transfer_and_check_tx_key() {
     let alice_wallet = monero.wallet("alice").unwrap();
     let bob_wallet = monero.wallet("bob").unwrap();
 
-    // fund alice
-    monero
-        .init(vec![("alice", fund_alice), ("bob", fund_bob)])
-        .await
-        .unwrap();
+    monero.init_miner().await.unwrap();
+    monero.init_wallet("alice", vec![fund_alice]).await.unwrap();
+    monero.init_wallet("bob", vec![fund_bob]).await.unwrap();
+    monero.start_miner().await.unwrap();
 
     // check alice balance
     let got_alice_balance = alice_wallet.balance().await.unwrap();

--- a/monero-rpc/src/rpc/wallet.rs
+++ b/monero-rpc/src/rpc/wallet.rs
@@ -279,7 +279,7 @@ impl Client {
             .text()
             .await?;
 
-        debug!("transfer RPC response: {}", response);
+        debug!("check_tx_key RPC response: {}", response);
 
         let r = serde_json::from_str::<Response<CheckTxKey>>(&response)?;
         Ok(r.result)

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -107,8 +107,9 @@ async fn main() -> Result<()> {
             let mut swarm = swarm::new::<Behaviour>(&seed)?;
             swarm.add_address(alice_peer_id, alice_multiaddr);
 
+            let swap_id = Uuid::new_v4();
             let (event_loop, mut event_loop_handle) =
-                EventLoop::new(swarm, alice_peer_id, bitcoin_wallet.clone())?;
+                EventLoop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
             let event_loop = tokio::spawn(event_loop.run());
 
             let send_bitcoin = determine_btc_to_swap(
@@ -128,7 +129,6 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let swap_id = Uuid::new_v4();
             db.insert_peer_id(swap_id, alice_peer_id).await?;
 
             let swap = Builder::new(
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
             swarm.add_address(alice_peer_id, alice_multiaddr);
 
             let (event_loop, event_loop_handle) =
-                EventLoop::new(swarm, alice_peer_id, bitcoin_wallet.clone())?;
+                EventLoop::new(swap_id, swarm, alice_peer_id, bitcoin_wallet.clone())?;
             let handle = tokio::spawn(event_loop.run());
 
             let swap = Builder::new(

--- a/swap/src/network/encrypted_signature.rs
+++ b/swap/src/network/encrypted_signature.rs
@@ -5,6 +5,7 @@ use libp2p::request_response::{
     RequestResponseMessage,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 pub type OutEvent = RequestResponseEvent<Request, ()>;
 
@@ -19,6 +20,7 @@ impl ProtocolName for EncryptedSignatureProtocol {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Request {
+    pub swap_id: Uuid,
     pub tx_redeem_encsig: crate::bitcoin::EncryptedSignature,
 }
 

--- a/swap/src/network/transfer_proof.rs
+++ b/swap/src/network/transfer_proof.rs
@@ -6,6 +6,7 @@ use libp2p::request_response::{
     RequestResponseMessage,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 pub type OutEvent = RequestResponseEvent<Request, ()>;
 
@@ -20,6 +21,7 @@ impl ProtocolName for TransferProofProtocol {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Request {
+    pub swap_id: Uuid,
     pub tx_lock_proof: monero::TransferProof,
 }
 

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sigma_fun::ext::dl_secp256k1_ed25519_eq::{CrossCurveDLEQ, CrossCurveDLEQProof};
 use sigma_fun::HashTranscript;
+use uuid::Uuid;
 
 pub mod alice;
 pub mod bob;
@@ -18,14 +19,9 @@ pub static CROSS_CURVE_PROOF_SYSTEM: Lazy<
     )
 });
 
-#[derive(Debug, Copy, Clone)]
-pub struct StartingBalances {
-    pub xmr: monero::Amount,
-    pub btc: bitcoin::Amount,
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message0 {
+    swap_id: Uuid,
     B: bitcoin::PublicKey,
     S_b_monero: monero::PublicKey,
     S_b_bitcoin: bitcoin::PublicKey,

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -6,6 +6,7 @@ use libp2p::request_response::{
     RequestId, RequestResponseEvent, RequestResponseMessage, ResponseChannel,
 };
 use libp2p::{NetworkBehaviour, PeerId};
+use uuid::Uuid;
 
 #[derive(Debug)]
 pub enum OutEvent {
@@ -20,6 +21,7 @@ pub enum OutEvent {
     },
     ExecutionSetupDone {
         bob_peer_id: PeerId,
+        swap_id: Uuid,
         state3: Box<State3>,
     },
     TransferProofAcknowledged {
@@ -157,9 +159,11 @@ impl From<execution_setup::OutEvent> for OutEvent {
         match event {
             Done {
                 bob_peer_id,
+                swap_id,
                 state3,
             } => OutEvent::ExecutionSetupDone {
                 bob_peer_id,
+                swap_id,
                 state3: Box::new(state3),
             },
             Failure { peer, error } => OutEvent::Failure { peer, error },

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -13,6 +13,7 @@ use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sigma_fun::ext::dl_secp256k1_ed25519_eq::CrossCurveDLEQProof;
 use std::fmt;
+use uuid::Uuid;
 
 #[derive(Debug)]
 pub enum AliceState {
@@ -146,7 +147,7 @@ impl State0 {
         })
     }
 
-    pub fn receive(self, msg: Message0) -> Result<State1> {
+    pub fn receive(self, msg: Message0) -> Result<(Uuid, State1)> {
         let valid = CROSS_CURVE_PROOF_SYSTEM.verify(
             &msg.dleq_proof_s_b,
             (
@@ -164,7 +165,7 @@ impl State0 {
 
         let v = self.v_a + msg.v_b;
 
-        Ok(State1 {
+        Ok((msg.swap_id, State1 {
             a: self.a,
             B: msg.B,
             s_a: self.s_a,
@@ -182,7 +183,7 @@ impl State0 {
             refund_address: msg.refund_address,
             redeem_address: self.redeem_address,
             punish_address: self.punish_address,
-        })
+        }))
     }
 }
 

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -5,7 +5,6 @@ use crate::env::Config;
 use crate::protocol::alice;
 use crate::protocol::alice::event_loop::EventLoopHandle;
 use crate::protocol::alice::AliceState;
-use crate::protocol::alice::AliceState::XmrLockTransferProofSent;
 use crate::{bitcoin, database, monero};
 use anyhow::{bail, Context, Result};
 use tokio::select;
@@ -16,7 +15,7 @@ pub async fn run(swap: alice::Swap) -> Result<AliceState> {
     run_until(swap, |_| false).await
 }
 
-#[tracing::instrument(name = "swap", skip(swap,exit_early), fields(id = %swap.swap_id))]
+#[tracing::instrument(name = "swap", skip(swap,exit_early), fields(id = %swap.swap_id), err)]
 pub async fn run_until(
     mut swap: alice::Swap,
     exit_early: fn(&AliceState) -> bool,
@@ -127,7 +126,7 @@ async fn next_state(
                 result = event_loop_handle.send_transfer_proof(transfer_proof.clone()) => {
                    result?;
 
-                   XmrLockTransferProofSent {
+                   AliceState::XmrLockTransferProofSent {
                        monero_wallet_restore_blockheight,
                        transfer_proof,
                        state3,

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sigma_fun::ext::dl_secp256k1_ed25519_eq::CrossCurveDLEQProof;
 use std::fmt;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub enum BobState {
@@ -69,6 +70,7 @@ impl fmt::Display for BobState {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct State0 {
+    swap_id: Uuid,
     b: bitcoin::SecretKey,
     s_b: monero::Scalar,
     S_b_monero: monero::PublicKey,
@@ -84,7 +86,9 @@ pub struct State0 {
 }
 
 impl State0 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<R: RngCore + CryptoRng>(
+        swap_id: Uuid,
         rng: &mut R,
         btc: bitcoin::Amount,
         xmr: monero::Amount,
@@ -101,6 +105,7 @@ impl State0 {
         let (dleq_proof_s_b, (S_b_bitcoin, S_b_monero)) = CROSS_CURVE_PROOF_SYSTEM.prove(&s_b, rng);
 
         Self {
+            swap_id,
             b,
             s_b,
             v_b,
@@ -120,6 +125,7 @@ impl State0 {
 
     pub fn next_message(&self) -> Message0 {
         Message0 {
+            swap_id: self.swap_id,
             B: self.b.public(),
             S_b_monero: self.S_b_monero,
             S_b_bitcoin: self.S_b_bitcoin,

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -8,6 +8,7 @@ use crate::{bitcoin, monero};
 use anyhow::{bail, Context, Result};
 use rand::rngs::OsRng;
 use tokio::select;
+use uuid::Uuid;
 
 pub fn is_complete(state: &BobState) -> bool {
     matches!(
@@ -32,6 +33,7 @@ pub async fn run_until(
 
     while !is_target_state(&current_state) {
         current_state = next_state(
+            swap.swap_id,
             current_state,
             &mut swap.event_loop_handle,
             swap.bitcoin_wallet.as_ref(),
@@ -51,6 +53,7 @@ pub async fn run_until(
 }
 
 async fn next_state(
+    swap_id: Uuid,
     state: BobState,
     event_loop_handle: &mut EventLoopHandle,
     bitcoin_wallet: &bitcoin::Wallet,
@@ -65,6 +68,7 @@ async fn next_state(
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
 
             let state2 = request_price_and_setup(
+                swap_id,
                 btc_amount,
                 event_loop_handle,
                 env_config,
@@ -103,7 +107,7 @@ async fn next_state(
 
                 select! {
                     transfer_proof = transfer_proof_watcher => {
-                        let transfer_proof = transfer_proof?.tx_lock_proof;
+                        let transfer_proof = transfer_proof?;
 
                         tracing::info!(txid = %transfer_proof.tx_hash(), "Alice locked Monero");
 
@@ -244,6 +248,7 @@ async fn next_state(
 }
 
 pub async fn request_price_and_setup(
+    swap_id: Uuid,
     btc: bitcoin::Amount,
     event_loop_handle: &mut EventLoopHandle,
     env_config: &Config,
@@ -254,6 +259,7 @@ pub async fn request_price_and_setup(
     tracing::info!("Spot price for {} is {}", btc, xmr);
 
     let state0 = State0::new(
+        swap_id,
         &mut OsRng,
         btc,
         xmr,

--- a/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
+++ b/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
@@ -13,6 +13,7 @@ use swap::protocol::{alice, bob};
 async fn alice_punishes_after_restart_if_punish_timelock_expired() {
     harness::setup_test(FastPunishConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -33,11 +34,7 @@ async fn alice_punishes_after_restart_if_punish_timelock_expired() {
                 .wait_until_confirmed_with(state3.punish_timelock)
                 .await?;
         } else {
-            panic!(
-                "\
-            Alice in unexpected state {}",
-                alice_state
-            );
+            panic!("Alice in unexpected state {}", alice_state);
         }
 
         ctx.restart_alice().await;
@@ -49,7 +46,9 @@ async fn alice_punishes_after_restart_if_punish_timelock_expired() {
 
         // Restart Bob after Alice punished to ensure Bob transitions to
         // punished and does not run indefinitely
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;

--- a/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
@@ -1,0 +1,60 @@
+pub mod harness;
+
+use harness::bob_run_until::is_xmr_locked;
+use harness::SlowCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+#[tokio::test]
+async fn concurrent_bobs_after_xmr_lock_proof_sent() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap_1, bob_join_handle_1) = ctx.bob_swap().await;
+
+        let swap_id = bob_swap_1.swap_id;
+
+        let bob_swap_1 = tokio::spawn(bob::run_until(bob_swap_1, is_xmr_locked));
+
+        let alice_swap_1 = ctx.alice_next_swap().await;
+        let alice_swap_1 = tokio::spawn(alice::run(alice_swap_1));
+
+        let bob_state_1 = bob_swap_1.await??;
+        assert!(matches!(bob_state_1, BobState::XmrLocked { .. }));
+
+        // make sure bob_swap_1's event loop is gone
+        bob_join_handle_1.abort();
+
+        let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
+        let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
+
+        let alice_swap_2 = ctx.alice_next_swap().await;
+        let alice_swap_2 = tokio::spawn(alice::run(alice_swap_2));
+
+        // The 2nd swap should ALWAYS finish successfully in this
+        // scenario
+
+        let bob_state_2 = bob_swap_2.await??;
+        assert!(matches!(bob_state_2, BobState::XmrRedeemed { .. }));
+
+        let alice_state_2 = alice_swap_2.await??;
+        assert!(matches!(alice_state_2, AliceState::BtcRedeemed { .. }));
+
+        let (bob_swap_1, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle_2, swap_id)
+            .await;
+        assert!(matches!(bob_swap_1.state, BobState::XmrLocked { .. }));
+
+        // The 1st (paused) swap ALWAYS finishes successfully in this
+        // scenario, because it is ensured that Bob already received the
+        // transfer proof.
+
+        let bob_state_1 = bob::run(bob_swap_1).await?;
+        assert!(matches!(bob_state_1, BobState::XmrRedeemed { .. }));
+
+        let alice_state_1 = alice_swap_1.await??;
+        assert!(matches!(alice_state_1, AliceState::BtcRedeemed { .. }));
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
@@ -1,0 +1,61 @@
+pub mod harness;
+
+use harness::bob_run_until::is_btc_locked;
+use harness::SlowCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+#[tokio::test]
+async fn concurrent_bobs_before_xmr_lock_proof_sent() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap_1, bob_join_handle_1) = ctx.bob_swap().await;
+
+        let swap_id = bob_swap_1.swap_id;
+
+        let bob_swap_1 = tokio::spawn(bob::run_until(bob_swap_1, is_btc_locked));
+
+        let alice_swap_1 = ctx.alice_next_swap().await;
+        let alice_swap_1 = tokio::spawn(alice::run(alice_swap_1));
+
+        let bob_state_1 = bob_swap_1.await??;
+        assert!(matches!(bob_state_1, BobState::BtcLocked(_)));
+
+        // make sure bob_swap_1's event loop is gone
+        bob_join_handle_1.abort();
+
+        let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
+        let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
+
+        let alice_swap_2 = ctx.alice_next_swap().await;
+        let alice_swap_2 = tokio::spawn(alice::run(alice_swap_2));
+
+        // The 2nd swap ALWAYS finish successfully in this
+        // scenario, but will receive an "unwanted" transfer proof that is ignored in
+        // the event loop.
+
+        let bob_state_2 = bob_swap_2.await??;
+        assert!(matches!(bob_state_2, BobState::XmrRedeemed { .. }));
+
+        let alice_state_2 = alice_swap_2.await??;
+        assert!(matches!(alice_state_2, AliceState::BtcRedeemed { .. }));
+
+        let (bob_swap_1, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle_2, swap_id)
+            .await;
+        assert!(matches!(bob_state_1, BobState::BtcLocked(_)));
+
+        // The 1st (paused) swap is expected to refund, because the transfer
+        // proof is delivered to the wrong swap, and we currently don't store it in the
+        // database for the other swap.
+
+        let bob_state_1 = bob::run(bob_swap_1).await?;
+        assert!(matches!(bob_state_1, BobState::BtcRefunded { .. }));
+
+        let alice_state_1 = alice_swap_1.await??;
+        assert!(matches!(alice_state_1, AliceState::XmrRefunded { .. }));
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/ensure_same_swap_id.rs
+++ b/swap/tests/ensure_same_swap_id.rs
@@ -1,0 +1,21 @@
+pub mod harness;
+
+use harness::SlowCancelConfig;
+use swap::protocol::bob;
+
+#[tokio::test]
+async fn ensure_same_swap_id_for_alice_and_bob() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap, _) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
+        let _ = tokio::spawn(bob::run(bob_swap));
+
+        // once Bob's swap is spawned we can retrieve Alice's swap and assert on the
+        // swap ID
+        let alice_swap = ctx.alice_next_swap().await;
+        assert_eq!(alice_swap.swap_id, bob_swap_id);
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/happy_path_restart_bob_after_xmr_locked.rs
+++ b/swap/tests/happy_path_restart_bob_after_xmr_locked.rs
@@ -9,6 +9,7 @@ use swap::protocol::{alice, bob};
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     harness::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_xmr_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -18,7 +19,9 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked { .. }));
 
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;

--- a/swap/tests/happy_path_restart_bob_before_xmr_locked.rs
+++ b/swap/tests/happy_path_restart_bob_before_xmr_locked.rs
@@ -9,6 +9,7 @@ use swap::protocol::{alice, bob};
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     harness::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_xmr_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -18,7 +19,9 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked { .. }));
 
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -482,7 +482,7 @@ where
     let cli = Cli::default();
 
     let _guard = tracing_subscriber::fmt()
-        .with_env_filter("warn,swap=debug,monero_harness=debug,monero_rpc=info,bitcoin_harness=info,testcontainers=info")
+        .with_env_filter("warn,swap=debug,monero_harness=debug,monero_rpc=debug,bitcoin_harness=info,testcontainers=info")
         .with_test_writer()
         .set_default();
 


### PR DESCRIPTION
Fixes #367 

- [x] Concurrent swaps with same peer

Not sure how much more time I should invest into this. We could just merge the current state and then do improvements on top...?

Improvements:

- [x] Think `// TODO: Remove unnecessary swap-id check` through and remove it
- [x] Add concurrent swap test, multiple swaps with same Bob
- [ ] Save swap messages without matching swap in execution in the database
- [ ] Assert the balances in the new concurrent swap tests
- [ ] ~~Add concurrent swap test, multiple swaps with different Bobs~~
- [ ] ~~Send swap-id in separate message, not on top of `Message0`~~