### PR TITLE
Update default Monero node URLs and info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An issue where the ASB gives long price guarantees when setting up a swap.
   Now, after sending a spot price the ASB will wait for one minute for the CLI's to trigger the execution setup, and three minutes to see the BTC lock transaction of the CLI in mempool after the swap started.
   If the first timeout is triggered the execution setup will be aborted, if the second timeout is triggered the swap will be safely aborted.
+- An issue where the default Monero node connection string would not work, because the public nodes were moved to a different domain.
+  The default monerod nodes were updated to use the [melo tool nodes](https://melo.tools/nodes.html).
 
 ### Changed
 

--- a/docs/asb/README.md
+++ b/docs/asb/README.md
@@ -12,10 +12,7 @@ This quickstart guide assumes that you are running the software on testnet (i.e.
 3. Run the ASB in terminal: `./asb --testnet start`
 4. Follow the setup wizard in the terminal
 
-Public Monero stagenet nodes for running the Monero Wallet RPC:
-
-- `monero-stagenet.exan.tech:38081`
-- `stagenet.melo.tools:38081`
+Public Monero nodes for running the Monero Wallet RPC can be found [here](https://melo.tools/nodes.html).
 
 Run `./asb --help` for more information.
 

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -12,8 +12,8 @@ use url::Url;
 use uuid::Uuid;
 
 // See: https://moneroworld.com/
-pub const DEFAULT_MONERO_DAEMON_ADDRESS: &str = "node.xmr.to:18081";
-pub const DEFAULT_MONERO_DAEMON_ADDRESS_STAGENET: &str = "monero-stagenet.exan.tech:38081";
+pub const DEFAULT_MONERO_DAEMON_ADDRESS: &str = "node.melo.tools:18081";
+pub const DEFAULT_MONERO_DAEMON_ADDRESS_STAGENET: &str = "stagenet.melo.tools:38081";
 
 // See: https://1209k.com/bitcoin-eye/ele.php?chain=btc
 const DEFAULT_ELECTRUM_RPC_URL: &str = "ssl://electrum.blockstream.info:50002";


### PR DESCRIPTION
xmr.to nodes are not served at the xmr.to domain but moved to melo.tools