### PR TITLE
Use rfc3339 date time when logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- logs to use rfc3339 local time formatting.
+
 ## [0.10.1] - 2021-12-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,7 +2246,7 @@ dependencies = [
  "testcontainers 0.12.0",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2271,7 +2280,7 @@ dependencies = [
  "rand 0.7.3",
  "testcontainers 0.12.0",
  "tokio",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -4020,7 +4029,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-futures",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.3",
  "url",
  "uuid",
  "vergen",
@@ -4160,6 +4169,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde1cf55178e0293453ba2cca0d5f8392a922e52aa958aee9c28ed02becc6d03"
 dependencies = [
+ "itoa",
  "libc",
 ]
 
@@ -4356,13 +4366,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
- "chrono",
  "crossbeam-channel",
- "tracing-subscriber",
+ "time 0.3.3",
+ "tracing-subscriber 0.3.3",
 ]
 
 [[package]]
@@ -4427,12 +4437,30 @@ dependencies = [
  "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers 0.1.0",
  "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "thread_local",
+ "time 0.3.3",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -60,9 +60,9 @@ tokio-util = { version = "0.6", features = [ "io" ] }
 toml = "0.5"
 torut = { version = "0.2", default-features = false, features = [ "v3", "control" ] }
 tracing = { version = "0.1", features = [ "attributes" ] }
-tracing-appender = "0.1"
+tracing-appender = "0.2"
 tracing-futures = { version = "0.2", features = [ "std-future", "futures-03" ] }
-tracing-subscriber = { version = "0.2", default-features = false, features = [ "fmt", "ansi", "env-filter", "chrono", "tracing-log", "json" ] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [ "fmt", "ansi", "env-filter", "local-time", "tracing-log", "json" ] }
 url = { version = "2", features = [ "serde" ] }
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 void = "1"

--- a/swap/src/asb/tracing.rs
+++ b/swap/src/asb/tracing.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
+use time::format_description::well_known::Rfc3339;
 use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::fmt::time::ChronoLocal;
+use tracing_subscriber::fmt::time::LocalTime;
 use tracing_subscriber::FmtSubscriber;
 
 pub fn init(level: LevelFilter, json_format: bool, timestamp: bool) -> Result<()> {
@@ -14,7 +15,7 @@ pub fn init(level: LevelFilter, json_format: bool, timestamp: bool) -> Result<()
         .with_env_filter(format!("asb={},swap={}", level, level))
         .with_writer(std::io::stderr)
         .with_ansi(is_terminal)
-        .with_timer(ChronoLocal::with_format("%F %T".to_owned()))
+        .with_timer(LocalTime::new(Rfc3339))
         .with_target(false);
 
     match (json_format, timestamp) {

--- a/swap/src/cli/tracing.rs
+++ b/swap/src/cli/tracing.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
 use std::option::Option::Some;
 use std::path::Path;
+use time::format_description::well_known::Rfc3339;
 use tracing::subscriber::set_global_default;
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::fmt::format::{DefaultFields, Format, JsonFields};
-use tracing_subscriber::fmt::time::ChronoLocal;
+use tracing_subscriber::fmt::time::LocalTime;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::{fmt, EnvFilter, FmtSubscriber, Layer, Registry};
 use uuid::Uuid;
@@ -52,7 +53,7 @@ pub fn init(debug: bool, json: bool, dir: impl AsRef<Path>, swap_id: Option<Uuid
             .with_env_filter(format!("swap={}", level))
             .with_writer(std::io::stderr)
             .with_ansi(is_terminal)
-            .with_timer(ChronoLocal::with_format("%F %T".to_owned()))
+            .with_timer(LocalTime::new(Rfc3339))
             .with_target(false);
 
         if json {
@@ -84,25 +85,25 @@ type StdErrJsonLayer<S, T> = tracing_subscriber::fmt::Layer<
     fn() -> std::io::Stderr,
 >;
 
-fn debug_terminal_printer<S>() -> StdErrPrinter<StdErrLayer<S, ChronoLocal>> {
+fn debug_terminal_printer<S>() -> StdErrPrinter<StdErrLayer<S, LocalTime<Rfc3339>>> {
     let is_terminal = atty::is(atty::Stream::Stderr);
     StdErrPrinter {
         inner: fmt::layer()
             .with_ansi(is_terminal)
             .with_target(false)
-            .with_timer(ChronoLocal::with_format("%F %T".to_owned()))
+            .with_timer(LocalTime::new(Rfc3339))
             .with_writer(std::io::stderr),
         level: Level::DEBUG,
     }
 }
 
-fn debug_json_terminal_printer<S>() -> StdErrPrinter<StdErrJsonLayer<S, ChronoLocal>> {
+fn debug_json_terminal_printer<S>() -> StdErrPrinter<StdErrJsonLayer<S, LocalTime<Rfc3339>>> {
     let is_terminal = atty::is(atty::Stream::Stderr);
     StdErrPrinter {
         inner: fmt::layer()
             .with_ansi(is_terminal)
             .with_target(false)
-            .with_timer(ChronoLocal::with_format("%F %T".to_owned()))
+            .with_timer(LocalTime::new(Rfc3339))
             .json()
             .with_writer(std::io::stderr),
         level: Level::DEBUG,

--- a/swap/src/tracing_ext.rs
+++ b/swap/src/tracing_ext.rs
@@ -41,7 +41,7 @@ impl MakeCapturingWriter {
     }
 }
 
-impl MakeWriter for MakeCapturingWriter {
+impl MakeWriter<'_> for MakeCapturingWriter {
     type Writer = CapturingWriter;
 
     fn make_writer(&self) -> Self::Writer {


### PR DESCRIPTION
Chrono feature is deprecated in tracing-subscriber 0.3.3

Closes #838 