### PR TITLE
Release version 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2021-09-02
+
 ### Fixed
 
 - A bug where the ASB erroneously transitioned into a punishable state upon a bitcoin transaction monitoring error.
@@ -208,7 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[Unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.2...HEAD
+[Unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.3...HEAD
+[0.8.3]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/comit-network/xmr-btc-swap/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.7.0...0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,7 +4106,7 @@ checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 
 [[package]]
 name = "swap"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "0.8.2"
+version = "0.8.3"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2018"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @rishflab!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/comit-network/xmr-btc-swap/actions/runs/1192970084.
I've updated the changelog and bumped the versions in the manifest files in this commit: 2a4ffaeacb2b570a675b85746c5ff6c25066f5bd.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.