### PR TITLE
Release version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2021-07-09
+
 ### Added
 
 - Printing the deposit address to the terminal as a QR code.
@@ -173,7 +175,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[Unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/0.7.0...HEAD
+[Unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.4.0...0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,7 +4038,7 @@ checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 
 [[package]]
 name = "swap"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "0.7.0"
+version = "0.8.0"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2018"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @da-kami!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/comit-network/xmr-btc-swap/actions/runs/1013671991.
I've updated the changelog and bumped the versions in the manifest files in this commit: 403e3d2b334f421de4fd2b6a7cca5474c2e06bb5.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.