### PR TITLE
Fix bug that breaks swap ID for logging

### DIFF
--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -81,7 +81,6 @@ async fn main() -> Result<()> {
                 .behaviour_mut()
                 .add_address(seller_peer_id, seller_addr);
 
-            let swap_id = Uuid::new_v4();
             let (event_loop, mut event_loop_handle) = EventLoop::new(
                 swap_id,
                 swarm,


### PR DESCRIPTION
Somehow I introduced this really stupid bug. Might have happened during a rebase. 

We create the swap id at the top of main.
Creating another id here breaks the name of the swap's logfile for the CLI, because the actual swap will have another id. 
Should definitely go in before releasing :)