### PR TITLE
Limit the number of open dependabot to 10 instead of 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
-      
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should give us a bit more slack to update certain dependencies
even if we have a few pending that are currently breaking the build.