### PR TITLE
Change message log level to debug to allow enabling through flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `cancel`, `refund` and `punish` subcommands in ASB and CLI are run with the `--force` by default and the `--force` option has been removed.
   The force flag was used to ignore blockheight and protocol state checks.
   Users can still restart a swap with these checks using the `resume` subcommand.
+- Changed log level of the "Advancing state", "Establishing Connection through Tor proxy" and "Connection through Tor established" log message from tracing to debug in the CLI.
 
 ## [0.8.3] - 2021-09-03
 

--- a/swap/src/network/tor_transport.rs
+++ b/swap/src/network/tor_transport.rs
@@ -42,14 +42,14 @@ impl Transport for TorDialOnlyTransport {
         }
 
         let dial_future = async move {
-            tracing::trace!(address = %addr, "Establishing connection through Tor proxy");
+            tracing::debug!(address = %addr, "Establishing connection through Tor proxy");
 
             let stream =
                 Socks5Stream::connect((Ipv4Addr::LOCALHOST, self.socks_port), address.to_string())
                     .await
                     .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, e))?;
 
-            tracing::trace!("Connection through Tor established");
+            tracing::debug!("Connection through Tor established");
 
             Ok(TcpStream(stream.into_inner()))
         };

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -58,7 +58,7 @@ async fn next_state(
     monero_wallet: &monero::Wallet,
     monero_receive_address: monero::Address,
 ) -> Result<BobState> {
-    tracing::trace!(%state, "Advancing state");
+    tracing::debug!(%state, "Advancing state");
 
     Ok(match state {
         BobState::Started {


### PR DESCRIPTION
We do not have a way to enable tracing through a command line
argument so it did not make sense to have these messages set to
trace. Ideally a trace flag should be added but it is not that
straightforward with structopt. We could add a --log-level arg
that allows you select a log level but this is verbose.

Closes #759
