### PR TITLE
Different default directories for CLI and ASB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - An issue where both the ASB and the CLI point to the same default directory `xmr-btc-swap` for storing data.
-  The asb now uses `xmr-btc-swap-asb` and the CLI `xmr-btc-swap-cli` as default directory.
+  The asb now uses `xmr-btc-swap/asb` and the CLI `xmr-btc-swap/cli` as default directory.
   This is a breaking change.
-  If you want to access data created by a previous version you will have to rename the data folder or one of the following.
-  For the CLI you can use `--data-dir` to point to the old directory.
-  For the ASB you can change the data-dir in the config file of the ASB.
+  If you want to access data created by a previous version you will have to rename the data folder or one of the following:
+  1. For the CLI you can use `--data-dir` to point to the old directory.
+  2. For the ASB you can change the data-dir in the config file of the ASB.
 
 ## [0.5.0] - 2021-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- An issue where both the ASB and the CLI point to the same default directory `xmr-btc-swap` for storing data.
+  The asb now uses `xmr-btc-swap-asb` and the CLI `xmr-btc-swap-cli` as default directory.
+  This is a breaking change.
+  If you want to access data created by a previous version you will have to rename the data folder or one of the following.
+  For the CLI you can use `--data-dir` to point to the old directory.
+  For the ASB you can change the data-dir in the config file of the ASB.
+
 ## [0.5.0] - 2021-04-17
 
 ### Changed

--- a/swap/src/asb/config.rs
+++ b/swap/src/asb/config.rs
@@ -1,9 +1,10 @@
-use crate::fs::{default_data_dir, ensure_directory_exists};
+use crate::fs::ensure_directory_exists;
 use crate::tor::{DEFAULT_CONTROL_PORT, DEFAULT_SOCKS5_PORT};
 use anyhow::{Context, Result};
 use config::ConfigError;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Input;
+use directories_next::ProjectDirs;
 use libp2p::core::Multiaddr;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
@@ -99,6 +100,24 @@ pub fn read_config(config_path: PathBuf) -> Result<Result<Config, ConfigNotIniti
     Ok(Ok(file))
 }
 
+/// This is to store the configuration and seed files
+// Linux: /home/<user>/.config/xmr-btc-swap/config.toml
+// OSX: /Users/<user>/Library/Preferences/xmr-btc-swap/config.toml
+pub fn default_config_path() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "xmr-btc-swap-asb")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+        .map(|dir| Path::join(&dir, "config.toml"))
+        .context("Could not generate default configuration path")
+}
+
+/// This is the default location for storing data for the ASB
+// Linux: /home/<user>/.local/share/xmr-btc-swap-asb/
+// OSX: /Users/<user>/Library/Application Support/xmr-btc-swap-asb/
+fn asb_default_data_dir() -> Option<std::path::PathBuf> {
+    ProjectDirs::from("", "", "xmr-btc-swap-asb")
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+}
+
 pub fn initial_setup<F>(config_path: PathBuf, config_file: F) -> Result<()>
 where
     F: Fn() -> Result<Config>,
@@ -122,7 +141,7 @@ pub fn query_user_for_initial_testnet_config() -> Result<Config> {
     let data_dir = Input::with_theme(&ColorfulTheme::default())
         .with_prompt("Enter data directory for asb or hit return to use default")
         .default(
-            default_data_dir()
+            asb_default_data_dir()
                 .context("No default data dir value for this system")?
                 .to_str()
                 .context("Unsupported characters in default path")?

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -22,11 +22,11 @@ use std::sync::Arc;
 use structopt::StructOpt;
 use swap::asb::command::{Arguments, Command};
 use swap::asb::config::{
-    initial_setup, query_user_for_initial_testnet_config, read_config, Config, ConfigNotInitialized,
+    default_config_path, initial_setup, query_user_for_initial_testnet_config, read_config, Config,
+    ConfigNotInitialized,
 };
 use swap::database::Database;
 use swap::env::GetConfig;
-use swap::fs::default_config_path;
 use swap::monero::Amount;
 use swap::network::swarm;
 use swap::protocol::alice::event_loop::KrakenRate;

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -1,5 +1,5 @@
-use crate::fs::default_data_dir;
 use anyhow::{Context, Result};
+use directories_next::ProjectDirs;
 use libp2p::core::Multiaddr;
 use libp2p::PeerId;
 use std::path::PathBuf;
@@ -134,9 +134,16 @@ pub struct MoneroParams {
 #[derive(Clone, Debug)]
 pub struct Data(pub PathBuf);
 
+/// Default location for storing data for the CLI
+// Linux: /home/<user>/.local/share/xmr-btc-swap-cli/
+// OSX: /Users/<user>/Library/Application Support/xmr-btc-swap-cli/
 impl Default for Data {
     fn default() -> Self {
-        Data(default_data_dir().expect("computed valid path for data dir"))
+        Data(
+            ProjectDirs::from("", "", "xmr-btc-swap-cli")
+                .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+                .expect("computed valid path for data dir"),
+        )
     }
 }
 

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -1,8 +1,8 @@
+use crate::fs::system_data_dir;
 use anyhow::{Context, Result};
-use directories_next::ProjectDirs;
 use libp2p::core::Multiaddr;
 use libp2p::PeerId;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
@@ -135,13 +135,12 @@ pub struct MoneroParams {
 pub struct Data(pub PathBuf);
 
 /// Default location for storing data for the CLI
-// Linux: /home/<user>/.local/share/xmr-btc-swap-cli/
-// OSX: /Users/<user>/Library/Application Support/xmr-btc-swap-cli/
+// Takes the default system data-dir and adds a `/cli`
 impl Default for Data {
     fn default() -> Self {
         Data(
-            ProjectDirs::from("", "", "xmr-btc-swap-cli")
-                .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+            system_data_dir()
+                .map(|proj_dir| Path::join(&proj_dir, "cli"))
                 .expect("computed valid path for data dir"),
         )
     }

--- a/swap/src/fs.rs
+++ b/swap/src/fs.rs
@@ -1,5 +1,24 @@
-use anyhow::Result;
-use std::path::Path;
+use anyhow::{Context, Result};
+use directories_next::ProjectDirs;
+use std::path::{Path, PathBuf};
+
+/// This is the default location for the overall config-dir specific by system
+// Linux: /home/<user>/.config/xmr-btc-swap/
+// OSX: /Users/<user>/Library/Preferences/xmr-btc-swap/
+pub fn system_config_dir() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "xmr-btc-swap")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+        .context("Could not generate default system configuration dir path")
+}
+
+/// This is the default location for the overall data-dir specific by system
+// Linux: /home/<user>/.local/share/xmr-btc-swap/
+// OSX: /Users/<user>/Library/ApplicationSupport/xmr-btc-swap/
+pub fn system_data_dir() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "xmr-btc-swap")
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+        .context("Could not generate default system data-dir dir path")
+}
 
 pub fn ensure_directory_exists(file: &Path) -> Result<(), std::io::Error> {
     if let Some(path) = file.parent() {

--- a/swap/src/fs.rs
+++ b/swap/src/fs.rs
@@ -1,26 +1,5 @@
-use anyhow::{Context, Result};
-use directories_next::ProjectDirs;
-use std::path::{Path, PathBuf};
-
-/// This is to store the configuration and seed files
-// Linux: /home/<user>/.config/xmr-btc-swap/
-// OSX: /Users/<user>/Library/Preferences/xmr-btc-swap/
-fn default_config_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "", "xmr-btc-swap").map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
-}
-
-pub fn default_config_path() -> Result<PathBuf> {
-    default_config_dir()
-        .map(|dir| Path::join(&dir, "config.toml"))
-        .context("Could not generate default configuration path")
-}
-
-/// This is to store the DB
-// Linux: /home/<user>/.local/share/xmr-btc-swap/
-// OSX: /Users/<user>/Library/Application Support/xmr-btc-swap/
-pub fn default_data_dir() -> Option<std::path::PathBuf> {
-    ProjectDirs::from("", "", "xmr-btc-swap").map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
-}
+use anyhow::Result;
+use std::path::Path;
 
 pub fn ensure_directory_exists(file: &Path) -> Result<(), std::io::Error> {
     if let Some(path) = file.parent() {


### PR DESCRIPTION
Fixes #437 

Using the same default directory as data-/config-dir has caused unwanted side effects when running both applications on the same machine.
Use these directory names:
- ASB: `xmr-btc-swap-asb`
- CLI: `xmr-btc-swap-cli`

Since the functionality is now application specific the respective functions were moved into the appropriate module of the application.