### PR TITLE
Move "Lost connection" log line from WARN to Debug

### DIFF
--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -271,7 +271,7 @@ where
                             tracing::warn!(%address, "Failed to set up connection with peer: {:#}", error);
                         }
                         SwarmEvent::ConnectionClosed { peer_id: peer, num_established, endpoint, cause: Some(error) } if num_established == 0 => {
-                            tracing::warn!(%peer, address = %endpoint.get_remote_address(), "Lost connection to peer: {:#}", error);
+                            tracing::debug!(%peer, address = %endpoint.get_remote_address(), "Lost connection to peer: {:#}", error);
                         }
                         SwarmEvent::ConnectionClosed { peer_id: peer, num_established, endpoint, cause: None } if num_established == 0 => {
                             tracing::info!(%peer, address = %endpoint.get_remote_address(), "Successfully closed connection");


### PR DESCRIPTION
Per #660, moving the log line on a peer closing connection outside of a swap to DEBUG instead of WARN, as there is no action that can be taken by the ASB owner.

Fixes #660.