### PR TITLE
Improve error reporting of failed protocols

### DIFF
--- a/swap/src/network.rs
+++ b/swap/src/network.rs
@@ -1,3 +1,5 @@
+mod impl_from_rr_event;
+
 pub mod cbor_request_response;
 pub mod encrypted_signature;
 pub mod quote;

--- a/swap/src/network/encrypted_signature.rs
+++ b/swap/src/network/encrypted_signature.rs
@@ -1,20 +1,26 @@
 use crate::network::cbor_request_response::CborCodec;
+use crate::protocol::{alice, bob};
 use libp2p::core::ProtocolName;
 use libp2p::request_response::{
     ProtocolSupport, RequestResponse, RequestResponseConfig, RequestResponseEvent,
     RequestResponseMessage,
 };
+use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub type OutEvent = RequestResponseEvent<Request, ()>;
+const PROTOCOL: &str = "/comit/xmr/btc/encrypted_signature/1.0.0";
+type OutEvent = RequestResponseEvent<Request, ()>;
+type Message = RequestResponseMessage<Request, ()>;
+
+pub type Behaviour = RequestResponse<CborCodec<EncryptedSignatureProtocol, Request, ()>>;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct EncryptedSignatureProtocol;
 
 impl ProtocolName for EncryptedSignatureProtocol {
     fn protocol_name(&self) -> &[u8] {
-        b"/comit/xmr/btc/encrypted_signature/1.0.0"
+        PROTOCOL.as_bytes()
     }
 }
 
@@ -23,10 +29,6 @@ pub struct Request {
     pub swap_id: Uuid,
     pub tx_redeem_encsig: crate::bitcoin::EncryptedSignature,
 }
-
-pub type Behaviour = RequestResponse<CborCodec<EncryptedSignatureProtocol, Request, ()>>;
-
-pub type Message = RequestResponseMessage<Request, ()>;
 
 pub fn alice() -> Behaviour {
     Behaviour::new(
@@ -43,3 +45,31 @@ pub fn bob() -> Behaviour {
         RequestResponseConfig::default(),
     )
 }
+
+impl From<(PeerId, Message)> for alice::OutEvent {
+    fn from((peer, message): (PeerId, Message)) -> Self {
+        match message {
+            Message::Request {
+                request, channel, ..
+            } => Self::EncryptedSignatureReceived {
+                msg: Box::new(request),
+                channel,
+                peer,
+            },
+            Message::Response { .. } => Self::unexpected_response(peer),
+        }
+    }
+}
+crate::impl_from_rr_event!(OutEvent, alice::OutEvent, PROTOCOL);
+
+impl From<(PeerId, Message)> for bob::OutEvent {
+    fn from((peer, message): (PeerId, Message)) -> Self {
+        match message {
+            Message::Request { .. } => Self::unexpected_request(peer),
+            Message::Response { request_id, .. } => {
+                Self::EncryptedSignatureAcknowledged { id: request_id }
+            }
+        }
+    }
+}
+crate::impl_from_rr_event!(OutEvent, bob::OutEvent, PROTOCOL);

--- a/swap/src/network/impl_from_rr_event.rs
+++ b/swap/src/network/impl_from_rr_event.rs
@@ -1,0 +1,66 @@
+/// Helper macro to map a [`RequestResponseEvent`] to our [`OutEvent`].
+///
+/// This is primarily a macro and not a regular function because we use it for
+/// Alice and Bob and they have different [`OutEvent`]s that just happen to
+/// share a couple of variants, like `OutEvent::Failure` and `OutEvent::Other`.
+#[macro_export]
+macro_rules! impl_from_rr_event {
+    ($protocol_event:ty, $behaviour_out_event:ty, $protocol:ident) => {
+        impl From<$protocol_event> for $behaviour_out_event {
+            fn from(event: $protocol_event) -> Self {
+                use ::libp2p::request_response::RequestResponseEvent::*;
+                use anyhow::anyhow;
+
+                match event {
+                    Message { message, peer, .. } => Self::from((peer, message)),
+                    ResponseSent { .. } => Self::Other,
+                    InboundFailure { peer, error, .. } => {
+                        use libp2p::request_response::InboundFailure::*;
+
+                        match error {
+                            Timeout => {
+                                Self::Failure {
+                                    error: anyhow!("{} failed because of an inbound timeout", $protocol),
+                                    peer,
+                                }
+                            }
+                            ConnectionClosed => {
+                                Self::Failure {
+                                    error: anyhow!("{} failed because the connection was closed before a response could be sent", $protocol),
+                                    peer,
+                                }
+                            }
+                            UnsupportedProtocols => Self::Other, // TODO: Report this and disconnected / ban the peer?
+                            ResponseOmission => Self::Other
+                        }
+                    }
+                    OutboundFailure { peer, error, .. } => {
+                        use libp2p::request_response::OutboundFailure::*;
+
+                        match error {
+                            Timeout => {
+                                Self::Failure {
+                                    error: anyhow!("{} failed because we did not receive a response within the configured timeout", $protocol),
+                                    peer,
+                                }
+                            }
+                            ConnectionClosed => {
+                                Self::Failure {
+                                    error: anyhow!("{} failed because the connection was closed we received a response", $protocol),
+                                    peer,
+                                }
+                            }
+                            UnsupportedProtocols => Self::Other, // TODO: Report this and disconnected / ban the peer?
+                            DialFailure => {
+                                Self::Failure {
+                                    error: anyhow!("{} failed because we failed to dial", $protocol),
+                                    peer,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/swap/src/network/redial.rs
+++ b/swap/src/network/redial.rs
@@ -1,3 +1,4 @@
+use crate::protocol::bob;
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
 use futures::future::FutureExt;
@@ -115,5 +116,15 @@ impl NetworkBehaviour for Behaviour {
             peer_id: self.peer,
             condition: DialPeerCondition::Disconnected,
         })
+    }
+}
+
+impl From<OutEvent> for bob::OutEvent {
+    fn from(event: OutEvent) -> Self {
+        match event {
+            OutEvent::AllAttemptsExhausted { peer } => {
+                bob::OutEvent::AllRedialAttemptsExhausted { peer }
+            }
+        }
     }
 }

--- a/swap/src/network/transfer_proof.rs
+++ b/swap/src/network/transfer_proof.rs
@@ -1,21 +1,27 @@
 use crate::monero;
 use crate::network::cbor_request_response::CborCodec;
+use crate::protocol::{alice, bob};
 use libp2p::core::ProtocolName;
 use libp2p::request_response::{
     ProtocolSupport, RequestResponse, RequestResponseConfig, RequestResponseEvent,
     RequestResponseMessage,
 };
+use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub type OutEvent = RequestResponseEvent<Request, ()>;
+const PROTOCOL: &str = "/comit/xmr/btc/transfer_proof/1.0.0";
+type OutEvent = RequestResponseEvent<Request, ()>;
+type Message = RequestResponseMessage<Request, ()>;
+
+pub type Behaviour = RequestResponse<CborCodec<TransferProofProtocol, Request, ()>>;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TransferProofProtocol;
 
 impl ProtocolName for TransferProofProtocol {
     fn protocol_name(&self) -> &[u8] {
-        b"/comit/xmr/btc/transfer_proof/1.0.0"
+        PROTOCOL.as_bytes()
     }
 }
 
@@ -24,10 +30,6 @@ pub struct Request {
     pub swap_id: Uuid,
     pub tx_lock_proof: monero::TransferProof,
 }
-
-pub type Behaviour = RequestResponse<CborCodec<TransferProofProtocol, Request, ()>>;
-
-pub type Message = RequestResponseMessage<Request, ()>;
 
 pub fn alice() -> Behaviour {
     Behaviour::new(
@@ -44,3 +46,31 @@ pub fn bob() -> Behaviour {
         RequestResponseConfig::default(),
     )
 }
+
+impl From<(PeerId, Message)> for alice::OutEvent {
+    fn from((peer, message): (PeerId, Message)) -> Self {
+        match message {
+            Message::Request { .. } => Self::unexpected_request(peer),
+            Message::Response { request_id, .. } => Self::TransferProofAcknowledged {
+                peer,
+                id: request_id,
+            },
+        }
+    }
+}
+crate::impl_from_rr_event!(OutEvent, alice::OutEvent, PROTOCOL);
+
+impl From<(PeerId, Message)> for bob::OutEvent {
+    fn from((peer, message): (PeerId, Message)) -> Self {
+        match message {
+            Message::Request {
+                request, channel, ..
+            } => Self::TransferProofReceived {
+                msg: Box::new(request),
+                channel,
+            },
+            Message::Response { .. } => Self::unexpected_response(peer),
+        }
+    }
+}
+crate::impl_from_rr_event!(OutEvent, bob::OutEvent, PROTOCOL);

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -2,9 +2,7 @@ use crate::network::quote::BidQuote;
 use crate::network::{encrypted_signature, quote, spot_price, transfer_proof};
 use crate::protocol::alice::{execution_setup, State3};
 use anyhow::{anyhow, Error};
-use libp2p::request_response::{
-    RequestId, RequestResponseEvent, RequestResponseMessage, ResponseChannel,
-};
+use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::{NetworkBehaviour, PeerId};
 use uuid::Uuid;
 
@@ -33,140 +31,27 @@ pub enum OutEvent {
         channel: ResponseChannel<()>,
         peer: PeerId,
     },
-    ResponseSent, // Same variant is used for all messages as no processing is done
     Failure {
         peer: PeerId,
         error: Error,
     },
+    /// "Fallback" variant that allows the event mapping code to swallow certain
+    /// events that we don't want the caller to deal with.
+    Other,
 }
 
 impl OutEvent {
-    fn unexpected_request(peer: PeerId) -> OutEvent {
+    pub fn unexpected_request(peer: PeerId) -> OutEvent {
         OutEvent::Failure {
             peer,
             error: anyhow!("Unexpected request received"),
         }
     }
 
-    fn unexpected_response(peer: PeerId) -> OutEvent {
+    pub fn unexpected_response(peer: PeerId) -> OutEvent {
         OutEvent::Failure {
             peer,
             error: anyhow!("Unexpected response received"),
-        }
-    }
-}
-
-impl From<(PeerId, quote::Message)> for OutEvent {
-    fn from((peer, message): (PeerId, quote::Message)) -> Self {
-        match message {
-            quote::Message::Request { channel, .. } => OutEvent::QuoteRequested { channel, peer },
-            quote::Message::Response { .. } => OutEvent::unexpected_response(peer),
-        }
-    }
-}
-
-impl From<(PeerId, spot_price::Message)> for OutEvent {
-    fn from((peer, message): (PeerId, spot_price::Message)) -> Self {
-        match message {
-            spot_price::Message::Request {
-                request, channel, ..
-            } => OutEvent::SpotPriceRequested {
-                request,
-                channel,
-                peer,
-            },
-            spot_price::Message::Response { .. } => OutEvent::unexpected_response(peer),
-        }
-    }
-}
-
-impl From<(PeerId, transfer_proof::Message)> for OutEvent {
-    fn from((peer, message): (PeerId, transfer_proof::Message)) -> Self {
-        match message {
-            transfer_proof::Message::Request { .. } => OutEvent::unexpected_request(peer),
-            transfer_proof::Message::Response { request_id, .. } => {
-                OutEvent::TransferProofAcknowledged {
-                    peer,
-                    id: request_id,
-                }
-            }
-        }
-    }
-}
-
-impl From<(PeerId, encrypted_signature::Message)> for OutEvent {
-    fn from((peer, message): (PeerId, encrypted_signature::Message)) -> Self {
-        match message {
-            encrypted_signature::Message::Request {
-                request, channel, ..
-            } => OutEvent::EncryptedSignatureReceived {
-                msg: Box::new(request),
-                channel,
-                peer,
-            },
-            encrypted_signature::Message::Response { .. } => OutEvent::unexpected_response(peer),
-        }
-    }
-}
-
-impl From<spot_price::OutEvent> for OutEvent {
-    fn from(event: spot_price::OutEvent) -> Self {
-        map_rr_event_to_outevent(event)
-    }
-}
-
-impl From<quote::OutEvent> for OutEvent {
-    fn from(event: quote::OutEvent) -> Self {
-        map_rr_event_to_outevent(event)
-    }
-}
-
-impl From<transfer_proof::OutEvent> for OutEvent {
-    fn from(event: transfer_proof::OutEvent) -> Self {
-        map_rr_event_to_outevent(event)
-    }
-}
-
-impl From<encrypted_signature::OutEvent> for OutEvent {
-    fn from(event: encrypted_signature::OutEvent) -> Self {
-        map_rr_event_to_outevent(event)
-    }
-}
-
-fn map_rr_event_to_outevent<I, O>(event: RequestResponseEvent<I, O>) -> OutEvent
-where
-    OutEvent: From<(PeerId, RequestResponseMessage<I, O>)>,
-{
-    use RequestResponseEvent::*;
-
-    match event {
-        Message { message, peer, .. } => OutEvent::from((peer, message)),
-        ResponseSent { .. } => OutEvent::ResponseSent,
-        InboundFailure { peer, error, .. } => OutEvent::Failure {
-            error: anyhow!("protocol failed due to {:?}", error),
-            peer,
-        },
-        OutboundFailure { peer, error, .. } => OutEvent::Failure {
-            error: anyhow!("protocol failed due to {:?}", error),
-            peer,
-        },
-    }
-}
-
-impl From<execution_setup::OutEvent> for OutEvent {
-    fn from(event: execution_setup::OutEvent) -> Self {
-        use crate::protocol::alice::execution_setup::OutEvent::*;
-        match event {
-            Done {
-                bob_peer_id,
-                swap_id,
-                state3,
-            } => OutEvent::ExecutionSetupDone {
-                bob_peer_id,
-                swap_id,
-                state3: Box::new(state3),
-            },
-            Failure { peer, error } => OutEvent::Failure { peer, error },
         }
     }
 }

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -218,7 +218,6 @@ where
                                 channel
                             }.boxed());
                         }
-                        SwarmEvent::Behaviour(OutEvent::ResponseSent) => {}
                         SwarmEvent::Behaviour(OutEvent::Failure {peer, error}) => {
                             tracing::error!(%peer, "Communication error: {:#}", error);
                         }

--- a/swap/src/protocol/alice/execution_setup.rs
+++ b/swap/src/protocol/alice/execution_setup.rs
@@ -1,6 +1,6 @@
 use crate::network::cbor_request_response::BUF_SIZE;
 use crate::protocol::alice::{State0, State3};
-use crate::protocol::{Message0, Message2, Message4};
+use crate::protocol::{alice, Message0, Message2, Message4};
 use anyhow::{Context, Error};
 use libp2p::PeerId;
 use libp2p_async_await::BehaviourOutEvent;
@@ -84,5 +84,22 @@ impl Behaviour {
 
                 Ok((bob, (swap_id, state3)))
             })
+    }
+}
+
+impl From<OutEvent> for alice::OutEvent {
+    fn from(event: OutEvent) -> Self {
+        match event {
+            OutEvent::Done {
+                bob_peer_id,
+                state3,
+                swap_id,
+            } => Self::ExecutionSetupDone {
+                bob_peer_id,
+                state3: Box::new(state3),
+                swap_id,
+            },
+            OutEvent::Failure { peer, error } => Self::Failure { peer, error },
+        }
     }
 }

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -151,11 +151,8 @@ impl EventLoop {
                             tracing::error!("Exhausted all re-dial attempts to Alice");
                             return;
                         }
-                        SwarmEvent::Behaviour(OutEvent::ResponseSent) => {
-
-                        }
-                        SwarmEvent::Behaviour(OutEvent::CommunicationError(error)) => {
-                            tracing::warn!("Communication error: {:#}", error);
+                        SwarmEvent::Behaviour(OutEvent::Failure { peer, error }) => {
+                            tracing::warn!(%peer, "Communication error: {:#}", error);
                             return;
                         }
                         SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } if peer_id == self.alice_peer_id => {

--- a/swap/src/protocol/bob/execution_setup.rs
+++ b/swap/src/protocol/bob/execution_setup.rs
@@ -1,6 +1,6 @@
 use crate::network::cbor_request_response::BUF_SIZE;
 use crate::protocol::bob::{State0, State2};
-use crate::protocol::{Message1, Message3};
+use crate::protocol::{bob, Message1, Message3};
 use anyhow::{Context, Error, Result};
 use libp2p::PeerId;
 use libp2p_async_await::BehaviourOutEvent;
@@ -83,5 +83,13 @@ impl Behaviour {
 
             async move { tokio::time::timeout(Duration::from_secs(10), protocol).await? }
         })
+    }
+}
+
+impl From<OutEvent> for bob::OutEvent {
+    fn from(event: OutEvent) -> Self {
+        match event {
+            OutEvent::Done(res) => Self::ExecutionSetupDone(Box::new(res)),
+        }
     }
 }


### PR DESCRIPTION
Instead of forwarding every error, we deliberately ignore certain
variants that are not worth being printed to the log. In particular,
this concerns "UnsupportedProtocols" and "ResponseOmission".

To make this less verbose we introduce a macro for mapping a
`RequestResponseEvent` to `{alice,bob}::OutEvent`. We use a macro
because those `OutEvent`s are different types and the only other
way of abstracting over them would be to introduce traits that we
implement on both of them.

To make the macro easier to use, we move all the `From` implementations
that convert between the protocol and the more high-level behaviour
into the actual protocol module.