### PR TITLE
Remove unused command line argument from the balance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - A `config` subcommand that prints the current configuration including the data directory location.
   This feature should alleviate difficulties users were having when finding where xmr-btc-swap was storing data.
 
+### Removed
+
+- The `bitcoin-target-block` argument from the `balance` subcommand on the CLI.
+  This argument did not affect how the balance was calculated and was pointless.
+
 ## [0.8.3] - 2021-09-03
 
 ### Fixed

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -121,7 +121,13 @@ where
             data_dir: data::data_dir_from(data, is_testnet)?,
             cmd: Command::Config,
         },
-        RawCommand::Balance { bitcoin } => {
+        RawCommand::Balance {
+            bitcoin_electrum_rpc_url,
+        } => {
+            let bitcoin = Bitcoin {
+                bitcoin_electrum_rpc_url,
+                bitcoin_target_block: None,
+            };
             let (bitcoin_electrum_rpc_url, bitcoin_target_block) =
                 bitcoin.apply_defaults(is_testnet)?;
 
@@ -381,8 +387,8 @@ enum RawCommand {
     },
     #[structopt(about = "Prints the Bitcoin balance.")]
     Balance {
-        #[structopt(flatten)]
-        bitcoin: Bitcoin,
+        #[structopt(long = "electrum-rpc", help = "Provide the Bitcoin Electrum RPC URL")]
+        bitcoin_electrum_rpc_url: Option<Url>,
     },
     /// Resume a swap
     Resume {


### PR DESCRIPTION
The target block is irrelevant when calculating the balance.

Closes #793 