### PR TITLE
WIP - concurrent swap tests

### DIFF
--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -111,8 +111,8 @@ impl EventLoop {
                         SwarmEvent::Behaviour(OutEvent::TransferProofReceived { msg, channel }) => {
                             let mut responder = match self.transfer_proof.send(*msg).await {
                                 Ok(responder) => responder,
-                                Err(_) => {
-                                    tracing::warn!("Failed to pass on transfer proof");
+                                Err(e) => {
+                                    tracing::warn!("Failed to pass on transfer proof: {:#}", e);
                                     continue;
                                 }
                             };

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -120,6 +120,8 @@ async fn next_state(
                                 monero_wallet_restore_blockheight
                             }
                         } else {
+                            // TODO: More elaborate handling for "wrong" transfer proofs, we can store them in the db
+
                             tracing::warn!("Received transfer proof for swap {} but currently executing \
                                 swap {}. This transfer proof will be ignored!", transfer_proof.swap_id, swap_id);
                             // In case we receive a transfer proof that is not meant to be for this swap we

--- a/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
+++ b/swap/tests/alice_punishes_after_restart_punish_timelock_expired.rs
@@ -13,6 +13,7 @@ use swap::protocol::{alice, bob};
 async fn alice_punishes_after_restart_if_punish_timelock_expired() {
     harness::setup_test(FastPunishConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -33,11 +34,7 @@ async fn alice_punishes_after_restart_if_punish_timelock_expired() {
                 .wait_until_confirmed_with(state3.punish_timelock)
                 .await?;
         } else {
-            panic!(
-                "\
-            Alice in unexpected state {}",
-                alice_state
-            );
+            panic!("Alice in unexpected state {}", alice_state);
         }
 
         ctx.restart_alice().await;
@@ -49,7 +46,9 @@ async fn alice_punishes_after_restart_if_punish_timelock_expired() {
 
         // Restart Bob after Alice punished to ensure Bob transitions to
         // punished and does not run indefinitely
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;

--- a/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
@@ -1,0 +1,61 @@
+pub mod harness;
+
+use harness::bob_run_until::is_xmr_locked;
+use harness::SlowCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+#[tokio::test]
+async fn concurrent_bobs_after_xmr_lock_proof_sent() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap_1, bob_join_handle_1) = ctx.bob_swap().await;
+        let bob_bitcoin_wallet = bob_swap_1.bitcoin_wallet.clone();
+        let bob_swap_id_1 = bob_swap_1.swap_id;
+        let bob_swap_1 = tokio::spawn(bob::run_until(bob_swap_1, is_xmr_locked));
+
+        let alice_swap_1 = ctx.alice_next_swap().await;
+        let alice_swap_1 = tokio::spawn(alice::run(alice_swap_1));
+
+        let bob_state_1 = bob_swap_1.await??;
+        assert!(matches!(bob_state_1, BobState::XmrLocked { .. }));
+
+        // make sure Bob's swap one event loop is gone
+        bob_join_handle_1.abort();
+        // sync wallet to ensure lock tx for second swap works out
+        bob_bitcoin_wallet.sync().await?;
+
+        let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
+        let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
+
+        let alice_swap_2 = ctx.alice_next_swap().await;
+        let alice_swap_2 = tokio::spawn(alice::run(alice_swap_2));
+
+        // The second (inner) swap should ALWAYS finish successfully in this
+        // scenario
+
+        let bob_state_2 = bob_swap_2.await??;
+        assert!(matches!(bob_state_2, BobState::XmrRedeemed { .. }));
+
+        let alice_state_2 = alice_swap_2.await??;
+        assert!(matches!(alice_state_2, AliceState::BtcRedeemed { .. }));
+
+        let (bob_swap_1, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle_2, bob_swap_id_1)
+            .await;
+        assert!(matches!(bob_swap_1.state, BobState::XmrLocked { .. }));
+
+        // The first (paused, outer) swap should ALWAYS finish successfully in this
+        // scenario, because it is ensured that Bob already received the
+        // transfer proof.
+
+        let bob_state_1 = bob::run(bob_swap_1).await?;
+        assert!(matches!(bob_state_1, BobState::XmrRedeemed { .. }));
+
+        let alice_state_1 = alice_swap_1.await??;
+        assert!(matches!(alice_state_1, AliceState::BtcRedeemed { .. }));
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
@@ -1,0 +1,66 @@
+pub mod harness;
+
+use harness::bob_run_until::is_btc_locked;
+use harness::SlowCancelConfig;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+#[tokio::test]
+async fn concurrent_bobs_before_xmr_lock_proof_sent() {
+    harness::setup_test(SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap_1, bob_join_handle_1) = ctx.bob_swap().await;
+        let bob_swap_id_1 = bob_swap_1.swap_id;
+        let bob_bitcoin_wallet = bob_swap_1.bitcoin_wallet.clone();
+        let bob_swap_1 = tokio::spawn(bob::run_until(bob_swap_1, is_btc_locked));
+
+        let alice_swap_1 = ctx.alice_next_swap().await;
+        let alice_swap_1 = tokio::spawn(alice::run(alice_swap_1));
+
+        let bob_state_1 = bob_swap_1.await??;
+        assert!(matches!(bob_state_1, BobState::BtcLocked(_)));
+
+        // make sure Bob's swap one event loop is gone
+        bob_join_handle_1.abort();
+        // sync wallet to ensure lock tx for second swap works out
+        bob_bitcoin_wallet.sync().await?;
+
+        let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
+        let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
+
+        let alice_swap_2 = ctx.alice_next_swap().await;
+        let alice_swap_2 = tokio::spawn(alice::run(alice_swap_2));
+
+        // The second (inner) swap should ALWAYS finish successfully in this
+        // scenario, but MIGHT receive an "unwanted" transfer proof that is ignored.
+
+        // TODO: The inner swap (bob_swap_2) currently does not succeed properly.
+        //  It DOES receive a transfer proof that does not match the swap and prints a
+        //  warning - which is expected!  But then it never receives the actual transfer
+        //  proof.
+
+        let bob_state_2 = bob_swap_2.await??;
+        assert!(matches!(bob_state_2, BobState::XmrRedeemed { .. }));
+
+        let alice_state_2 = alice_swap_2.await??;
+        assert!(matches!(alice_state_2, AliceState::BtcRedeemed { .. }));
+
+        let (bob_swap_1, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle_2, bob_swap_id_1)
+            .await;
+        assert!(matches!(bob_state_1, BobState::BtcLocked(_)));
+
+        // The first (paused, outer) swap is expected to refund, because the transfer
+        // proof is delivered to the wrong swap, and we currently don't store it in the
+        // database for the other swap.
+
+        let bob_state_1 = bob::run(bob_swap_1).await?;
+        assert!(matches!(bob_state_1, BobState::BtcRefunded { .. }));
+
+        let alice_state_1 = alice_swap_1.await??;
+        assert!(matches!(alice_state_1, AliceState::XmrRefunded { .. }));
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/happy_path_restart_bob_after_xmr_locked.rs
+++ b/swap/tests/happy_path_restart_bob_after_xmr_locked.rs
@@ -9,6 +9,7 @@ use swap::protocol::{alice, bob};
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     harness::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_xmr_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -18,7 +19,9 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked { .. }));
 
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;

--- a/swap/tests/happy_path_restart_bob_before_xmr_locked.rs
+++ b/swap/tests/happy_path_restart_bob_before_xmr_locked.rs
@@ -9,6 +9,7 @@ use swap::protocol::{alice, bob};
 async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
     harness::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.swap_id;
         let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_xmr_locked));
 
         let alice_swap = ctx.alice_next_swap().await;
@@ -18,7 +19,9 @@ async fn given_bob_restarts_after_xmr_is_locked_resume_swap() {
 
         assert!(matches!(bob_state, BobState::XmrLocked { .. }));
 
-        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_join_handle).await;
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
         assert!(matches!(bob_swap.state, BobState::XmrLocked { .. }));
 
         let bob_state = bob::run(bob_swap).await?;


### PR DESCRIPTION
See comments in code for details on current open issues.

`concurrent_bobs_after_xmr_lock_proof_sent` behaves as expected - however, it was weird that I had to adapt the channel buffer for the transfer proofs. I don't think that should be needed if I understand the implementation correctly (see TODO comment in Alice's event loop `new_handle`).

`concurrent_bobs_before_xmr_lock_proof_sent` does NOT behave as expected. A "wrong" transfer proof is received by the inner (concurrent) swap (which is expected), but then we never receive the actual transfer proof for that swap.  