### PR TITLE
Add ping protocol to ensure connection is alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- An issue where long-running connections are dead without a connection closure being reported back to the swarm.
+  Adding a periodic ping ensures that the connection is kept alive, and a broken connection is reported back resulting in a close event on the swarm.
+  This fixes the error of the ASB being unable to send a transfer proof to the CLI.
+
 ## [0.6.0] - 2021-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "libp2p-dns",
  "libp2p-mplex",
  "libp2p-noise",
+ "libp2p-ping",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-swarm-derive",
@@ -1874,6 +1875,21 @@ dependencies = [
  "static_assertions",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4bfaffac63bf3c7ec11ed9d8879d455966ddea7e78ee14737f0b6dce0d1cd1"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.14",
+ "rand 0.7.3",
+ "void",
+ "wasm-timer",
 ]
 
 [[package]]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -29,7 +29,7 @@ ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", features = [ "libs
 ed25519-dalek = "1"
 futures = { version = "0.3", default-features = false }
 itertools = "0.10"
-libp2p = { version = "0.38", default-features = false, features = [ "tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "request-response", "websocket" ] }
+libp2p = { version = "0.38", default-features = false, features = [ "tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "request-response", "websocket", "ping" ] }
 libp2p-async-await = { git = "https://github.com/comit-network/rust-libp2p-async-await" }
 miniscript = { version = "5", features = [ "serde" ] }
 monero = { version = "0.12", features = [ "serde_support" ] }

--- a/swap/src/protocol/alice/behaviour.rs
+++ b/swap/src/protocol/alice/behaviour.rs
@@ -4,6 +4,7 @@ use crate::protocol::alice::event_loop::LatestRate;
 use crate::protocol::alice::{execution_setup, spot_price, State3};
 use crate::{env, monero};
 use anyhow::{anyhow, Error};
+use libp2p::ping::{Ping, PingEvent};
 use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p::{NetworkBehaviour, PeerId};
 use uuid::Uuid;
@@ -75,6 +76,11 @@ where
     pub execution_setup: execution_setup::Behaviour,
     pub transfer_proof: transfer_proof::Behaviour,
     pub encrypted_signature: encrypted_signature::Behaviour,
+
+    /// Ping behaviour that ensures that the underlying network connection is
+    /// still alive. If the ping fails a connection close event will be
+    /// emitted that is picked up as swarm event.
+    ping: Ping,
 }
 
 impl<LR> Behaviour<LR>
@@ -104,6 +110,13 @@ where
             execution_setup: Default::default(),
             transfer_proof: transfer_proof::alice(),
             encrypted_signature: encrypted_signature::alice(),
+            ping: Ping::default(),
         }
+    }
+}
+
+impl From<PingEvent> for OutEvent {
+    fn from(_: PingEvent) -> Self {
+        OutEvent::Other
     }
 }


### PR DESCRIPTION
Fixes #532 

Adds the ping behaviour to both ASB and CLI behaviour that periodically pings a connected party to ensure that the underlying network connection is still alive.
This fixes problems with long-running connections that become dead without a connection closure being reported back to the swarm.