### PR TITLE
Print peer ID on debog when starting CLI

### DIFF
--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -174,6 +174,8 @@ async fn main() -> Result<()> {
 
             let alice_peer_id = db.get_peer_id(swap_id)?;
             let mut swarm = swarm::bob(&seed, alice_peer_id)?;
+            let bob_peer_id = swarm.local_peer_id();
+            tracing::debug!("Our peer-id: {}", bob_peer_id);
             swarm
                 .behaviour_mut()
                 .add_address(alice_peer_id, alice_multiaddr);

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -19,8 +19,10 @@ where
 {
     let identity = seed.derive_libp2p_identity();
     let transport = transport::build(&identity)?;
+    let peer_id = identity.public().into_peer_id();
+    tracing::debug!("Our peer-id: {}", peer_id);
 
-    let swarm = SwarmBuilder::new(transport, behaviour, identity.public().into_peer_id())
+    let swarm = SwarmBuilder::new(transport, behaviour, peer_id)
         .executor(Box::new(|f| {
             tokio::spawn(f);
         }))


### PR DESCRIPTION
In order to add more context to the debug logs we print Bob's peer ID.
This allows identifying peer related logs on the ASB.