### PR TITLE
Add `monero-recovery` command to print address + view/spend keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `monero-recovery` command that can be used to print the monero address, private spend and view key so one can manually recover instances where the `monero-wallet-rpc` does not pick up the Monero funds locked up by the ASB.
+  Related issue: https://github.com/comit-network/xmr-btc-swap/issues/537
+  The command takes the swap-id as parameter.
+  The swap has to be in a `BtcRedeemed` state.
+  Use `--help` for more details.
+
 ## [0.10.0] - 2021-10-15
 
 ### Removed

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -249,6 +249,15 @@ where
                 },
             }
         }
+        RawCommand::MoneroRecovery { swap_id } => Arguments {
+            env_config: env_config_from(is_testnet),
+            debug,
+            json,
+            data_dir: data::data_dir_from(data, is_testnet)?,
+            cmd: Command::MoneroRecovery {
+                swap_id: swap_id.swap_id,
+            },
+        },
     };
 
     Ok(ParseResult::Arguments(arguments))
@@ -302,6 +311,9 @@ pub enum Command {
     ExportBitcoinWallet {
         bitcoin_electrum_rpc_url: Url,
         bitcoin_target_block: usize,
+    },
+    MoneroRecovery {
+        swap_id: Uuid,
     },
 }
 
@@ -438,6 +450,13 @@ enum RawCommand {
     ExportBitcoinWallet {
         #[structopt(flatten)]
         bitcoin: Bitcoin,
+    },
+    /// Prints Monero information related to the swap in case the generated
+    /// wallet fails to detect the funds. This can only be used for swaps
+    /// that are in a `btc is redeemed` state.
+    MoneroRecovery {
+        #[structopt(flatten)]
+        swap_id: SwapId,
     },
 }
 


### PR DESCRIPTION
This allows manual recovery of problems like https://github.com/comit-network/xmr-btc-swap/issues/537
Since we could not figure out what causes this issue, and it is most likely an upstream problem this is the best we can do so far to allow the user to manually interact with `monero-wallet-cli` or `monero-wallet-rpc`.