### PR TITLE
Fix messages for awaiting containers ready

### DIFF
--- a/monero-harness/src/image.rs
+++ b/monero-harness/src/image.rs
@@ -34,7 +34,7 @@ impl Image for Monerod {
         container
             .logs()
             .stdout
-            .wait_for_message("JOINING all threads")
+            .wait_for_message("RPC server started ok")
             .unwrap();
     }
 
@@ -87,7 +87,7 @@ impl Image for MoneroWalletRpc {
         container
             .logs()
             .stdout
-            .wait_for_message("JOINING all threads")
+            .wait_for_message("Run server thread name: RPC")
             .unwrap();
     }
 


### PR DESCRIPTION
The message `JOINING all threads` is unfortunately not deterministic, it can happen that it just is not printed in the logs.
For Monerod container the message is set to `RPC server started ok`. This message appears in both a test run that was hanging with `JOINING all threads` and a successful run. Initially the message was set to `core RPC server started ok` with `core` being a variable value. We assume that `core` does not change, but did not to further code analysis what values it can be.

For Monero Wallet RPC container the message is set to `Run server thread name: RPC` which is what it was set to initially. After several container runs this message seems to be reasonable - there are no recorded issues of the Wallet RPC container hanging, but we had problems with Monerod in the past.