### PR TITLE
Tell dependabot to stop automatically rebasing PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    rebase-strategy: "disabled"
       
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
This interferes with bors trying to merge several PRs at once.