### PR TITLE
Default to quad9 DNS configuration instead of system

### DIFF
--- a/swap/src/cli/transport.rs
+++ b/swap/src/cli/transport.rs
@@ -3,7 +3,7 @@ use crate::network::transport::authenticate_and_multiplex;
 use anyhow::Result;
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::{Boxed, OptionalTransport};
-use libp2p::dns::TokioDnsConfig;
+use libp2p::dns::{ResolverConfig, ResolverOpts, TokioDnsConfig};
 use libp2p::tcp::TokioTcpConfig;
 use libp2p::{identity, PeerId, Transport};
 
@@ -20,7 +20,8 @@ pub fn new(
     maybe_tor_socks5_port: Option<u16>,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>> {
     let tcp = TokioTcpConfig::new().nodelay(true);
-    let tcp_with_dns = TokioDnsConfig::system(tcp)?;
+    let tcp_with_dns =
+        TokioDnsConfig::custom(tcp, ResolverConfig::quad9(), ResolverOpts::default())?;
     let maybe_tor_transport = match maybe_tor_socks5_port {
         Some(port) => OptionalTransport::some(TorDialOnlyTransport::new(port)),
         None => OptionalTransport::none(),


### PR DESCRIPTION
Relying on the system DNS configuration causes problems for some
users. Let's try defaulting to quad9's config.