### PR TITLE
Introduce read-only wallet for xpubs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A minimum accepted Bitcoin amount for the ASB similar to the maximum amount already present.
   For the CLI the minimum amount is enforced by waiting until at least the minimum is available as max-giveable amount.
 - Added a new argument to ASB: `--json` or `-j`. If set, log messages will be printed in JSON format.
+- New read-only wallet for ASB which enables users to provide a xpub key to derive redeem/punish address from.
+  If not provided in the config, an internal wallet will be used. Users can still withdraw all their funds from the
+  internal wall.
 
 ### Fixed
 
@@ -48,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The ASB's `--max-buy` and `ask-spread` parameter were removed in favour of entries in the config file.
   The initial setup includes setting these two values now.
+- Introduce a new read-only wallet for the ASB. This means, we now have two wallets within the ASB as well as
+  the Swap CLI. Because of this a new folder structure was introduced:
+  - `{data-dir}/wallet` can now be found in `{data-dir}/internal_wallet`. Note: an existing wallet will NOT.
+    automatically be moved to the new folder.
+  - `{data-dir}/personal_wallet` is the new read-only wallet.
+    This is a breaking change!
 
 ## [0.5.0] - 2021-04-17
 

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -297,11 +297,15 @@ async fn init_bitcoin_wallets(
     )
     .context("Failed to initialize protocol Bitcoin wallet")?;
 
+    let xpub = match config.bitcoin.xpub {
+        None => seed.derive_extended_public_key(env_config.bitcoin_network)?,
+        Some(key) => key,
+    };
     let wallet_dir = config.data.dir.join("personal_wallet");
     let personal_wallet = bitcoin::wallet::Wallet::new_readonly(
         config.bitcoin.electrum_rpc_url.clone(),
         &wallet_dir,
-        seed.derive_extended_private_key(env_config.bitcoin_network)?,
+        xpub,
         env_config,
     )
     .context("Failed to initialize personal Bitcoin wallet")?;

--- a/swap/src/protocol/bob.rs
+++ b/swap/src/protocol/bob.rs
@@ -24,7 +24,8 @@ pub struct Swap {
     pub state: BobState,
     pub event_loop_handle: EventLoopHandle,
     pub db: Database,
-    pub bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub internal_bitcoin_wallet: Arc<bitcoin::Wallet>,
+    pub personal_bitcoin_wallet: Arc<bitcoin::Wallet>,
     pub monero_wallet: Arc<monero::Wallet>,
     pub env_config: env::Config,
     pub id: Uuid,
@@ -36,7 +37,8 @@ impl Swap {
     pub fn new(
         db: Database,
         id: Uuid,
-        bitcoin_wallet: Arc<bitcoin::Wallet>,
+        internal_bitcoin_wallet: Arc<bitcoin::Wallet>,
+        personal_bitcoin_wallet: Arc<bitcoin::Wallet>,
         monero_wallet: Arc<monero::Wallet>,
         env_config: env::Config,
         event_loop_handle: EventLoopHandle,
@@ -47,7 +49,8 @@ impl Swap {
             state: BobState::Started { btc_amount },
             event_loop_handle,
             db,
-            bitcoin_wallet,
+            internal_bitcoin_wallet,
+            personal_bitcoin_wallet,
             monero_wallet,
             env_config,
             id,
@@ -55,10 +58,12 @@ impl Swap {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn from_db(
         db: Database,
         id: Uuid,
-        bitcoin_wallet: Arc<bitcoin::Wallet>,
+        internal_bitcoin_wallet: Arc<bitcoin::Wallet>,
+        personal_bitcoin_wallet: Arc<bitcoin::Wallet>,
         monero_wallet: Arc<monero::Wallet>,
         env_config: env::Config,
         event_loop_handle: EventLoopHandle,
@@ -70,7 +75,8 @@ impl Swap {
             state,
             event_loop_handle,
             db,
-            bitcoin_wallet,
+            internal_bitcoin_wallet,
+            personal_bitcoin_wallet,
             monero_wallet,
             env_config,
             id,

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -65,6 +65,7 @@ async fn next_state(
 
     Ok(match state {
         BobState::Started { btc_amount } => {
+            // todo (phh) use new wallet
             let bitcoin_refund_address = bitcoin_wallet.new_address().await?;
             let tx_refund_fee = bitcoin_wallet
                 .estimate_fee(TxRefund::weight(), btc_amount)

--- a/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command.rs
+++ b/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command.rs
@@ -38,7 +38,7 @@ async fn given_alice_and_bob_manually_refund_after_funds_locked_both_refund() {
         // Ensure cancel timelock is expired
         if let BobState::BtcLocked(state3) = bob_swap.state.clone() {
             bob_swap
-                .bitcoin_wallet
+                .internal_bitcoin_wallet
                 .subscribe_to(state3.tx_lock)
                 .await
                 .wait_until_confirmed_with(state3.cancel_timelock)
@@ -49,8 +49,13 @@ async fn given_alice_and_bob_manually_refund_after_funds_locked_both_refund() {
 
         // Bob manually cancels
         bob_join_handle.abort();
-        let (_, state) =
-            bob::cancel(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, false).await??;
+        let (_, state) = bob::cancel(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            false,
+        )
+        .await??;
         assert!(matches!(state, BobState::BtcCancelled { .. }));
 
         let (bob_swap, bob_join_handle) = ctx
@@ -60,8 +65,13 @@ async fn given_alice_and_bob_manually_refund_after_funds_locked_both_refund() {
 
         // Bob manually refunds
         bob_join_handle.abort();
-        let bob_state =
-            bob::refund(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, false).await??;
+        let bob_state = bob::refund(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            false,
+        )
+        .await??;
 
         ctx.assert_bob_refunded(bob_state).await;
 

--- a/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command_timelock_not_expired.rs
+++ b/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command_timelock_not_expired.rs
@@ -37,9 +37,14 @@ async fn given_alice_and_bob_manually_cancel_when_timelock_not_expired_errors() 
         ));
 
         // Bob tries but fails to manually cancel
-        let result = bob::cancel(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, false)
-            .await?
-            .unwrap_err();
+        let result = bob::cancel(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            false,
+        )
+        .await?
+        .unwrap_err();
         assert!(matches!(
             result,
             bob::cancel::Error::CancelTimelockNotExpiredYet
@@ -72,9 +77,14 @@ async fn given_alice_and_bob_manually_cancel_when_timelock_not_expired_errors() 
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
 
         // Bob tries but fails to manually refund
-        let result = bob::refund(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, false)
-            .await?
-            .unwrap_err();
+        let result = bob::refund(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            false,
+        )
+        .await?
+        .unwrap_err();
         assert!(matches!(result, bob::refund::SwapNotCancelledYet(_)));
 
         let (bob_swap, _) = ctx

--- a/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command_timelock_not_expired_force.rs
+++ b/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command_timelock_not_expired_force.rs
@@ -37,7 +37,13 @@ async fn given_alice_and_bob_manually_force_cancel_when_timelock_not_expired_err
         ));
 
         // Bob tries but fails to manually cancel
-        let result = bob::cancel(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, true).await;
+        let result = bob::cancel(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            true,
+        )
+        .await;
         assert!(matches!(result, Err(_)));
 
         ctx.restart_alice().await;
@@ -64,9 +70,14 @@ async fn given_alice_and_bob_manually_force_cancel_when_timelock_not_expired_err
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
 
         // Bob tries but fails to manually refund
-        let is_outer_err = bob::refund(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db, true)
-            .await
-            .is_err();
+        let is_outer_err = bob::refund(
+            bob_swap.id,
+            bob_swap.internal_bitcoin_wallet,
+            bob_swap.db,
+            true,
+        )
+        .await
+        .is_err();
         assert!(is_outer_err);
 
         let (bob_swap, _) = ctx

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -643,7 +643,7 @@ impl TestContext {
         assert!(matches!(state, AliceState::BtcPunished));
 
         assert_eventual_balance(
-            self.alice_internal_bitcoin_wallet.as_ref(),
+            self.alice_personal_bitcoin_wallet.as_ref(),
             Ordering::Equal,
             self.alice_punished_btc_balance().await,
         )
@@ -782,7 +782,7 @@ impl TestContext {
             .estimate_fee(TxPunish::weight(), self.btc_amount)
             .await
             .expect("To estimate fee correctly");
-        self.alice_starting_balances.btc + self.btc_amount - cancel_fee - punish_fee
+        self.btc_amount - cancel_fee - punish_fee
     }
 
     fn bob_punished_xmr_balance(&self) -> monero::Amount {

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -305,7 +305,6 @@ async fn init_test_wallets(
         env_config,
         1,
     )
-    .await
     .expect("could not init btc wallet");
 
     if starting_balances.btc != bitcoin::Amount::ZERO {


### PR DESCRIPTION
At the end of a swaps (may it be redeemed, refunded, or punished), the Bitcoin funds should be transferred to an address controlled by the according party.
This wallet should be decoupled from the protocol wallet, i.e. the wallet which will be used to sign internal transactions.
In this PR, we introduce a `personal_wallet` which is meant for exactly this.

Resolves #489 

Some notes: 

1. `zpub-support`: a `zpub` is an `xpub` which implies native segwit support, i.e. an address derived from a `zpub` key should be prefixed with `bc1` (if mainnet). 
Unfortunately [bdk](https://github.com/bitcoindevkit/bdk) does not support `zpub` keys. However, we can achieve the same with `xpub` keys as well. By implying Bip84 descriptors, any key derived from this address will be a `bech32` (native segwit) address. 
3. optional `xpub`-entry for Asb config: A user running the ASB can optionally provide an `xpub` key. We will derive `redeem` and `punish` addresses from this. Since `xpub` keys are read-only, this has the implication that the `withdraw-all` command is useless. If, however, the user does not provide an `xpub` key, we use our internal seed to derive a wallet. In this case, the `withdraw-all` command is still useful :) 
4. `xpub`- support for Swap Cli it wasn't part of the ticket so I only pulled it through to the binary but do not expose it yet to the user. I guess this will need some more thinking, e.g. does an xpub make sense for the Swap Cli or would a single refund address be sufficient? A single address has the disadvantage of making our tests more complicated, i.e. if we have a full wallet, we can just _connect_ it to the blockchain and query for the balance while with an address we would need to build a bit more logic for this. I propose to create a follow-up ticket on this. 

