### PR TITLE
Change the public ASB to use the default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More information about the protocol in this [presentation](https://youtu.be/Jj8r
    The seller will provide you their peer id and multiaddress.
    We are running an `asb` instance on testnet.
    You can swap with to get familiar with the `swap` CLI.
-   Our peer id is `12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi` and our multiaddress is `/dns4/xmr-btc-asb.coblox.tech/tcp/9876`
+   Our peer id is `12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi` and our multiaddress is `/dns4/xmr-btc-asb.coblox.tech/tcp/9939`
 3. Follow the instructions printed to the terminal
 
 ## Limitations


### PR DESCRIPTION
I noticed that out public ASB is not using the configured default port for `tcp` connections. 
I don't know why that is, but I felt it would be better to update it to use the default port. I already opened port `9939` and closed `9876`.

This has the side-effect that releases prior to `0.4.0` will NOT just work upon startup anymore, because the ASB is not running on the auto-configured port anymore. I think that is a good thing, because the public ASB does not support these versions anymore. 