### PR TITLE
Provide a commit-specific version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1053,6 +1056,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1343,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "ghash"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1362,19 @@ checksum = "5f6fb2a26dd2ebd268a68bc8e9acc9e67e487952f33384055a1cbe697514c64e"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log 0.4.14",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1676,6 +1724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1847,18 @@ name = "libc"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.21+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libp2p"
@@ -4037,6 +4106,7 @@ dependencies = [
  "tracing-subscriber",
  "url 2.2.2",
  "uuid",
+ "vergen",
  "void",
  "zip",
 ]
@@ -4727,6 +4797,22 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "5.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cadc93a5cf745b643d29e6ec4612acdcd8fe7e73995050fff3fa812ed6d0312"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "chrono",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustversion",
+ "thiserror",
+]
 
 [[package]]
 name = "version_check"

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -84,3 +84,7 @@ serde_cbor = "0.11"
 spectral = "0.6"
 tempfile = "3"
 testcontainers = "0.12"
+
+[build-dependencies]
+vergen = { version = "5", default-features = false, features = [ "git", "build" ] }
+anyhow = "1"

--- a/swap/build.rs
+++ b/swap/build.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use vergen::{vergen, Config, SemverKind};
+
+fn main() -> Result<()> {
+    let mut config = Config::default();
+    *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
+
+    vergen(config)
+}

--- a/swap/src/asb/command.rs
+++ b/swap/src/asb/command.rs
@@ -200,7 +200,8 @@ pub enum Command {
 #[structopt(
     name = "asb",
     about = "Automated Swap Backend for swapping XMR for BTC",
-    author
+    author,
+    version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
 )]
 pub struct RawArguments {
     #[structopt(long, help = "Swap on testnet")]

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -245,7 +245,12 @@ pub enum Command {
 }
 
 #[derive(structopt::StructOpt, Debug)]
-#[structopt(name = "swap", about = "CLI for swapping BTC for XMR", author)]
+#[structopt(
+    name = "swap",
+    about = "CLI for swapping BTC for XMR",
+    author,
+    version = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
+)]
 struct RawArguments {
     // global is necessary to ensure that clap can match against testnet in subcommands
     #[structopt(


### PR DESCRIPTION
For builds made directly on the tag, the output of `--version` will
not change. For builds not made on a tagged commit, the output will
look something like this:

```
> swap --version

swap 0.7.0-117-g93161f9
```

Fixes #409.