### PR TITLE
Add support to dynamically chose bitcoin transaction fees. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitcoin"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,6 +2708,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.0",
+ "rand 0.8.3",
+ "rand_chacha 0.3.0",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2783,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quicksink"
@@ -2806,7 +2847,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
 
@@ -2979,6 +3020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -3196,6 +3246,18 @@ name = "rustversion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -3762,6 +3824,7 @@ dependencies = [
  "pem",
  "port_check",
  "prettytable-rs",
+ "proptest",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "reqwest",
@@ -4491,6 +4554,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -36,6 +36,7 @@ monero = { version = "0.12", features = [ "serde_support" ] }
 monero-rpc = { path = "../monero-rpc" }
 pem = "0.8"
 prettytable-rs = "0.8"
+proptest = "1"
 rand = "0.7"
 rand_chacha = "0.2"
 reqwest = { version = "0.11", features = [ "rustls-tls", "stream", "socks" ], default-features = false }

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -211,6 +211,7 @@ async fn init_bitcoin_wallet(
         &wallet_dir,
         seed.derive_extended_private_key(env_config.bitcoin_network)?,
         env_config,
+        6, // TODO move this into config
     )
     .await
     .context("Failed to initialize Bitcoin wallet")?;

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -211,7 +211,7 @@ async fn init_bitcoin_wallet(
         &wallet_dir,
         seed.derive_extended_private_key(env_config.bitcoin_network)?,
         env_config,
-        6, // TODO move this into config
+        config.bitcoin.target_block,
     )
     .await
     .context("Failed to initialize Bitcoin wallet")?;

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -272,6 +272,7 @@ async fn init_bitcoin_wallet(
         &wallet_dir,
         seed.derive_extended_private_key(env_config.bitcoin_network)?,
         env_config,
+        6, // TODO move this into config
     )
     .await
     .context("Failed to initialize Bitcoin wallet")?;

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -37,18 +37,10 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
+pub use crate::bitcoin::cancel::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_CANCEL;
 pub use crate::bitcoin::punish::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_PUNISH;
 pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REDEEM;
 pub use crate::bitcoin::refund::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REFUND;
-
-// TODO: Configurable tx-fee (note: parties have to agree prior to swapping)
-// Current reasoning:
-// tx with largest weight (as determined by get_weight() upon broadcast in e2e
-// test) = 609 assuming segwit and 60 sat/vB:
-// (609 / 4) * 60 (sat/vB) = 9135 sats
-// Recommended: Overpay a bit to ensure we don't have to wait too long for test
-// runs.
-pub const TX_FEE: u64 = 15_000;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct SecretKey {

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -37,6 +37,8 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
+pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REDEEM;
+
 // TODO: Configurable tx-fee (note: parties have to agree prior to swapping)
 // Current reasoning:
 // tx with largest weight (as determined by get_weight() upon broadcast in e2e

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -37,10 +37,10 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
-pub use crate::bitcoin::cancel::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_CANCEL;
-pub use crate::bitcoin::punish::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_PUNISH;
-pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REDEEM;
-pub use crate::bitcoin::refund::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REFUND;
+pub use crate::bitcoin::cancel::ESTIMATED_WEIGHT as TX_CANCEL_ESTIMATED_WEIGHT;
+pub use crate::bitcoin::punish::ESTIMATED_WEIGHT as TX_PUNISH_ESTIMATED_WEIGHT;
+pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as TX_REDEEM_ESTIMATED_WEIGHT;
+pub use crate::bitcoin::refund::ESTIMATED_WEIGHT as TX_REFUND_ESTIMATED_WEIGHT;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct SecretKey {

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -37,7 +37,9 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
+pub use crate::bitcoin::punish::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_PUNISH;
 pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REDEEM;
+pub use crate::bitcoin::refund::ESTIMATED_WEIGHT as ESTIMATED_WEIGHT_TX_REFUND;
 
 // TODO: Configurable tx-fee (note: parties have to agree prior to swapping)
 // Current reasoning:

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -37,11 +37,6 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
-pub use crate::bitcoin::cancel::ESTIMATED_WEIGHT as TX_CANCEL_ESTIMATED_WEIGHT;
-pub use crate::bitcoin::punish::ESTIMATED_WEIGHT as TX_PUNISH_ESTIMATED_WEIGHT;
-pub use crate::bitcoin::redeem::ESTIMATED_WEIGHT as TX_REDEEM_ESTIMATED_WEIGHT;
-pub use crate::bitcoin::refund::ESTIMATED_WEIGHT as TX_REFUND_ESTIMATED_WEIGHT;
-
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct SecretKey {
     inner: Scalar,
@@ -259,6 +254,12 @@ pub struct NotThreeWitnesses(usize);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bitcoin::wallet::EstimateFeeRate;
+    use crate::env::{GetConfig, Regtest};
+    use crate::protocol::{alice, bob};
+    use bdk::FeeRate;
+    use rand::rngs::OsRng;
+    use uuid::Uuid;
 
     #[test]
     fn lock_confirmations_le_to_cancel_timelock_no_timelock_expired() {
@@ -303,5 +304,121 @@ mod tests {
         );
 
         assert_eq!(expired_timelock, ExpiredTimelocks::Punish)
+    }
+
+    struct StaticFeeRate {}
+    impl EstimateFeeRate for StaticFeeRate {
+        fn estimate_feerate(&self, _target_block: usize) -> Result<FeeRate> {
+            Ok(FeeRate::default_min_relay_fee())
+        }
+
+        fn min_relay_fee(&self) -> Result<bitcoin::Amount> {
+            Ok(bitcoin::Amount::from_sat(1_000))
+        }
+    }
+
+    #[tokio::test]
+    async fn calculate_transaction_weights() {
+        let alice_wallet = Wallet::new_funded(Amount::ONE_BTC.as_sat(), StaticFeeRate {});
+        let bob_wallet = Wallet::new_funded(Amount::ONE_BTC.as_sat(), StaticFeeRate {});
+        let spending_fee = Amount::from_sat(1_000);
+        let btc_amount = Amount::from_sat(500_000);
+        let xmr_amount = crate::monero::Amount::from_piconero(10000);
+
+        let tx_redeem_fee = alice_wallet.estimate_fee(TxRedeem::weight()).await.unwrap();
+        let tx_punish_fee = alice_wallet.estimate_fee(TxPunish::weight()).await.unwrap();
+        let redeem_address = alice_wallet.new_address().await.unwrap();
+        let punish_address = alice_wallet.new_address().await.unwrap();
+
+        let config = Regtest::get_config();
+        let alice_state0 = alice::State0::new(
+            btc_amount,
+            xmr_amount,
+            config,
+            redeem_address,
+            punish_address,
+            tx_redeem_fee,
+            tx_punish_fee,
+            &mut OsRng,
+        )
+        .unwrap();
+
+        let bob_state0 = bob::State0::new(
+            Uuid::new_v4(),
+            &mut OsRng,
+            btc_amount,
+            xmr_amount,
+            config.bitcoin_cancel_timelock,
+            config.bitcoin_punish_timelock,
+            bob_wallet.new_address().await.unwrap(),
+            config.monero_finality_confirmations,
+            spending_fee,
+            spending_fee,
+        );
+
+        let message0 = bob_state0.next_message();
+
+        let (_, alice_state1) = alice_state0.receive(message0).unwrap();
+        let alice_message1 = alice_state1.next_message();
+
+        let bob_state1 = bob_state0
+            .receive(&bob_wallet, alice_message1)
+            .await
+            .unwrap();
+        let bob_message2 = bob_state1.next_message();
+
+        let alice_state2 = alice_state1.receive(bob_message2).unwrap();
+        let alice_message3 = alice_state2.next_message();
+
+        let bob_state2 = bob_state1.receive(alice_message3).unwrap();
+        let bob_message4 = bob_state2.next_message();
+
+        let alice_state3 = alice_state2.receive(bob_message4).unwrap();
+
+        let (bob_state3, _tx_lock) = bob_state2.lock_btc().await.unwrap();
+        let bob_state4 = bob_state3.xmr_locked(monero_rpc::wallet::BlockHeight { height: 0 });
+        let encrypted_signature = bob_state4.tx_redeem_encsig();
+        let bob_state6 = bob_state4.cancel();
+
+        let cancel_transaction = alice_state3.signed_cancel_transaction().unwrap();
+        let punish_transaction = alice_state3.signed_punish_transaction().unwrap();
+        let redeem_transaction = alice_state3
+            .signed_redeem_transaction(encrypted_signature)
+            .unwrap();
+        let refund_transaction = bob_state6.signed_refund_transaction().unwrap();
+
+        assert_weight(
+            redeem_transaction.get_weight(),
+            TxRedeem::weight(),
+            "TxRedeem",
+        );
+        assert_weight(
+            cancel_transaction.get_weight(),
+            TxCancel::weight(),
+            "TxCancel",
+        );
+        assert_weight(
+            punish_transaction.get_weight(),
+            TxPunish::weight(),
+            "TxPunish",
+        );
+        assert_weight(
+            refund_transaction.get_weight(),
+            TxRefund::weight(),
+            "TxRefund",
+        );
+    }
+
+    // Weights fluctuate -+2 wu assuming because of the length of the signatures.
+    fn assert_weight(is_weight: usize, expected_weight: usize, tx_name: &str) {
+        assert!(
+            is_weight + 1 == expected_weight
+                || is_weight + 2 == expected_weight
+                || is_weight == expected_weight,
+            "{} to have weight {}, but was {}",
+            tx_name,
+            expected_weight,
+            is_weight
+        )
     }
 }

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -325,8 +325,14 @@ mod tests {
         let btc_amount = Amount::from_sat(500_000);
         let xmr_amount = crate::monero::Amount::from_piconero(10000);
 
-        let tx_redeem_fee = alice_wallet.estimate_fee(TxRedeem::weight()).await.unwrap();
-        let tx_punish_fee = alice_wallet.estimate_fee(TxPunish::weight()).await.unwrap();
+        let tx_redeem_fee = alice_wallet
+            .estimate_fee(TxRedeem::weight(), btc_amount)
+            .await
+            .unwrap();
+        let tx_punish_fee = alice_wallet
+            .estimate_fee(TxPunish::weight(), btc_amount)
+            .await
+            .unwrap();
         let redeem_address = alice_wallet.new_address().await.unwrap();
         let punish_address = alice_wallet.new_address().await.unwrap();
 

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -415,7 +415,9 @@ mod tests {
         );
     }
 
-    // Weights fluctuate -+2 wu assuming because of the length of the signatures.
+    // Weights fluctuate -+1 wu because of the length of the signatures.
+    // Some of our transactions have 2 signatures and hence the weight can fluctuate
+    // +-2
     fn assert_weight(is_weight: usize, expected_weight: usize, tx_name: &str) {
         assert!(
             is_weight + 1 == expected_weight

--- a/swap/src/bitcoin/cancel.rs
+++ b/swap/src/bitcoin/cancel.rs
@@ -13,8 +13,9 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ops::Add;
 
-// TODO take real tx weight from past transaction
-pub const ESTIMATED_WEIGHT: usize = 10_000;
+// Taken from https://mempool.space/testnet/tx/8da32d6cada4903c7043563c50cacce656a8be9e02f233201996739df5368b1f
+// The weight might fluctuate slightly in reality.
+pub const ESTIMATED_WEIGHT: usize = 485;
 
 /// Represent a timelock, expressed in relative block height as defined in
 /// [BIP68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki).

--- a/swap/src/bitcoin/cancel.rs
+++ b/swap/src/bitcoin/cancel.rs
@@ -216,6 +216,7 @@ impl TxCancel {
         &self,
         spend_address: &Address,
         sequence: Option<PunishTimelock>,
+        spending_fee: Amount,
     ) -> Transaction {
         let previous_output = self.as_outpoint();
 
@@ -227,7 +228,7 @@ impl TxCancel {
         };
 
         let tx_out = TxOut {
-            value: self.amount().as_sat() - TX_FEE,
+            value: self.amount().as_sat() - spending_fee.as_sat(),
             script_pubkey: spend_address.script_pubkey(),
         };
 

--- a/swap/src/bitcoin/cancel.rs
+++ b/swap/src/bitcoin/cancel.rs
@@ -13,10 +13,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ops::Add;
 
-// Taken from https://mempool.space/testnet/tx/8da32d6cada4903c7043563c50cacce656a8be9e02f233201996739df5368b1f
-// The weight might fluctuate slightly in reality.
-pub const ESTIMATED_WEIGHT: usize = 485;
-
 /// Represent a timelock, expressed in relative block height as defined in
 /// [BIP68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki).
 /// E.g. The timelock expires 10 blocks after the reference transaction is
@@ -242,6 +238,10 @@ impl TxCancel {
             input: vec![tx_in],
             output: vec![tx_out],
         }
+    }
+
+    pub fn weight() -> usize {
+        596
     }
 }
 

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -148,10 +148,11 @@ impl TxLock {
             witness: Vec::new(),
         };
 
-        let i = spending_fee.as_sat();
-        tracing::debug!("Redeem tx fee: {}", i);
+        let spending_fee = spending_fee.as_sat();
+        tracing::debug!(%spending_fee, "Redeem tx fee");
         let tx_out = TxOut {
-            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value - i,
+            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value
+                - spending_fee,
             script_pubkey: spend_address.script_pubkey(),
         };
 

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -136,6 +136,7 @@ impl TxLock {
         &self,
         spend_address: &Address,
         sequence: Option<u32>,
+        spending_fee: Amount,
     ) -> Transaction {
         let previous_output = self.as_outpoint();
 
@@ -147,7 +148,8 @@ impl TxLock {
         };
 
         let tx_out = TxOut {
-            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value - TX_FEE,
+            value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value
+                - spending_fee.as_sat(),
             script_pubkey: spend_address.script_pubkey(),
         };
 

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::wallet::Watchable;
 use crate::bitcoin::{
-    build_shared_output_descriptor, Address, Amount, PublicKey, Transaction, Wallet, TX_FEE,
+    build_shared_output_descriptor, Address, Amount, PublicKey, Transaction, Wallet,
 };
 use ::bitcoin::util::psbt::PartiallySignedTransaction;
 use ::bitcoin::{OutPoint, TxIn, TxOut, Txid};

--- a/swap/src/bitcoin/punish.rs
+++ b/swap/src/bitcoin/punish.rs
@@ -7,8 +7,9 @@ use bdk::bitcoin::Script;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
 
-// TODO take real tx weight from past transaction
-pub const ESTIMATED_WEIGHT: usize = 10_000;
+// Taken from https://mempool.space/testnet/tx/ed4d60bc1fd172feca444ed3d06cccb90346b9098c2d28d2d034dac66f608f68
+// The weight might fluctuate slightly in reality.
+pub const ESTIMATED_WEIGHT: usize = 547;
 
 #[derive(Debug)]
 pub struct TxPunish {

--- a/swap/src/bitcoin/punish.rs
+++ b/swap/src/bitcoin/punish.rs
@@ -7,10 +7,6 @@ use bdk::bitcoin::Script;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
 
-// Taken from https://mempool.space/testnet/tx/ed4d60bc1fd172feca444ed3d06cccb90346b9098c2d28d2d034dac66f608f68
-// The weight might fluctuate slightly in reality.
-pub const ESTIMATED_WEIGHT: usize = 547;
-
 #[derive(Debug)]
 pub struct TxPunish {
     inner: Transaction,
@@ -76,6 +72,10 @@ impl TxPunish {
             .context("Failed to satisfy inputs with given signatures")?;
 
         Ok(tx_punish)
+    }
+
+    pub fn weight() -> usize {
+        548
     }
 }
 

--- a/swap/src/bitcoin/punish.rs
+++ b/swap/src/bitcoin/punish.rs
@@ -1,11 +1,14 @@
 use crate::bitcoin::wallet::Watchable;
-use crate::bitcoin::{self, Address, PunishTimelock, Transaction, TxCancel, Txid};
+use crate::bitcoin::{self, Address, Amount, PunishTimelock, Transaction, TxCancel, Txid};
 use ::bitcoin::util::bip143::SigHashCache;
 use ::bitcoin::{SigHash, SigHashType};
 use anyhow::{Context, Result};
 use bdk::bitcoin::Script;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
+
+// TODO take real tx weight from past transaction
+pub const ESTIMATED_WEIGHT: usize = 10_000;
 
 #[derive(Debug)]
 pub struct TxPunish {
@@ -20,8 +23,10 @@ impl TxPunish {
         tx_cancel: &TxCancel,
         punish_address: &Address,
         punish_timelock: PunishTimelock,
+        spending_fee: Amount,
     ) -> Self {
-        let tx_punish = tx_cancel.build_spend_transaction(punish_address, Some(punish_timelock));
+        let tx_punish =
+            tx_cancel.build_spend_transaction(punish_address, Some(punish_timelock), spending_fee);
 
         let digest = SigHashCache::new(&tx_punish).signature_hash(
             0, // Only one input: cancel transaction

--- a/swap/src/bitcoin/redeem.rs
+++ b/swap/src/bitcoin/redeem.rs
@@ -15,8 +15,9 @@ use miniscript::{Descriptor, DescriptorTrait};
 use sha2::Sha256;
 use std::collections::HashMap;
 
-// TODO take real tx weight from past transaction
-pub const ESTIMATED_WEIGHT: usize = 10_000;
+// Taken from https://mempool.space/testnet/tx/80c265f5c3862075aab2bd8c94e261b092bc13a34294c6fb4071717fbf46c801
+// The weight might fluctuate slightly in reality.
+pub const ESTIMATED_WEIGHT: usize = 547;
 
 #[derive(Clone, Debug)]
 pub struct TxRedeem {

--- a/swap/src/bitcoin/redeem.rs
+++ b/swap/src/bitcoin/redeem.rs
@@ -15,10 +15,6 @@ use miniscript::{Descriptor, DescriptorTrait};
 use sha2::Sha256;
 use std::collections::HashMap;
 
-// Taken from https://mempool.space/testnet/tx/80c265f5c3862075aab2bd8c94e261b092bc13a34294c6fb4071717fbf46c801
-// The weight might fluctuate slightly in reality.
-pub const ESTIMATED_WEIGHT: usize = 547;
-
 #[derive(Clone, Debug)]
 pub struct TxRedeem {
     inner: Transaction,
@@ -136,6 +132,15 @@ impl TxRedeem {
             .context("Neither signature on witness stack verifies against B")?;
 
         Ok(sig)
+    }
+
+    pub fn weight() -> usize {
+        548
+    }
+
+    #[cfg(test)]
+    pub fn inner(&self) -> Transaction {
+        self.inner.clone()
     }
 }
 

--- a/swap/src/bitcoin/refund.rs
+++ b/swap/src/bitcoin/refund.rs
@@ -11,8 +11,9 @@ use ecdsa_fun::Signature;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
 
-// TODO take real tx weight from past transaction
-pub const ESTIMATED_WEIGHT: usize = 10_000;
+// Taken from https://mempool.space/testnet/tx/10aef570973bcf524b1a6e8d2eaf3bc1522e776381fc7520fd8987fba96e5424
+// The weight might fluctuate slightly in reality.
+pub const ESTIMATED_WEIGHT: usize = 547;
 
 #[derive(Debug)]
 pub struct TxRefund {

--- a/swap/src/bitcoin/refund.rs
+++ b/swap/src/bitcoin/refund.rs
@@ -11,10 +11,6 @@ use ecdsa_fun::Signature;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
 
-// Taken from https://mempool.space/testnet/tx/10aef570973bcf524b1a6e8d2eaf3bc1522e776381fc7520fd8987fba96e5424
-// The weight might fluctuate slightly in reality.
-pub const ESTIMATED_WEIGHT: usize = 547;
-
 #[derive(Debug)]
 pub struct TxRefund {
     inner: Transaction,
@@ -140,6 +136,10 @@ impl TxRefund {
             .context("Neither signature on witness stack verifies against B")?;
 
         Ok(sig)
+    }
+
+    pub fn weight() -> usize {
+        548
     }
 }
 

--- a/swap/src/bitcoin/refund.rs
+++ b/swap/src/bitcoin/refund.rs
@@ -1,7 +1,7 @@
 use crate::bitcoin::wallet::Watchable;
 use crate::bitcoin::{
-    verify_sig, Address, EmptyWitnessStack, NoInputs, NotThreeWitnesses, PublicKey, TooManyInputs,
-    Transaction, TxCancel,
+    verify_sig, Address, Amount, EmptyWitnessStack, NoInputs, NotThreeWitnesses, PublicKey,
+    TooManyInputs, Transaction, TxCancel,
 };
 use crate::{bitcoin, monero};
 use ::bitcoin::util::bip143::SigHashCache;
@@ -10,6 +10,9 @@ use anyhow::{bail, Context, Result};
 use ecdsa_fun::Signature;
 use miniscript::{Descriptor, DescriptorTrait};
 use std::collections::HashMap;
+
+// TODO take real tx weight from past transaction
+pub const ESTIMATED_WEIGHT: usize = 10_000;
 
 #[derive(Debug)]
 pub struct TxRefund {
@@ -20,10 +23,10 @@ pub struct TxRefund {
 }
 
 impl TxRefund {
-    pub fn new(tx_cancel: &TxCancel, refund_address: &Address) -> Self {
-        let tx_punish = tx_cancel.build_spend_transaction(refund_address, None);
+    pub fn new(tx_cancel: &TxCancel, refund_address: &Address, spending_fee: Amount) -> Self {
+        let tx_refund = tx_cancel.build_spend_transaction(refund_address, None, spending_fee);
 
-        let digest = SigHashCache::new(&tx_punish).signature_hash(
+        let digest = SigHashCache::new(&tx_refund).signature_hash(
             0, // Only one input: cancel transaction
             &tx_cancel.output_descriptor.script_code(),
             tx_cancel.amount().as_sat(),
@@ -31,7 +34,7 @@ impl TxRefund {
         );
 
         Self {
-            inner: tx_punish,
+            inner: tx_refund,
             digest,
             cancel_output_descriptor: tx_cancel.output_descriptor.clone(),
             watch_script: refund_address.script_pubkey(),

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -23,7 +23,6 @@ use tokio::sync::{watch, Mutex};
 
 const SLED_TREE_NAME: &str = "default_tree";
 
-// TODO make these values configurable
 /// Assuming we add a spread of 3% we don't want to pay more than 3% of the
 /// amount for tx fees.
 const MAX_RELATIVE_TX_FEE: f64 = 0.03;

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -326,7 +326,7 @@ where
         Ok(Amount::from_sat(max_giveable))
     }
 
-    /// Estimate total tx fee based for a pre-defined target block based on the
+    /// Estimate total tx fee for a pre-defined target block based on the
     /// transaction weight. The max fee cannot be more than MAX_PERCENTAGE_FEE
     /// of amount
     pub async fn estimate_fee(
@@ -357,7 +357,7 @@ fn estimate_fee(
 ) -> Amount {
     // Doing some heavy math here :)
     // `usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide.
-    // This fine because such a big transaction cannot exist and there are also no
+    // This is fine because such a big transaction cannot exist and there are also no
     // negative fees.
     #[allow(
         clippy::cast_precision_loss,

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -356,8 +356,8 @@ fn estimate_fee(
 ) -> Amount {
     // Doing some heavy math here :)
     // `usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide.
-    // This is fine because such a big transaction cannot exist and there are also no
-    // negative fees.
+    // This is fine because such a big transaction cannot exist and there are also
+    // no negative fees.
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -16,7 +16,7 @@ const DEFAULT_ELECTRUM_RPC_URL: &str = "ssl://electrum.blockstream.info:60002";
 const DEFAULT_TOR_SOCKS5_PORT: &str = "9050";
 
 // Bitcoin transactions should be confirmed within X blocks
-const DEFAUL_BITCOIN_CONFIRMATION_TARGET: &str = "3";
+const DEFAULT_BITCOIN_CONFIRMATION_TARGET: &str = "3";
 
 #[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "swap", about = "CLI for swapping BTC for XMR", author)]
@@ -57,7 +57,7 @@ pub enum Command {
         #[structopt(long = "tor-socks5-port", help = "Your local Tor socks5 proxy port", default_value = DEFAULT_TOR_SOCKS5_PORT)]
         tor_socks5_port: u16,
 
-        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAULT_BITCOIN_CONFIRMATION_TARGET)]
         bitcoin_target_block: usize,
     },
     /// Show a list of past ongoing and completed swaps
@@ -85,7 +85,7 @@ pub enum Command {
         #[structopt(long = "tor-socks5-port", help = "Your local Tor socks5 proxy port", default_value = DEFAULT_TOR_SOCKS5_PORT)]
         tor_socks5_port: u16,
 
-        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAULT_BITCOIN_CONFIRMATION_TARGET)]
         bitcoin_target_block: usize,
     },
     /// Try to cancel an ongoing swap (expert users only)
@@ -105,7 +105,7 @@ pub enum Command {
         )]
         electrum_rpc_url: Url,
 
-        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAULT_BITCOIN_CONFIRMATION_TARGET)]
         bitcoin_target_block: usize,
     },
     /// Try to cancel a swap and refund my BTC (expert users only)
@@ -125,7 +125,7 @@ pub enum Command {
         )]
         electrum_rpc_url: Url,
 
-        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAULT_BITCOIN_CONFIRMATION_TARGET)]
         bitcoin_target_block: usize,
     },
 }

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -15,6 +15,9 @@ const DEFAULT_ELECTRUM_RPC_URL: &str = "ssl://electrum.blockstream.info:60002";
 
 const DEFAULT_TOR_SOCKS5_PORT: &str = "9050";
 
+// Bitcoin transactions should be confirmed within X blocks
+const DEFAUL_BITCOIN_CONFIRMATION_TARGET: &str = "3";
+
 #[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "swap", about = "CLI for swapping BTC for XMR", author)]
 pub struct Arguments {
@@ -53,6 +56,9 @@ pub enum Command {
 
         #[structopt(long = "tor-socks5-port", help = "Your local Tor socks5 proxy port", default_value = DEFAULT_TOR_SOCKS5_PORT)]
         tor_socks5_port: u16,
+
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        bitcoin_target_block: usize,
     },
     /// Show a list of past ongoing and completed swaps
     History,
@@ -78,6 +84,9 @@ pub enum Command {
 
         #[structopt(long = "tor-socks5-port", help = "Your local Tor socks5 proxy port", default_value = DEFAULT_TOR_SOCKS5_PORT)]
         tor_socks5_port: u16,
+
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        bitcoin_target_block: usize,
     },
     /// Try to cancel an ongoing swap (expert users only)
     Cancel {
@@ -95,6 +104,9 @@ pub enum Command {
         default_value = DEFAULT_ELECTRUM_RPC_URL
         )]
         electrum_rpc_url: Url,
+
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        bitcoin_target_block: usize,
     },
     /// Try to cancel a swap and refund my BTC (expert users only)
     Refund {
@@ -112,6 +124,9 @@ pub enum Command {
         default_value = DEFAULT_ELECTRUM_RPC_URL
         )]
         electrum_rpc_url: Url,
+
+        #[structopt(long = "bitcoin-target-block", help = "Within how many blocks should the Bitcoin transactions be confirmed.", default_value = DEFAUL_BITCOIN_CONFIRMATION_TARGET)]
+        bitcoin_target_block: usize,
     },
 }
 

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -28,6 +28,8 @@ pub struct Message0 {
     dleq_proof_s_b: CrossCurveDLEQProof,
     v_b: monero::PrivateViewKey,
     refund_address: bitcoin::Address,
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
+    tx_refund_fee: bitcoin::Amount,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,6 +43,8 @@ pub struct Message1 {
     punish_address: bitcoin::Address,
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     tx_redeem_fee: bitcoin::Amount,
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
+    tx_punish_fee: bitcoin::Amount,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -39,6 +39,8 @@ pub struct Message1 {
     v_a: monero::PrivateViewKey,
     redeem_address: bitcoin::Address,
     punish_address: bitcoin::Address,
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
+    tx_redeem_fee: bitcoin::Amount,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -30,6 +30,8 @@ pub struct Message0 {
     refund_address: bitcoin::Address,
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     tx_refund_fee: bitcoin::Amount,
+    #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
+    tx_cancel_fee: bitcoin::Amount,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -161,7 +161,6 @@ where
                                     continue;
                                 }
                             }
-                            // TODO: This should be cleaned up.
                             let tx_redeem_fee = self.bitcoin_wallet
                                 .estimate_fee(bitcoin::TxRedeem::weight(), btc)
                                 .await;

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -163,10 +163,10 @@ where
                             }
                             // TODO: This should be cleaned up.
                             let tx_redeem_fee = self.bitcoin_wallet
-                                .estimate_fee(bitcoin::TxRedeem::weight())
+                                .estimate_fee(bitcoin::TxRedeem::weight(), btc)
                                 .await;
                             let tx_punish_fee = self.bitcoin_wallet
-                                .estimate_fee(bitcoin::TxPunish::weight())
+                                .estimate_fee(bitcoin::TxPunish::weight(), btc)
                                 .await;
                             let redeem_address = self.bitcoin_wallet.new_address().await;
                             let punish_address = self.bitcoin_wallet.new_address().await;

--- a/swap/src/protocol/alice/event_loop.rs
+++ b/swap/src/protocol/alice/event_loop.rs
@@ -171,16 +171,30 @@ where
                             let redeem_address = self.bitcoin_wallet.new_address().await;
                             let punish_address = self.bitcoin_wallet.new_address().await;
 
-                            let (tx_redeem_fee, tx_punish_fee, redeem_address, punish_address) = match (
-                                tx_redeem_fee,
-                                tx_punish_fee,
+                            let (redeem_address, punish_address) = match (
                                 redeem_address,
                                 punish_address,
                             ) {
-                                (Ok(tx_redeem_fee), Ok(tx_punish_fee), Ok(redeem_address), Ok(punish_address)) => {
-                                    (tx_redeem_fee, tx_punish_fee, redeem_address, punish_address)
+                                (Ok(redeem_address), Ok(punish_address)) => {
+                                    (redeem_address, punish_address)
                                 }
-                                _ => { continue; }
+                                _ => {
+                                    tracing::error!("Could not get new address.");
+                                    continue;
+                                }
+                            };
+
+                            let (tx_redeem_fee, tx_punish_fee) = match (
+                                tx_redeem_fee,
+                                tx_punish_fee,
+                            ) {
+                                (Ok(tx_redeem_fee), Ok(tx_punish_fee)) => {
+                                    (tx_redeem_fee, tx_punish_fee)
+                                }
+                                _ => {
+                                    tracing::error!("Could not calculate transaction fees.");
+                                    continue;
+                                }
                             };
 
                             let state0 = match State0::new(

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -113,6 +113,7 @@ pub struct State0 {
 }
 
 impl State0 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<R>(
         btc: bitcoin::Amount,
         xmr: monero::Amount,

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -1,6 +1,6 @@
 use crate::bitcoin::{
     current_epoch, CancelTimelock, ExpiredTimelocks, PunishTimelock, TxCancel, TxPunish, TxRefund,
-    ESTIMATED_WEIGHT_TX_PUNISH, ESTIMATED_WEIGHT_TX_REDEEM,
+    TX_PUNISH_ESTIMATED_WEIGHT, TX_REDEEM_ESTIMATED_WEIGHT,
 };
 use crate::env::Config;
 use crate::monero::wallet::{TransferRequest, WatchRequest};
@@ -133,10 +133,10 @@ impl State0 {
         let (dleq_proof_s_a, (S_a_bitcoin, S_a_monero)) = CROSS_CURVE_PROOF_SYSTEM.prove(&s_a, rng);
 
         let tx_redeem_fee = bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_REDEEM)
+            .estimate_fee(TX_REDEEM_ESTIMATED_WEIGHT)
             .await?;
         let tx_punish_fee = bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_PUNISH)
+            .estimate_fee(TX_PUNISH_ESTIMATED_WEIGHT)
             .await?;
         Ok(Self {
             a,

--- a/swap/src/protocol/alice/state.rs
+++ b/swap/src/protocol/alice/state.rs
@@ -132,6 +132,12 @@ impl State0 {
         let s_a = monero::Scalar::random(rng);
         let (dleq_proof_s_a, (S_a_bitcoin, S_a_monero)) = CROSS_CURVE_PROOF_SYSTEM.prove(&s_a, rng);
 
+        let tx_redeem_fee = bitcoin_wallet
+            .estimate_fee(ESTIMATED_WEIGHT_TX_REDEEM)
+            .await?;
+        let tx_punish_fee = bitcoin_wallet
+            .estimate_fee(ESTIMATED_WEIGHT_TX_PUNISH)
+            .await?;
         Ok(Self {
             a,
             s_a,
@@ -147,8 +153,8 @@ impl State0 {
             xmr,
             cancel_timelock: env_config.bitcoin_cancel_timelock,
             punish_timelock: env_config.bitcoin_punish_timelock,
-            tx_redeem_fee: bitcoin_wallet.estimate_fee(ESTIMATED_WEIGHT_TX_REDEEM),
-            tx_punish_fee: bitcoin_wallet.estimate_fee(ESTIMATED_WEIGHT_TX_PUNISH),
+            tx_redeem_fee,
+            tx_punish_fee,
         })
     }
 

--- a/swap/src/protocol/bob/refund.rs
+++ b/swap/src/protocol/bob/refund.rs
@@ -45,7 +45,7 @@ pub async fn refund(
         }
     };
 
-    state6.refund_btc(bitcoin_wallet.as_ref()).await?;
+    state6.publish_refund_btc(bitcoin_wallet.as_ref()).await?;
 
     let state = BobState::BtcRefunded(state6);
     let db_state = state.clone().into();

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -67,10 +67,10 @@ async fn next_state(
         BobState::Started { btc_amount } => {
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
             let tx_refund_fee = bitcoin_wallet
-                .estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_REDEEM)
+                .estimate_fee(bitcoin::TX_REFUND_ESTIMATED_WEIGHT)
                 .await?;
             let tx_cancel_fee = bitcoin_wallet
-                .estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_CANCEL)
+                .estimate_fee(bitcoin::TX_CANCEL_ESTIMATED_WEIGHT)
                 .await?;
 
             let state2 = request_price_and_setup(

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -66,8 +66,12 @@ async fn next_state(
     Ok(match state {
         BobState::Started { btc_amount } => {
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
-            let tx_refund_fee = bitcoin_wallet.estimate_fee(TxRefund::weight()).await?;
-            let tx_cancel_fee = bitcoin_wallet.estimate_fee(TxCancel::weight()).await?;
+            let tx_refund_fee = bitcoin_wallet
+                .estimate_fee(TxRefund::weight(), btc_amount)
+                .await?;
+            let tx_cancel_fee = bitcoin_wallet
+                .estimate_fee(TxCancel::weight(), btc_amount)
+                .await?;
 
             let state2 = request_price_and_setup(
                 swap_id,

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -66,6 +66,7 @@ async fn next_state(
     Ok(match state {
         BobState::Started { btc_amount } => {
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
+            let tx_refund_fee = bitcoin_wallet.estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_REDEEM);
 
             let state2 = request_price_and_setup(
                 swap_id,
@@ -73,6 +74,7 @@ async fn next_state(
                 event_loop_handle,
                 env_config,
                 bitcoin_refund_address,
+                tx_refund_fee,
             )
             .await?;
 
@@ -268,6 +270,7 @@ pub async fn request_price_and_setup(
     event_loop_handle: &mut EventLoopHandle,
     env_config: &Config,
     bitcoin_refund_address: bitcoin::Address,
+    tx_refund_fee: bitcoin::Amount,
 ) -> Result<bob::state::State2> {
     let xmr = event_loop_handle.request_spot_price(btc).await?;
 
@@ -282,6 +285,7 @@ pub async fn request_price_and_setup(
         env_config.bitcoin_punish_timelock,
         bitcoin_refund_address,
         env_config.monero_finality_confirmations,
+        tx_refund_fee,
     );
 
     let state2 = event_loop_handle.execution_setup(state0).await?;

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -67,6 +67,7 @@ async fn next_state(
         BobState::Started { btc_amount } => {
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
             let tx_refund_fee = bitcoin_wallet.estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_REDEEM);
+            let tx_cancel_fee = bitcoin_wallet.estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_CANCEL);
 
             let state2 = request_price_and_setup(
                 swap_id,
@@ -75,6 +76,7 @@ async fn next_state(
                 env_config,
                 bitcoin_refund_address,
                 tx_refund_fee,
+                tx_cancel_fee,
             )
             .await?;
 
@@ -271,6 +273,7 @@ pub async fn request_price_and_setup(
     env_config: &Config,
     bitcoin_refund_address: bitcoin::Address,
     tx_refund_fee: bitcoin::Amount,
+    tx_cancel_fee: bitcoin::Amount,
 ) -> Result<bob::state::State2> {
     let xmr = event_loop_handle.request_spot_price(btc).await?;
 
@@ -286,6 +289,7 @@ pub async fn request_price_and_setup(
         bitcoin_refund_address,
         env_config.monero_finality_confirmations,
         tx_refund_fee,
+        tx_cancel_fee,
     );
 
     let state2 = event_loop_handle.execution_setup(state0).await?;

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -66,8 +66,12 @@ async fn next_state(
     Ok(match state {
         BobState::Started { btc_amount } => {
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
-            let tx_refund_fee = bitcoin_wallet.estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_REDEEM);
-            let tx_cancel_fee = bitcoin_wallet.estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_CANCEL);
+            let tx_refund_fee = bitcoin_wallet
+                .estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_REDEEM)
+                .await?;
+            let tx_cancel_fee = bitcoin_wallet
+                .estimate_fee(bitcoin::ESTIMATED_WEIGHT_TX_CANCEL)
+                .await?;
 
             let state2 = request_price_and_setup(
                 swap_id,

--- a/swap/tests/harness/bitcoind.rs
+++ b/swap/tests/harness/bitcoind.rs
@@ -8,6 +8,10 @@ pub const RPC_PORT: u16 = 18443;
 pub const PORT: u16 = 18886;
 pub const DATADIR: &str = "/home/bdk";
 
+// Bitcoin regtest TX fee. The fee itself does not matter for our tests. It just
+// has to be static so that we can assert on the amounts.
+pub const TX_FEE: u64 = 10_000;
+
 #[derive(Debug)]
 pub struct Bitcoind {
     args: BitcoindArgs,

--- a/swap/tests/harness/bitcoind.rs
+++ b/swap/tests/harness/bitcoind.rs
@@ -8,10 +8,6 @@ pub const RPC_PORT: u16 = 18443;
 pub const PORT: u16 = 18886;
 pub const DATADIR: &str = "/home/bdk";
 
-// Bitcoin regtest TX fee. The fee itself does not matter for our tests. It just
-// has to be static so that we can assert on the amounts.
-pub const TX_FEE: u64 = 15_000;
-
 #[derive(Debug)]
 pub struct Bitcoind {
     args: BitcoindArgs,

--- a/swap/tests/harness/bitcoind.rs
+++ b/swap/tests/harness/bitcoind.rs
@@ -10,7 +10,7 @@ pub const DATADIR: &str = "/home/bdk";
 
 // Bitcoin regtest TX fee. The fee itself does not matter for our tests. It just
 // has to be static so that we can assert on the amounts.
-pub const TX_FEE: u64 = 10_000;
+pub const TX_FEE: u64 = 15_000;
 
 #[derive(Debug)]
 pub struct Bitcoind {

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -634,12 +634,12 @@ impl TestContext {
         let alice_submitted_cancel = btc_balance_after_swap
             == self.bob_starting_balances.btc
                 - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(bitcoin::TX_FEE);
+                - bitcoin::Amount::from_sat(bitcoind::TX_FEE);
 
         let bob_submitted_cancel = btc_balance_after_swap
             == self.bob_starting_balances.btc
                 - lock_tx_bitcoin_fee
-                - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE);
+                - bitcoin::Amount::from_sat(2 * bitcoind::TX_FEE);
 
         // The cancel tx can be submitted by both Alice and Bob.
         // Since we cannot be sure who submitted it we have to assert accordingly
@@ -678,7 +678,7 @@ impl TestContext {
 
     fn alice_redeemed_btc_balance(&self) -> bitcoin::Amount {
         self.alice_starting_balances.btc + self.btc_amount
-            - bitcoin::Amount::from_sat(bitcoin::TX_FEE)
+            - bitcoin::Amount::from_sat(bitcoind::TX_FEE)
     }
 
     fn bob_redeemed_xmr_balance(&self) -> monero::Amount {
@@ -717,7 +717,7 @@ impl TestContext {
 
     fn alice_punished_btc_balance(&self) -> bitcoin::Amount {
         self.alice_starting_balances.btc + self.btc_amount
-            - bitcoin::Amount::from_sat(2 * bitcoin::TX_FEE)
+            - bitcoin::Amount::from_sat(2 * bitcoind::TX_FEE)
     }
 
     fn bob_punished_xmr_balance(&self) -> monero::Amount {

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -35,6 +35,11 @@ use tracing_subscriber::util::SubscriberInitExt;
 use url::Url;
 use uuid::Uuid;
 
+// Note: this needs to be adopted if bitcoin::wallet.select_feerate() or
+// bitcoin::ESTIMATED_WEIGHT_TX_REDEEM changes.
+// TODO: see if there is a better way.
+const TX_REDEEM_FEE: u64 = 12500;
+
 pub async fn setup_test<T, F, C>(_config: C, testfn: T)
 where
     T: Fn(TestContext) -> F,
@@ -678,7 +683,7 @@ impl TestContext {
 
     fn alice_redeemed_btc_balance(&self) -> bitcoin::Amount {
         self.alice_starting_balances.btc + self.btc_amount
-            - bitcoin::Amount::from_sat(bitcoind::TX_FEE)
+            - bitcoin::Amount::from_sat(TX_REDEEM_FEE)
     }
 
     fn bob_redeemed_xmr_balance(&self) -> monero::Amount {

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use swap::bitcoin::{
-    CancelTimelock, PunishTimelock, ESTIMATED_WEIGHT_TX_CANCEL, ESTIMATED_WEIGHT_TX_REDEEM,
-    ESTIMATED_WEIGHT_TX_REFUND,
+    CancelTimelock, PunishTimelock, TX_CANCEL_ESTIMATED_WEIGHT, TX_PUNISH_ESTIMATED_WEIGHT,
+    TX_REDEEM_ESTIMATED_WEIGHT, TX_REFUND_ESTIMATED_WEIGHT,
 };
 use swap::database::Database;
 use swap::env::{Config, GetConfig};
@@ -637,12 +637,12 @@ impl TestContext {
 
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_CANCEL)
+            .estimate_fee(TX_CANCEL_ESTIMATED_WEIGHT)
             .await
             .expect("To estimate fee correctly");
         let refund_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_REFUND)
+            .estimate_fee(TX_REFUND_ESTIMATED_WEIGHT)
             .await
             .expect("To estimate fee correctly");
 
@@ -685,7 +685,7 @@ impl TestContext {
     async fn alice_redeemed_btc_balance(&self) -> bitcoin::Amount {
         let fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_REDEEM)
+            .estimate_fee(TX_REDEEM_ESTIMATED_WEIGHT)
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - fee
@@ -728,12 +728,12 @@ impl TestContext {
     async fn alice_punished_btc_balance(&self) -> bitcoin::Amount {
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_CANCEL)
+            .estimate_fee(TX_CANCEL_ESTIMATED_WEIGHT)
             .await
             .expect("To estimate fee correctly");
         let punish_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(ESTIMATED_WEIGHT_TX_REFUND)
+            .estimate_fee(TX_PUNISH_ESTIMATED_WEIGHT)
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - cancel_fee - punish_fee

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -1,7 +1,6 @@
 mod bitcoind;
 mod electrs;
 
-use crate::harness::bitcoind::TX_FEE;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use bitcoin_harness::{BitcoindRpcApi, Client};
@@ -41,7 +40,8 @@ use uuid::Uuid;
 // TODO: see if there is a better way.
 const TX_REDEEM_FEE: u64 = 12500;
 const TX_REFUND_FEE: u64 = 12500;
-const TX_CANCEL_FEE: u64 = TX_FEE;
+const TX_CANCEL_FEE: u64 = 12500;
+const TX_PUNISH_FEE: u64 = 12500;
 
 pub async fn setup_test<T, F, C>(_config: C, testfn: T)
 where
@@ -719,7 +719,8 @@ impl TestContext {
 
     fn alice_punished_btc_balance(&self) -> bitcoin::Amount {
         self.alice_starting_balances.btc + self.btc_amount
-            - bitcoin::Amount::from_sat(2 * bitcoind::TX_FEE)
+            - bitcoin::Amount::from_sat(TX_CANCEL_FEE)
+            - bitcoin::Amount::from_sat(TX_PUNISH_FEE)
     }
 
     fn bob_punished_xmr_balance(&self) -> monero::Amount {

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -634,12 +634,12 @@ impl TestContext {
 
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TxCancel::weight())
+            .estimate_fee(TxCancel::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
         let refund_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TxRefund::weight())
+            .estimate_fee(TxRefund::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
 
@@ -682,7 +682,7 @@ impl TestContext {
     async fn alice_redeemed_btc_balance(&self) -> bitcoin::Amount {
         let fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TxRedeem::weight())
+            .estimate_fee(TxRedeem::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - fee
@@ -725,12 +725,12 @@ impl TestContext {
     async fn alice_punished_btc_balance(&self) -> bitcoin::Amount {
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TxCancel::weight())
+            .estimate_fee(TxCancel::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
         let punish_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TxPunish::weight())
+            .estimate_fee(TxPunish::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - cancel_fee - punish_fee

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -14,10 +14,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
-use swap::bitcoin::{
-    CancelTimelock, PunishTimelock, TX_CANCEL_ESTIMATED_WEIGHT, TX_PUNISH_ESTIMATED_WEIGHT,
-    TX_REDEEM_ESTIMATED_WEIGHT, TX_REFUND_ESTIMATED_WEIGHT,
-};
+use swap::bitcoin::{CancelTimelock, PunishTimelock, TxCancel, TxPunish, TxRedeem, TxRefund};
 use swap::database::Database;
 use swap::env::{Config, GetConfig};
 use swap::network::swarm;
@@ -637,12 +634,12 @@ impl TestContext {
 
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TX_CANCEL_ESTIMATED_WEIGHT)
+            .estimate_fee(TxCancel::weight())
             .await
             .expect("To estimate fee correctly");
         let refund_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TX_REFUND_ESTIMATED_WEIGHT)
+            .estimate_fee(TxRefund::weight())
             .await
             .expect("To estimate fee correctly");
 
@@ -685,7 +682,7 @@ impl TestContext {
     async fn alice_redeemed_btc_balance(&self) -> bitcoin::Amount {
         let fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TX_REDEEM_ESTIMATED_WEIGHT)
+            .estimate_fee(TxRedeem::weight())
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - fee
@@ -728,12 +725,12 @@ impl TestContext {
     async fn alice_punished_btc_balance(&self) -> bitcoin::Amount {
         let cancel_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TX_CANCEL_ESTIMATED_WEIGHT)
+            .estimate_fee(TxCancel::weight())
             .await
             .expect("To estimate fee correctly");
         let punish_fee = self
             .alice_bitcoin_wallet
-            .estimate_fee(TX_PUNISH_ESTIMATED_WEIGHT)
+            .estimate_fee(TxPunish::weight())
             .await
             .expect("To estimate fee correctly");
         self.alice_starting_balances.btc + self.btc_amount - cancel_fee - punish_fee


### PR DESCRIPTION
Resolves #443 (Bitcoin only). 

@da-kami  /@thomaseizinger: do you know how fees work in Monero? 
If not, I'll read up on it and to come up with a proper strategy. 

Monero Fees will be covered in #470

Note: 
The there is a hardcoded relative and absolute upper bound. I personally feel safer if this is hardcoded for now as it is too easy to get wrong. 
At the time of writing, this equals roughly USD $56. 
Eventually we will want to make this also configurable.
