### PR TITLE
Bitcoin transaction published state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3. ASB is running in resume-only mode and does not accept incoming swap requests
 - An issue where the monero daemon port used by the `monero-wallet-rpc` could not be specified.
   The CLI parameter `--monero-daemon-host` was changed to `--monero-daemon-address` where host and port have to be specified.
+- An issue where an ASB redeem scenario can transition to a cancel and publish scenario that will fail.
+  This is a breaking change for the ASB, because it introduces a new state into the database.
 
 ### Changed
 

--- a/swap/src/database/alice.rs
+++ b/swap/src/database/alice.rs
@@ -39,6 +39,9 @@ pub enum Alice {
         encrypted_signature: EncryptedSignature,
         state3: alice::State3,
     },
+    BtcRedeemTransactionPublished {
+        state3: alice::State3,
+    },
     CancelTimelockExpired {
         monero_wallet_restore_blockheight: BlockHeight,
         transfer_proof: TransferProof,
@@ -119,6 +122,11 @@ impl From<&AliceState> for Alice {
                 state3: state3.as_ref().clone(),
                 encrypted_signature: *encrypted_signature.clone(),
             },
+            AliceState::BtcRedeemTransactionPublished { state3 } => {
+                Alice::BtcRedeemTransactionPublished {
+                    state3: state3.as_ref().clone(),
+                }
+            }
             AliceState::BtcRedeemed => Alice::Done(AliceEndState::BtcRedeemed),
             AliceState::BtcCancelled {
                 monero_wallet_restore_blockheight,
@@ -212,6 +220,11 @@ impl From<Alice> for AliceState {
                 state3: Box::new(state),
                 encrypted_signature: Box::new(encrypted_signature),
             },
+            Alice::BtcRedeemTransactionPublished { state3 } => {
+                AliceState::BtcRedeemTransactionPublished {
+                    state3: Box::new(state3),
+                }
+            }
             Alice::CancelTimelockExpired {
                 monero_wallet_restore_blockheight,
                 transfer_proof,
@@ -271,12 +284,15 @@ impl Display for Alice {
             Alice::XmrLockTransferProofSent { .. } => {
                 f.write_str("Monero lock transfer proof sent")
             }
+            Alice::EncSigLearned { .. } => f.write_str("Encrypted signature learned"),
+            Alice::BtcRedeemTransactionPublished { .. } => {
+                f.write_str("Bitcoin redeem transaction published")
+            }
             Alice::CancelTimelockExpired { .. } => f.write_str("Cancel timelock is expired"),
             Alice::BtcCancelled { .. } => f.write_str("Bitcoin cancel transaction published"),
             Alice::BtcPunishable { .. } => f.write_str("Bitcoin punishable"),
             Alice::BtcRefunded { .. } => f.write_str("Monero refundable"),
             Alice::Done(end_state) => write!(f, "Done: {}", end_state),
-            Alice::EncSigLearned { .. } => f.write_str("Encrypted signature learned"),
         }
     }
 }

--- a/swap/src/protocol/alice/recovery/cancel.rs
+++ b/swap/src/protocol/alice/recovery/cancel.rs
@@ -34,6 +34,9 @@ pub async fn cancel(
             (monero_wallet_restore_blockheight, transfer_proof, state3)
         }
 
+        // The redeem transaction was already published, it is not safe to cancel anymore
+        AliceState::BtcRedeemTransactionPublished { .. } => bail!(" The redeem transaction was already published, it is not safe to cancel anymore"),
+
         // The cancel tx was already published, but Alice not yet in final state
         AliceState::BtcCancelled { .. }
         | AliceState::BtcRefunded { .. }
@@ -43,7 +46,7 @@ pub async fn cancel(
         | AliceState::BtcRedeemed
         | AliceState::XmrRefunded
         | AliceState::BtcPunished
-        | AliceState::SafelyAborted => bail!("Cannot cancel swap {} because it is in state {} which is not cancelable", swap_id, state),
+        | AliceState::SafelyAborted => bail!("Swap is is in state {} which is not cancelable", state),
     };
 
     tracing::info!(%swap_id, "Trying to manually cancel swap");

--- a/swap/src/protocol/alice/recovery/punish.rs
+++ b/swap/src/protocol/alice/recovery/punish.rs
@@ -50,7 +50,8 @@ pub async fn punish(
             }
 
             // If the swap was refunded it cannot be punished
-            AliceState::BtcRefunded {..}
+            AliceState::BtcRedeemTransactionPublished { .. }
+            | AliceState::BtcRefunded {..}
             // Alice already in final state
             | AliceState::BtcRedeemed
             | AliceState::XmrRefunded

--- a/swap/src/protocol/alice/recovery/refund.rs
+++ b/swap/src/protocol/alice/recovery/refund.rs
@@ -56,7 +56,8 @@ pub async fn refund(
             }
 
             // Alice already in final state
-            AliceState::BtcRedeemed
+            AliceState::BtcRedeemTransactionPublished { .. }
+            | AliceState::BtcRedeemed
             | AliceState::XmrRefunded
             | AliceState::BtcPunished
             | AliceState::SafelyAborted => bail!(Error::SwapNotRefundable(state)),

--- a/swap/src/protocol/alice/recovery/safely_abort.rs
+++ b/swap/src/protocol/alice/recovery/safely_abort.rs
@@ -22,6 +22,7 @@ pub async fn safely_abort(swap_id: Uuid, db: Arc<Database>) -> Result<AliceState
         | AliceState::XmrLocked { .. }
         | AliceState::XmrLockTransferProofSent { .. }
         | AliceState::EncSigLearned { .. }
+        | AliceState::BtcRedeemTransactionPublished { .. }
         | AliceState::CancelTimelockExpired { .. }
         | AliceState::BtcCancelled { .. }
         | AliceState::BtcRefunded { .. }


### PR DESCRIPTION
This improves the error handling on the ASB.
Once the Bitcoin redeem transaction is seen in mempool, the state machine cannot transition to a cancel scenario anymore because at that point the CLI will have redeemed the Monero.
The additional state then waits for transaction finality and prevents re-publishing the transaction.