### PR TITLE
Add resume-only mode for the ASB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If you want to access data created by a previous version you will have to rename the data folder or one of the following:
   1. For the CLI you can use `--data-dir` to point to the old directory.
   2. For the ASB you can change the data-dir in the config file of the ASB.
+- The CLI receives proper Error messages if setting up a swap with the ASB fails.
+  This is a breaking change because the spot-price protocol response changed.
+  Expected errors scenarios that are now reported back to the CLI:
+  1. Balance of ASB too low
+  2. Buy amount sent by CLI exceeds maximum buy amount accepted by ASB
+  3. ASB is running in resume-only mode and does not accept incoming swap requests
 
 ## [0.5.0] - 2021-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Resume-only mode for the ASB.
+  When started with `--resume-only` the ASB does not accept new, incoming swap requests but only finishes swaps that are resumed upon startup.
+
 ### Fixed
 
 - An issue where both the ASB and the CLI point to the same default directory `xmr-btc-swap` for storing data.

--- a/swap/src/asb/command.rs
+++ b/swap/src/asb/command.rs
@@ -34,6 +34,12 @@ pub enum Command {
             default_value = "0.02"
         )]
         ask_spread: Decimal,
+
+        #[structopt(
+            long = "resume-only",
+            help = "For maintenance only. When set, no new swap requests will be accepted, but existing unfinished swaps will be resumed."
+        )]
+        resume_only: bool,
     },
     History,
     WithdrawBtc {

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<()> {
         Command::Start {
             max_buy,
             ask_spread,
+            resume_only,
         } => {
             let bitcoin_wallet = init_bitcoin_wallet(&config, &seed, env_config).await?;
             let monero_wallet = init_monero_wallet(&config, env_config).await?;
@@ -133,6 +134,7 @@ async fn main() -> Result<()> {
                 Arc::new(db),
                 KrakenRate::new(ask_spread, kraken_price_updates),
                 max_buy,
+                resume_only,
             )
             .unwrap();
 

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -119,7 +119,17 @@ async fn main() -> Result<()> {
                 }
             };
 
-            let mut swarm = swarm::alice(&seed)?;
+            let current_balance = monero_wallet.get_balance().await?;
+            let lock_fee = monero_wallet.static_tx_fee_estimate();
+            let kraken_rate = KrakenRate::new(ask_spread, kraken_price_updates);
+            let mut swarm = swarm::alice(
+                &seed,
+                current_balance,
+                lock_fee,
+                max_buy,
+                kraken_rate.clone(),
+                resume_only,
+            )?;
 
             for listen in config.network.listen {
                 Swarm::listen_on(&mut swarm, listen.clone())
@@ -132,9 +142,8 @@ async fn main() -> Result<()> {
                 Arc::new(bitcoin_wallet),
                 Arc::new(monero_wallet),
                 Arc::new(db),
-                KrakenRate::new(ask_spread, kraken_price_updates),
+                kraken_rate,
                 max_buy,
-                resume_only,
             )
             .unwrap();
 

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -192,12 +192,6 @@ pub struct InsufficientFunds {
     pub actual: Amount,
 }
 
-#[derive(Debug, Clone, Copy, thiserror::Error)]
-#[error("The balance is too low, current balance: {balance}")]
-pub struct BalanceTooLow {
-    pub balance: Amount,
-}
-
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[error("Overflow, cannot convert {0} to u64")]
 pub struct OverflowError(pub String);

--- a/swap/src/network.rs
+++ b/swap/src/network.rs
@@ -10,3 +10,6 @@ pub mod swarm;
 pub mod tor_transport;
 pub mod transfer_proof;
 pub mod transport;
+
+#[cfg(any(test, feature = "test"))]
+pub mod test;

--- a/swap/src/network/spot_price.rs
+++ b/swap/src/network/spot_price.rs
@@ -41,7 +41,16 @@ pub struct Request {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Response {
-    pub xmr: monero::Amount,
+    pub xmr: Option<monero::Amount>,
+    pub error: Option<Error>,
+}
+
+#[derive(Clone, Debug, thiserror::Error, Serialize, Deserialize)]
+pub enum Error {
+    #[error(
+        "This seller currently does not accept incoming swap requests, please try again later"
+    )]
+    MaintenanceMode,
 }
 
 /// Constructs a new instance of the `spot-price` behaviour to be used by Alice.

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -1,13 +1,27 @@
 use crate::network::transport;
+use crate::protocol::alice::event_loop::LatestRate;
 use crate::protocol::{alice, bob};
 use crate::seed::Seed;
-use crate::tor;
+use crate::{monero, tor};
 use anyhow::Result;
 use libp2p::swarm::{NetworkBehaviour, SwarmBuilder};
 use libp2p::{PeerId, Swarm};
 
-pub fn alice(seed: &Seed) -> Result<Swarm<alice::Behaviour>> {
-    with_clear_net(seed, alice::Behaviour::default())
+pub fn alice<LR>(
+    seed: &Seed,
+    balance: monero::Amount,
+    lock_fee: monero::Amount,
+    max_buy: bitcoin::Amount,
+    latest_rate: LR,
+    resume_only: bool,
+) -> Result<Swarm<alice::Behaviour<LR>>>
+where
+    LR: LatestRate + Send + 'static,
+{
+    with_clear_net(
+        seed,
+        alice::Behaviour::new(balance, lock_fee, max_buy, latest_rate, resume_only),
+    )
 }
 
 pub async fn bob(

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -6,6 +6,7 @@ use crate::{monero, tor};
 use anyhow::Result;
 use libp2p::swarm::{NetworkBehaviour, SwarmBuilder};
 use libp2p::{PeerId, Swarm};
+use std::fmt::Debug;
 
 pub fn alice<LR>(
     seed: &Seed,
@@ -16,7 +17,7 @@ pub fn alice<LR>(
     resume_only: bool,
 ) -> Result<Swarm<alice::Behaviour<LR>>>
 where
-    LR: LatestRate + Send + 'static,
+    LR: LatestRate + Send + 'static + Debug,
 {
     with_clear_net(
         seed,

--- a/swap/src/network/test.rs
+++ b/swap/src/network/test.rs
@@ -1,0 +1,162 @@
+use futures::future;
+use libp2p::core::muxing::StreamMuxerBox;
+use libp2p::core::transport::memory::MemoryTransport;
+use libp2p::core::upgrade::{SelectUpgrade, Version};
+use libp2p::core::{Executor, Multiaddr};
+use libp2p::mplex::MplexConfig;
+use libp2p::noise::{self, NoiseConfig, X25519Spec};
+use libp2p::swarm::{
+    IntoProtocolsHandler, NetworkBehaviour, ProtocolsHandler, SwarmBuilder, SwarmEvent,
+};
+use libp2p::{identity, yamux, PeerId, Swarm, Transport};
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::time;
+
+/// An adaptor struct for libp2p that spawns futures into the current
+/// thread-local runtime.
+struct GlobalSpawnTokioExecutor;
+
+impl Executor for GlobalSpawnTokioExecutor {
+    fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+        let _ = tokio::spawn(future);
+    }
+}
+
+#[allow(missing_debug_implementations)]
+pub struct Actor<B: NetworkBehaviour> {
+    pub swarm: Swarm<B>,
+    pub addr: Multiaddr,
+    pub peer_id: PeerId,
+}
+
+pub async fn new_connected_swarm_pair<B, F>(behaviour_fn: F) -> (Actor<B>, Actor<B>)
+where
+    B: NetworkBehaviour,
+    F: Fn(PeerId, identity::Keypair) -> B + Clone,
+    <<<B as NetworkBehaviour>::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent: Clone,
+<B as NetworkBehaviour>::OutEvent: Debug{
+    let (swarm, addr, peer_id) = new_swarm(behaviour_fn.clone());
+    let mut alice = Actor {
+        swarm,
+        addr,
+        peer_id,
+    };
+
+    let (swarm, addr, peer_id) = new_swarm(behaviour_fn);
+    let mut bob = Actor {
+        swarm,
+        addr,
+        peer_id,
+    };
+
+    connect(&mut alice.swarm, &mut bob.swarm).await;
+
+    (alice, bob)
+}
+
+pub fn new_swarm<B: NetworkBehaviour, F: Fn(PeerId, identity::Keypair) -> B>(
+    behaviour_fn: F,
+) -> (Swarm<B>, Multiaddr, PeerId)
+where
+    B: NetworkBehaviour,
+{
+    let id_keys = identity::Keypair::generate_ed25519();
+    let peer_id = PeerId::from(id_keys.public());
+
+    let dh_keys = noise::Keypair::<X25519Spec>::new()
+        .into_authentic(&id_keys)
+        .expect("failed to create dh_keys");
+    let noise = NoiseConfig::xx(dh_keys).into_authenticated();
+
+    let transport = MemoryTransport::default()
+        .upgrade(Version::V1)
+        .authenticate(noise)
+        .multiplex(SelectUpgrade::new(
+            yamux::YamuxConfig::default(),
+            MplexConfig::new(),
+        ))
+        .timeout(Duration::from_secs(5))
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .boxed();
+
+    let mut swarm: Swarm<B> = SwarmBuilder::new(transport, behaviour_fn(peer_id, id_keys), peer_id)
+        .executor(Box::new(GlobalSpawnTokioExecutor))
+        .build();
+
+    let address_port = rand::random::<u64>();
+    let addr = format!("/memory/{}", address_port)
+        .parse::<Multiaddr>()
+        .unwrap();
+
+    Swarm::listen_on(&mut swarm, addr.clone()).unwrap();
+
+    (swarm, addr, peer_id)
+}
+
+pub async fn await_events_or_timeout<A, B>(
+    alice_event: impl Future<Output = A>,
+    bob_event: impl Future<Output = B>,
+) -> (A, B) {
+    time::timeout(
+        Duration::from_secs(10),
+        future::join(alice_event, bob_event),
+    )
+    .await
+    .expect("network behaviours to emit an event within 10 seconds")
+}
+
+/// Connects two swarms with each other.
+///
+/// This assumes the transport that is in use can be used by Bob to connect to
+/// the listen address that is emitted by Alice. In other words, they have to be
+/// on the same network. The memory transport used by the above `new_swarm`
+/// function fulfills this.
+///
+/// We also assume that the swarms don't emit any behaviour events during the
+/// connection phase. Any event emitted is considered a bug from this functions
+/// PoV because they would be lost.
+pub async fn connect<BA, BB>(alice: &mut Swarm<BA>, bob: &mut Swarm<BB>)
+where
+    BA: NetworkBehaviour,
+    BB: NetworkBehaviour,
+    <BA as NetworkBehaviour>::OutEvent: Debug,
+    <BB as NetworkBehaviour>::OutEvent: Debug,
+{
+    let mut alice_connected = false;
+    let mut bob_connected = false;
+
+    while !alice_connected && !bob_connected {
+        let (alice_event, bob_event) = future::join(alice.next_event(), bob.next_event()).await;
+
+        match alice_event {
+            SwarmEvent::ConnectionEstablished { .. } => {
+                alice_connected = true;
+            }
+            SwarmEvent::NewListenAddr(addr) => {
+                bob.dial_addr(addr).unwrap();
+            }
+            SwarmEvent::Behaviour(event) => {
+                panic!(
+                    "alice unexpectedly emitted a behaviour event during connection: {:?}",
+                    event
+                );
+            }
+            _ => {}
+        }
+        match bob_event {
+            SwarmEvent::ConnectionEstablished { .. } => {
+                bob_connected = true;
+            }
+            SwarmEvent::Behaviour(event) => {
+                panic!(
+                    "bob unexpectedly emitted a behaviour event during connection: {:?}",
+                    event
+                );
+            }
+            _ => {}
+        }
+    }
+}

--- a/swap/src/protocol/alice.rs
+++ b/swap/src/protocol/alice.rs
@@ -14,6 +14,7 @@ pub use self::swap::{run, run_until};
 mod behaviour;
 pub mod event_loop;
 mod execution_setup;
+mod spot_price;
 pub mod state;
 pub mod swap;
 

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -1,6 +1,8 @@
+use crate::monero;
 use crate::network::quote::BidQuote;
-use crate::network::{encrypted_signature, quote, spot_price, transfer_proof};
-use crate::protocol::alice::{execution_setup, State3};
+use crate::network::{encrypted_signature, quote, transfer_proof};
+use crate::protocol::alice::event_loop::LatestRate;
+use crate::protocol::alice::{execution_setup, spot_price, State3};
 use anyhow::{anyhow, Error};
 use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::{NetworkBehaviour, PeerId};
@@ -8,10 +10,10 @@ use uuid::Uuid;
 
 #[derive(Debug)]
 pub enum OutEvent {
-    SpotPriceRequested {
-        request: spot_price::Request,
-        channel: ResponseChannel<spot_price::Response>,
+    ExecutionSetupStart {
         peer: PeerId,
+        btc: bitcoin::Amount,
+        xmr: monero::Amount,
     },
     QuoteRequested {
         channel: ResponseChannel<BidQuote>,
@@ -60,19 +62,34 @@ impl OutEvent {
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "OutEvent", event_process = false)]
 #[allow(missing_debug_implementations)]
-pub struct Behaviour {
+pub struct Behaviour<LR: LatestRate + Send + 'static> {
     pub quote: quote::Behaviour,
-    pub spot_price: spot_price::Behaviour,
+    pub spot_price: spot_price::Behaviour<LR>,
     pub execution_setup: execution_setup::Behaviour,
     pub transfer_proof: transfer_proof::Behaviour,
     pub encrypted_signature: encrypted_signature::Behaviour,
 }
 
-impl Default for Behaviour {
-    fn default() -> Self {
+impl<LR> Behaviour<LR>
+where
+    LR: LatestRate + Send + 'static,
+{
+    pub fn new(
+        balance: monero::Amount,
+        lock_fee: monero::Amount,
+        max_buy: bitcoin::Amount,
+        latest_rate: LR,
+        resume_only: bool,
+    ) -> Self {
         Self {
             quote: quote::alice(),
-            spot_price: spot_price::alice(),
+            spot_price: spot_price::Behaviour::new(
+                balance,
+                lock_fee,
+                max_buy,
+                latest_rate,
+                resume_only,
+            ),
             execution_setup: Default::default(),
             transfer_proof: transfer_proof::alice(),
             encrypted_signature: encrypted_signature::alice(),

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -6,11 +6,14 @@ use crate::protocol::alice::{execution_setup, spot_price, State3};
 use anyhow::{anyhow, Error};
 use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::{NetworkBehaviour, PeerId};
-use std::fmt::Debug;
 use uuid::Uuid;
 
 #[derive(Debug)]
 pub enum OutEvent {
+    SwapRequestDeclined {
+        peer: PeerId,
+        error: spot_price::Error,
+    },
     ExecutionSetupStart {
         peer: PeerId,
         btc: bitcoin::Amount,
@@ -65,7 +68,7 @@ impl OutEvent {
 #[allow(missing_debug_implementations)]
 pub struct Behaviour<LR>
 where
-    LR: LatestRate + Send + 'static + Debug,
+    LR: LatestRate + Send + 'static,
 {
     pub quote: quote::Behaviour,
     pub spot_price: spot_price::Behaviour<LR>,
@@ -76,7 +79,7 @@ where
 
 impl<LR> Behaviour<LR>
 where
-    LR: LatestRate + Send + 'static + Debug,
+    LR: LatestRate + Send + 'static,
 {
     pub fn new(
         balance: monero::Amount,

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -6,6 +6,7 @@ use crate::protocol::alice::{execution_setup, spot_price, State3};
 use anyhow::{anyhow, Error};
 use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::{NetworkBehaviour, PeerId};
+use std::fmt::Debug;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -62,7 +63,10 @@ impl OutEvent {
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "OutEvent", event_process = false)]
 #[allow(missing_debug_implementations)]
-pub struct Behaviour<LR: LatestRate + Send + 'static> {
+pub struct Behaviour<LR>
+where
+    LR: LatestRate + Send + 'static + Debug,
+{
     pub quote: quote::Behaviour,
     pub spot_price: spot_price::Behaviour<LR>,
     pub execution_setup: execution_setup::Behaviour,
@@ -72,7 +76,7 @@ pub struct Behaviour<LR: LatestRate + Send + 'static> {
 
 impl<LR> Behaviour<LR>
 where
-    LR: LatestRate + Send + 'static,
+    LR: LatestRate + Send + 'static + Debug,
 {
     pub fn new(
         balance: monero::Amount,

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -16,6 +16,7 @@ use rand::rngs::OsRng;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -31,7 +32,10 @@ type OutgoingTransferProof =
     BoxFuture<'static, Result<(PeerId, transfer_proof::Request, bmrng::Responder<()>)>>;
 
 #[allow(missing_debug_implementations)]
-pub struct EventLoop<LR: LatestRate + Send + 'static> {
+pub struct EventLoop<LR>
+where
+    LR: LatestRate + Send + 'static + Debug,
+{
     swarm: libp2p::Swarm<Behaviour<LR>>,
     env_config: Config,
     bitcoin_wallet: Arc<bitcoin::Wallet>,
@@ -59,7 +63,7 @@ pub struct EventLoop<LR: LatestRate + Send + 'static> {
 
 impl<LR> EventLoop<LR>
 where
-    LR: LatestRate + Send + 'static,
+    LR: LatestRate + Send + 'static + Debug,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -2,7 +2,7 @@ use crate::asb::Rate;
 use crate::database::Database;
 use crate::env::Config;
 use crate::network::quote::BidQuote;
-use crate::network::{spot_price, transfer_proof};
+use crate::network::transfer_proof;
 use crate::protocol::alice::{AliceState, Behaviour, OutEvent, State0, State3, Swap};
 use crate::{bitcoin, kraken, monero};
 use anyhow::{Context, Result};
@@ -31,17 +31,16 @@ type OutgoingTransferProof =
     BoxFuture<'static, Result<(PeerId, transfer_proof::Request, bmrng::Responder<()>)>>;
 
 #[allow(missing_debug_implementations)]
-pub struct EventLoop<RS> {
-    swarm: libp2p::Swarm<Behaviour>,
+pub struct EventLoop<LR: LatestRate + Send + 'static> {
+    swarm: libp2p::Swarm<Behaviour<LR>>,
     env_config: Config,
     bitcoin_wallet: Arc<bitcoin::Wallet>,
     monero_wallet: Arc<monero::Wallet>,
     db: Arc<Database>,
-    latest_rate: RS,
+    latest_rate: LR,
     max_buy: bitcoin::Amount,
 
     swap_sender: mpsc::Sender<Swap>,
-    resume_only: bool,
 
     /// Stores incoming [`EncryptedSignature`]s per swap.
     recv_encrypted_signature: HashMap<Uuid, bmrng::RequestSender<bitcoin::EncryptedSignature, ()>>,
@@ -60,18 +59,17 @@ pub struct EventLoop<RS> {
 
 impl<LR> EventLoop<LR>
 where
-    LR: LatestRate,
+    LR: LatestRate + Send + 'static,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        swarm: Swarm<Behaviour>,
+        swarm: Swarm<Behaviour<LR>>,
         env_config: Config,
         bitcoin_wallet: Arc<bitcoin::Wallet>,
         monero_wallet: Arc<monero::Wallet>,
         db: Arc<Database>,
         latest_rate: LR,
         max_buy: bitcoin::Amount,
-        resume_only: bool,
     ) -> Result<(Self, mpsc::Receiver<Swap>)> {
         let swap_channel = MpscChannels::default();
 
@@ -83,7 +81,6 @@ where
             db,
             latest_rate,
             swap_sender: swap_channel.sender,
-            resume_only,
             max_buy,
             recv_encrypted_signature: Default::default(),
             inflight_encrypted_signatures: Default::default(),
@@ -146,38 +143,8 @@ where
             tokio::select! {
                 swarm_event = self.swarm.next_event() => {
                     match swarm_event {
-                        SwarmEvent::Behaviour(OutEvent::SpotPriceRequested { request, channel, peer }) => {
-                            let btc = request.btc;
-                            let xmr = match self.handle_spot_price_request(btc, self.monero_wallet.clone()).await {
-                                Ok(xmr) => match xmr {
-                                    Ok(xmr) => xmr,
-                                    Err(e) => {
-                                        tracing::warn!(%peer, "Ignoring spot price request from {} because: {:#}", peer, e);
-                                        match self.swarm.behaviour_mut().spot_price.send_response(channel, spot_price::Response::Error(e)) {
-                                            Ok(_) => {
-                                                continue;
-                                            },
-                                            Err(_) => {
-                                                tracing::debug!(%peer, "Failed to respond with error to spot price request");
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                },
-                                Err(e) => {
-                                    tracing::error!(%peer, "Unrecoverable error while producing spot price for {}: {:#}", btc, e);
-                                    continue;
-                                }
-                            };
+                        SwarmEvent::Behaviour(OutEvent::ExecutionSetupStart { peer, btc, xmr }) => {
 
-                            match self.swarm.behaviour_mut().spot_price.send_response(channel, spot_price::Response::Xmr(xmr)) {
-                                Ok(_) => {},
-                                Err(_) => {
-                                    // if we can't respond, the peer probably just disconnected so it is not a huge deal, only log this on debug
-                                    tracing::debug!(%peer, "Failed to respond with spot price");
-                                    continue;
-                                }
-                            }
                             let tx_redeem_fee = self.bitcoin_wallet
                                 .estimate_fee(bitcoin::TxRedeem::weight(), btc)
                                 .await;
@@ -195,7 +162,7 @@ where
                                     (redeem_address, punish_address)
                                 }
                                 _ => {
-                                    tracing::error!("Could not get new address.");
+                                    tracing::error!(%peer, "Failed to get new address during execution setup.");
                                     continue;
                                 }
                             };
@@ -208,7 +175,7 @@ where
                                     (tx_redeem_fee, tx_punish_fee)
                                 }
                                 _ => {
-                                    tracing::error!("Could not calculate transaction fees.");
+                                    tracing::error!(%peer, "Failed to calculate transaction fees during execution setup.");
                                     continue;
                                 }
                             };
@@ -233,6 +200,17 @@ where
                             self.swarm.behaviour_mut().execution_setup.run(peer, state0);
                         }
                         SwarmEvent::Behaviour(OutEvent::QuoteRequested { channel, peer }) => {
+                            // TODO: Move the spot-price update into dedicated update stream to decouple it from quote requests
+                            let current_balance = self.monero_wallet.get_balance().await;
+                            match current_balance {
+                                Ok(balance) => {
+                                    self.swarm.behaviour_mut().spot_price.update_balance(balance);
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to fetch Monero balance: {:#}", e);
+                                }
+                            }
+
                             let quote = match self.make_quote(self.max_buy).await {
                                 Ok(quote) => quote,
                                 Err(e) => {
@@ -360,38 +338,6 @@ where
         }
     }
 
-    async fn handle_spot_price_request(
-        &mut self,
-        btc: bitcoin::Amount,
-        monero_wallet: Arc<monero::Wallet>,
-    ) -> Result<Result<monero::Amount, spot_price::Error>> {
-        if self.resume_only {
-            return Ok(Err(spot_price::Error::MaintenanceMode));
-        }
-
-        let rate = self
-            .latest_rate
-            .latest_rate()
-            .context("Failed to get latest rate")?;
-
-        if btc > self.max_buy {
-            return Ok(Err(spot_price::Error::MaxBuyAmountExceeded {
-                buy: btc,
-                max: self.max_buy,
-            }));
-        }
-
-        let xmr_balance = monero_wallet.get_balance().await?;
-        let xmr_lock_fees = monero_wallet.static_tx_fee_estimate();
-        let xmr = rate.sell_quote(btc)?;
-
-        if xmr_balance < xmr + xmr_lock_fees {
-            return Ok(Err(spot_price::Error::BalanceTooLow { buy: btc }));
-        }
-
-        Ok(Ok(xmr))
-    }
-
     async fn make_quote(&mut self, max_buy: bitcoin::Amount) -> Result<BidQuote> {
         let rate = self
             .latest_rate
@@ -510,7 +456,7 @@ impl LatestRate for FixedRate {
 
 /// Produces [`Rate`]s based on [`PriceUpdate`]s from kraken and a configured
 /// spread.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KrakenRate {
     ask_spread: Decimal,
     price_updates: kraken::PriceUpdates,

--- a/swap/src/protocol/alice/spot_price.rs
+++ b/swap/src/protocol/alice/spot_price.rs
@@ -1,0 +1,199 @@
+use crate::monero;
+use crate::network::cbor_request_response::CborCodec;
+use crate::network::spot_price;
+use crate::network::spot_price::SpotPriceProtocol;
+use crate::protocol::alice;
+use crate::protocol::alice::event_loop::LatestRate;
+use libp2p::request_response::{
+    ProtocolSupport, RequestResponseConfig, RequestResponseEvent, RequestResponseMessage,
+    ResponseChannel,
+};
+use libp2p::swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters};
+use libp2p::{NetworkBehaviour, PeerId};
+use std::collections::VecDeque;
+use std::task::{Context, Poll};
+
+pub struct OutEvent {
+    peer: PeerId,
+    btc: bitcoin::Amount,
+    xmr: monero::Amount,
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "OutEvent", poll_method = "poll", event_process = true)]
+#[allow(missing_debug_implementations)]
+pub struct Behaviour<LR: LatestRate + Send + 'static> {
+    behaviour: spot_price::Behaviour,
+
+    #[behaviour(ignore)]
+    events: VecDeque<OutEvent>,
+
+    #[behaviour(ignore)]
+    balance: monero::Amount,
+    #[behaviour(ignore)]
+    lock_fee: monero::Amount,
+    #[behaviour(ignore)]
+    max_buy: bitcoin::Amount,
+    #[behaviour(ignore)]
+    latest_rate: LR,
+    #[behaviour(ignore)]
+    resume_only: bool,
+}
+
+/// Behaviour that handles spot prices.
+/// All the logic how to react to a spot price request is contained here, events
+/// reporting the successful handling of a spot price request or a failure are
+/// bubbled up to the parent behaviour.
+impl<LR> Behaviour<LR>
+where
+    LR: LatestRate + Send + 'static,
+{
+    pub fn new(
+        balance: monero::Amount,
+        lock_fee: monero::Amount,
+        max_buy: bitcoin::Amount,
+        latest_rate: LR,
+        resume_only: bool,
+    ) -> Self {
+        Self {
+            behaviour: spot_price::Behaviour::new(
+                CborCodec::default(),
+                vec![(SpotPriceProtocol, ProtocolSupport::Inbound)],
+                RequestResponseConfig::default(),
+            ),
+            events: Default::default(),
+            balance,
+            lock_fee,
+            max_buy,
+            latest_rate,
+            resume_only,
+        }
+    }
+
+    pub fn update_balance(&mut self, balance: monero::Amount) {
+        self.balance = balance;
+    }
+
+    fn send_error_response(
+        &mut self,
+        peer: PeerId,
+        channel: ResponseChannel<spot_price::Response>,
+        error: spot_price::Error,
+    ) {
+        if self
+            .behaviour
+            .send_response(channel, spot_price::Response::Error(error))
+            .is_err()
+        {
+            tracing::debug!(%peer, "Unable to send error response for spot price request");
+        }
+    }
+
+    fn poll<BIE>(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<BIE, OutEvent>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+        }
+
+        // We trust in libp2p to poll us.
+        Poll::Pending
+    }
+}
+
+impl<LR> NetworkBehaviourEventProcess<spot_price::OutEvent> for Behaviour<LR>
+where
+    LR: LatestRate + Send + 'static,
+{
+    fn inject_event(&mut self, event: spot_price::OutEvent) {
+        let (peer, message) = match event {
+            RequestResponseEvent::Message { peer, message } => (peer, message),
+            RequestResponseEvent::OutboundFailure { peer, error, .. } => {
+                tracing::error!(%peer, "Failure sending spot price response: {:#}", error);
+                return;
+            }
+            RequestResponseEvent::InboundFailure { peer, error, .. } => {
+                tracing::warn!(%peer, "Inbound failure when handling spot price request: {:#}", error);
+                return;
+            }
+            RequestResponseEvent::ResponseSent { peer, .. } => {
+                tracing::debug!(%peer, "Spot price response sent");
+                return;
+            }
+        };
+
+        let (request, channel) = match message {
+            RequestResponseMessage::Request {
+                request, channel, ..
+            } => (request, channel),
+            RequestResponseMessage::Response { .. } => {
+                tracing::error!("Unexpected message");
+                return;
+            }
+        };
+
+        if self.resume_only {
+            tracing::warn!(%peer, "Ignoring spot price request from {} because ASB is running in resume-only mode", peer);
+            self.send_error_response(peer, channel, spot_price::Error::NoSwapsAccepted);
+            return;
+        }
+
+        let btc = request.btc;
+        if btc > self.max_buy {
+            tracing::warn!(%peer, "Ignoring spot price request from {} because max muy amount exceeded", peer);
+            self.send_error_response(peer, channel, spot_price::Error::MaxBuyAmountExceeded {
+                max: self.max_buy,
+                buy: btc,
+            });
+            return;
+        }
+
+        let rate = match self.latest_rate.latest_rate() {
+            Ok(rate) => rate,
+            Err(e) => {
+                tracing::error!(%peer, "Ignoring spot price request from {} because we encountered a problem with fetching the latest rate: {:#}", peer, e);
+                self.send_error_response(peer, channel, spot_price::Error::Other);
+                return;
+            }
+        };
+        let xmr = match rate.sell_quote(btc) {
+            Ok(xmr) => xmr,
+            Err(e) => {
+                tracing::error!(%peer, "Ignoring spot price request from {} because we encountered a problem with calculating the amount from rate: {:#}", peer, e);
+                self.send_error_response(peer, channel, spot_price::Error::Other);
+                return;
+            }
+        };
+
+        let xmr_balance = self.balance;
+        let xmr_lock_fees = self.lock_fee;
+
+        if xmr_balance < xmr + xmr_lock_fees {
+            tracing::error!(%peer, "Ignoring spot price request from {} because the XMR balance is too low to fulfill the swap: {}", peer, xmr_balance);
+            self.send_error_response(peer, channel, spot_price::Error::BalanceTooLow { buy: btc });
+            return;
+        }
+
+        if self
+            .behaviour
+            .send_response(channel, spot_price::Response::Xmr(xmr))
+            .is_err()
+        {
+            tracing::error!(%peer, "Failed to send spot price response of {} for {}", xmr, btc)
+        }
+
+        self.events.push_back(OutEvent { peer, btc, xmr });
+    }
+}
+
+impl From<OutEvent> for alice::OutEvent {
+    fn from(event: OutEvent) -> Self {
+        Self::ExecutionSetupStart {
+            peer: event.peer,
+            btc: event.btc,
+            xmr: event.xmr,
+        }
+    }
+}

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -16,7 +16,7 @@ pub mod cancel;
 pub mod event_loop;
 mod execution_setup;
 pub mod refund;
-mod spot_price;
+pub mod spot_price;
 pub mod state;
 pub mod swap;
 

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -16,6 +16,7 @@ pub mod cancel;
 pub mod event_loop;
 mod execution_setup;
 pub mod refund;
+mod spot_price;
 pub mod state;
 pub mod swap;
 

--- a/swap/src/protocol/bob/behaviour.rs
+++ b/swap/src/protocol/bob/behaviour.rs
@@ -1,5 +1,6 @@
 use crate::network::quote::BidQuote;
 use crate::network::{encrypted_signature, quote, redial, spot_price, transfer_proof};
+use crate::protocol::bob;
 use crate::protocol::bob::{execution_setup, State2};
 use anyhow::{anyhow, Error, Result};
 use libp2p::core::Multiaddr;
@@ -71,7 +72,7 @@ impl Behaviour {
     pub fn new(alice: PeerId) -> Self {
         Self {
             quote: quote::bob(),
-            spot_price: spot_price::bob(),
+            spot_price: bob::spot_price::bob(),
             execution_setup: Default::default(),
             transfer_proof: transfer_proof::bob(),
             encrypted_signature: encrypted_signature::bob(),

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -2,6 +2,7 @@ use crate::bitcoin::EncryptedSignature;
 use crate::network::quote::BidQuote;
 use crate::network::spot_price::Response;
 use crate::network::{encrypted_signature, spot_price};
+use crate::protocol::bob;
 use crate::protocol::bob::{Behaviour, OutEvent, State0, State2};
 use crate::{bitcoin, monero};
 use anyhow::{bail, Context, Result};
@@ -270,6 +271,7 @@ impl EventLoopHandle {
         match response {
             Response::Xmr(xmr) => Ok(xmr),
             Response::Error(error) => {
+                let error: bob::spot_price::Error = error.into();
                 bail!(error);
             }
         }

--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -1,5 +1,6 @@
 use crate::bitcoin::EncryptedSignature;
 use crate::network::quote::BidQuote;
+use crate::network::spot_price::Response;
 use crate::network::{encrypted_signature, spot_price};
 use crate::protocol::bob::{Behaviour, OutEvent, State0, State2};
 use crate::{bitcoin, monero};
@@ -266,15 +267,10 @@ impl EventLoopHandle {
             .send_receive(spot_price::Request { btc })
             .await?;
 
-        match (response.xmr, response.error) {
-            (Some(xmr), None) => Ok(xmr),
-            (_, Some(error)) => {
+        match response {
+            Response::Xmr(xmr) => Ok(xmr),
+            Response::Error(error) => {
                 bail!(error);
-            }
-            (None, None) => {
-                bail!(
-                    "Unexpected response for spot-price request, neither price nor error received"
-                );
             }
         }
     }

--- a/swap/src/protocol/bob/spot_price.rs
+++ b/swap/src/protocol/bob/spot_price.rs
@@ -6,7 +6,7 @@ use libp2p::request_response::{ProtocolSupport, RequestResponseConfig};
 use libp2p::PeerId;
 
 const PROTOCOL: &str = spot_price::PROTOCOL;
-type SpotPriceOutEvent = spot_price::OutEvent;
+pub type SpotPriceOutEvent = spot_price::OutEvent;
 
 /// Constructs a new instance of the `spot-price` behaviour to be used by Bob.
 ///
@@ -37,7 +37,7 @@ impl From<(PeerId, spot_price::Message)> for OutEvent {
 
 crate::impl_from_rr_event!(SpotPriceOutEvent, OutEvent, PROTOCOL);
 
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error, PartialEq)]
 pub enum Error {
     #[error("Seller currently does not accept incoming swap requests, please try again later")]
     NoSwapsAccepted,

--- a/swap/src/protocol/bob/spot_price.rs
+++ b/swap/src/protocol/bob/spot_price.rs
@@ -1,0 +1,69 @@
+use crate::network::cbor_request_response::CborCodec;
+use crate::network::spot_price;
+use crate::network::spot_price::SpotPriceProtocol;
+use crate::protocol::bob::OutEvent;
+use libp2p::request_response::{ProtocolSupport, RequestResponseConfig};
+use libp2p::PeerId;
+
+const PROTOCOL: &str = spot_price::PROTOCOL;
+type SpotPriceOutEvent = spot_price::OutEvent;
+
+/// Constructs a new instance of the `spot-price` behaviour to be used by Bob.
+///
+/// Bob only supports outbound connections, i.e. requesting a spot price for a
+/// given amount of BTC in XMR.
+pub fn bob() -> spot_price::Behaviour {
+    spot_price::Behaviour::new(
+        CborCodec::default(),
+        vec![(SpotPriceProtocol, ProtocolSupport::Outbound)],
+        RequestResponseConfig::default(),
+    )
+}
+
+impl From<(PeerId, spot_price::Message)> for OutEvent {
+    fn from((peer, message): (PeerId, spot_price::Message)) -> Self {
+        match message {
+            spot_price::Message::Request { .. } => Self::unexpected_request(peer),
+            spot_price::Message::Response {
+                response,
+                request_id,
+            } => Self::SpotPriceReceived {
+                id: request_id,
+                response,
+            },
+        }
+    }
+}
+
+crate::impl_from_rr_event!(SpotPriceOutEvent, OutEvent, PROTOCOL);
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Seller currently does not accept incoming swap requests, please try again later")]
+    NoSwapsAccepted,
+    #[error("Seller refused to buy {buy} because the maximum configured buy limit is {max}")]
+    MaxBuyAmountExceeded {
+        max: bitcoin::Amount,
+        buy: bitcoin::Amount,
+    },
+    #[error("Seller's XMR balance is currently too low to fulfill the swap request to buy {buy}, please try again later")]
+    BalanceTooLow { buy: bitcoin::Amount },
+
+    /// To be used for errors that cannot be explained on the CLI side (e.g.
+    /// rate update problems on the seller side)
+    #[error("Seller encountered a problem, please try again later.")]
+    Other,
+}
+
+impl From<spot_price::Error> for Error {
+    fn from(error: spot_price::Error) -> Self {
+        match error {
+            spot_price::Error::NoSwapsAccepted => Error::NoSwapsAccepted,
+            spot_price::Error::MaxBuyAmountExceeded { max, buy } => {
+                Error::MaxBuyAmountExceeded { max, buy }
+            }
+            spot_price::Error::BalanceTooLow { buy } => Error::BalanceTooLow { buy },
+            spot_price::Error::Other => Error::Other,
+        }
+    }
+}

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -234,6 +234,7 @@ fn start_alice(
         db,
         FixedRate::default(),
         bitcoin::Amount::ONE_BTC,
+        false,
     )
     .unwrap();
 

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -90,7 +90,8 @@ where
         env_config,
         alice_bitcoin_wallet.clone(),
         alice_monero_wallet.clone(),
-    );
+    )
+    .await;
 
     let bob_seed = Seed::random().unwrap();
     let bob_starting_balances = StartingBalances::new(btc_amount * 10, monero::Amount::ZERO, None);
@@ -213,7 +214,7 @@ pub async fn init_electrs_container(
     Ok(docker)
 }
 
-fn start_alice(
+async fn start_alice(
     seed: &Seed,
     db_path: PathBuf,
     listen_address: Multiaddr,
@@ -223,7 +224,21 @@ fn start_alice(
 ) -> (AliceApplicationHandle, Receiver<alice::Swap>) {
     let db = Arc::new(Database::open(db_path.as_path()).unwrap());
 
-    let mut swarm = swarm::alice(&seed).unwrap();
+    let current_balance = monero_wallet.get_balance().await.unwrap();
+    let lock_fee = monero_wallet.static_tx_fee_estimate();
+    let max_buy = bitcoin::Amount::from_sat(u64::MAX);
+    let latest_rate = FixedRate::default();
+    let resume_only = false;
+
+    let mut swarm = swarm::alice(
+        &seed,
+        current_balance,
+        lock_fee,
+        max_buy,
+        latest_rate,
+        resume_only,
+    )
+    .unwrap();
     swarm.listen_on(listen_address).unwrap();
 
     let (event_loop, swap_handle) = alice::EventLoop::new(
@@ -234,7 +249,6 @@ fn start_alice(
         db,
         FixedRate::default(),
         bitcoin::Amount::ONE_BTC,
-        false,
     )
     .unwrap();
 
@@ -497,7 +511,8 @@ impl TestContext {
             self.env_config,
             self.alice_bitcoin_wallet.clone(),
             self.alice_monero_wallet.clone(),
-        );
+        )
+        .await;
 
         self.alice_handle = alice_handle;
         self.alice_swap_handle = alice_swap_handle;


### PR DESCRIPTION
Fixes #378 

Resume-only is a maintenance mode where no swaps are accepted but unfinished swaps are resumed.
This is achieve by ignoring incoming spot-price requests (that would lead to execution setup) in the event-loop.

- [x] Refactor `spot_price`, move Alice's decision logic into dedicated `NetworkBehaviour`
- [x] Protocol (network) level tests for the `spot_price` behaviour