### PR TITLE
Move "swap started" UI message after swap confirmed with ASB

### DIFF
--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            tracing::info!(%amount, %fees, %swap_id,  "Starting new swap");
+            tracing::info!(%amount, %fees,  "Determined swap amount");
 
             db.insert_peer_id(swap_id, seller_peer_id).await?;
             db.insert_monero_address(swap_id, monero_receive_address)

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -82,6 +82,8 @@ async fn next_state(
                 })
                 .await?;
 
+            tracing::info!(%swap_id, "Starting new swap");
+
             BobState::SwapSetupCompleted(state2)
         }
         BobState::SwapSetupCompleted(state2) => {


### PR DESCRIPTION
The "swap started" message was being too early, before the ASB had
confirmed they could perform the swap. This was leading to a confusing
scenario where the UI incorrectly indicated to the user that the swap
had started. Users were trying to resume or refund the swaps but there
was no swap id in the db. Moving this message after the swap setup
should resolve this problem. Closes #756, #729, #560.