### PR TITLE
Print the Bitcoin address to the terminal as a QR code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Printing the deposit address to the terminal as a QR code.
+  To not break automated scripts or integrations with other software, this behaviour is disabled if `--json` is passed to the application.
+
 ## [0.7.0] - 2021-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +635,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "config"
@@ -1561,6 +1579,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,7 +2404,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.1.42",
  "num-traits",
 ]
 
@@ -2429,6 +2461,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rustc-serialize",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2831,6 +2874,16 @@ checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
  "prost",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
+ "image",
 ]
 
 [[package]]
@@ -3913,6 +3966,7 @@ dependencies = [
  "port_check",
  "prettytable-rs",
  "proptest",
+ "qrcode",
  "rand 0.8.3",
  "rand_chacha 0.3.0",
  "reqwest",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -37,6 +37,7 @@ monero-rpc = { path = "../monero-rpc" }
 pem = "0.8"
 prettytable-rs = "0.8"
 proptest = "1"
+qrcode = "0.12"
 rand = "0.8"
 rand_chacha = "0.3"
 reqwest = { version = "0.11", features = [ "rustls-tls", "stream", "socks" ], default-features = false }


### PR DESCRIPTION
It helps to fund the Bitcoin address with your mobile device without a need to copy-paste the receive address. 

Here is how it looks like under different terminals:
1) Gnome Terminal:
![1](https://user-images.githubusercontent.com/46658470/120103390-0e87dd80-c158-11eb-9e0f-da5af89ea8d7.png)
2) Alacritty:
![2](https://user-images.githubusercontent.com/46658470/120103398-1ba4cc80-c158-11eb-89c0-8a54e8902658.png)
3) Kitty:
![3](https://user-images.githubusercontent.com/46658470/120103411-265f6180-c158-11eb-95e1-b37c2d16c2b6.png)
4) Konsole:
![4](https://user-images.githubusercontent.com/46658470/120103421-2f503300-c158-11eb-83bf-82d55b6e2dd8.png)

