### PR TITLE
Peer id check for transfer proof and encsig messages

### DIFF
--- a/swap/src/network/transfer_proof.rs
+++ b/swap/src/network/transfer_proof.rs
@@ -68,6 +68,7 @@ impl From<(PeerId, Message)> for bob::OutEvent {
             } => Self::TransferProofReceived {
                 msg: Box::new(request),
                 channel,
+                peer,
             },
             Message::Response { .. } => Self::unexpected_response(peer),
         }

--- a/swap/src/protocol/bob/behaviour.rs
+++ b/swap/src/protocol/bob/behaviour.rs
@@ -21,6 +21,7 @@ pub enum OutEvent {
     TransferProofReceived {
         msg: Box<transfer_proof::Request>,
         channel: ResponseChannel<()>,
+        peer: PeerId,
     },
     EncryptedSignatureAcknowledged {
         id: RequestId,


### PR DESCRIPTION
Fixes #416 

The second commit will be relevant for changes planned in #411 

@thomaseizinger with #411 we will need access to Bob's database in the eventloop, this might influence design decisions for #401