### PR TITLE
Add the arm CLI build to the release binaries

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -15,6 +15,10 @@ jobs:
             os: ubuntu-latest
             archive_ext: tar
           - bin: swap
+            target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            archive_ext: tar
+          - bin: swap
             target: x86_64-apple-darwin
             os: macos-latest
             archive_ext: tar


### PR DESCRIPTION
Currently it is not shipped because we forgot to include it.
I don't see a reason not to ship that as well. @bonomat  and me tested it on a raspi last Friday :)