### PR TITLE
Request timeout when swapping over Tor

### DIFF
--- a/swap/src/protocol/bob/event_loop.rs
+++ b/swap/src/protocol/bob/event_loop.rs
@@ -57,11 +57,11 @@ impl EventLoop {
         bitcoin_wallet: Arc<bitcoin::Wallet>,
         env_config: env::Config,
     ) -> Result<(Self, EventLoopHandle)> {
-        let execution_setup = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-        let transfer_proof = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-        let encrypted_signature = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-        let spot_price = bmrng::channel_with_timeout(1, Duration::from_secs(30));
-        let quote = bmrng::channel_with_timeout(1, Duration::from_secs(30));
+        let execution_setup = bmrng::channel_with_timeout(1, Duration::from_secs(60));
+        let transfer_proof = bmrng::channel_with_timeout(1, Duration::from_secs(60));
+        let encrypted_signature = bmrng::channel_with_timeout(1, Duration::from_secs(60));
+        let spot_price = bmrng::channel_with_timeout(1, Duration::from_secs(60));
+        let quote = bmrng::channel_with_timeout(1, Duration::from_secs(60));
 
         let event_loop = EventLoop {
             swap_id,


### PR DESCRIPTION
It seems the current chosen channel timeouts are still not optimal.
I ran into issues with swapping over Tor and traced them down to the CLI timeout of the bmrng channel.
It appears that the ASB waited significant time for the acknowledgement from the CLI, which caused quite a delay. 

Logs of the CLI timeout:

```
2021-06-23 12:37:49  INFO Spot price btc=0.00100000 BTC xmr=0.152542734847 XMR
2021-06-23 12:37:53 DEBUG Starting execution setup with 12D3KooWPZ69DRp4wbGB3wJsxxsg1XW1EVZ2evtVwcARCF3a1nrx
Error: Failed to complete swap

Caused by:
    request timed out

Process finished with exit code 1
```

ASB logs (sorry about the time zones being not aligned, the minutes are the interesting part)

```
Jun 23 03:48:27 raspberrypi asb[7933]:  WARN Estimated fee of 137.0 is smaller than the min relay fee, defaulting to min relay fee 1000
Jun 23 03:48:44 raspberrypi asb[7933]: DEBUG Spot price response sent peer=12D3KooWRqVnNWuahKawSSmxQQptGcEApNBFXNodzRv2q6tBvhUW
Jun 23 03:49:00 raspberrypi asb[7933]:  WARN Lost connection. Error Connection error: I/O error: connection is closed peer=12D3KooWRqVnNWuahKawSSmxQQptGcEApNBFXNodzRv2q6tBvhUW address=/ip4/127.0.0.1/tcp/49362
```