### PR TITLE
Reduce `bitcoin_finality_confirmations` from 2 to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adjust quote based on Bitcoin balance.
   If the max_buy_btc in the ASB config is higher than the available balance to trade it will return the max available balance discounting the locking fees for monero, in the case the balance is lower than the min_buy_btc config it will return 0 to the CLI. If the ASB returns a quote of 0 the CLI will not allow you continue with a trade.
+- Reduce required confirmations for Bitcoin transactions from 2 to 1
 
 ## [0.10.2] - 2021-12-25
 

--- a/swap/src/env.rs
+++ b/swap/src/env.rs
@@ -48,7 +48,7 @@ impl GetConfig for Mainnet {
         Config {
             bitcoin_lock_mempool_timeout: 3.std_minutes(),
             bitcoin_lock_confirmed_timeout: 2.std_hours(),
-            bitcoin_finality_confirmations: 2,
+            bitcoin_finality_confirmations: 1,
             bitcoin_avg_block_time: 10.std_minutes(),
             bitcoin_cancel_timelock: CancelTimelock::new(72),
             bitcoin_punish_timelock: PunishTimelock::new(72),
@@ -65,7 +65,7 @@ impl GetConfig for Testnet {
         Config {
             bitcoin_lock_mempool_timeout: 3.std_minutes(),
             bitcoin_lock_confirmed_timeout: 1.std_hours(),
-            bitcoin_finality_confirmations: 2,
+            bitcoin_finality_confirmations: 1,
             bitcoin_avg_block_time: 10.std_minutes(),
             bitcoin_cancel_timelock: CancelTimelock::new(12),
             bitcoin_punish_timelock: PunishTimelock::new(6),


### PR DESCRIPTION
Reduces `bitcoin_finality_confirmations` from 2 to 1. This lowers the total time needed for a swap by an average of 10 minutes

I'm aware that this has been proposed before (https://github.com/comit-network/xmr-btc-swap/pull/800) and was rejected. 

> On the ASB, the bitcoin finality confirmations can be set to 1 using the config file. This will get you the swap reduction time you desire.

I believe this is not correct. There is no way for ASB operators to configure the `bitcoin_finality_confirmations` setting. Only the `target_block` can be configured manually, but this is only used for estimating the fee rate when a btc transaction is published and not for deciding when it is safe to assume that the transaction is finalized.

E.g the `config.toml` file of my (testate) asb
```
[data]
dir = "/root/.local/share/xmr-btc-swap/asb/testnet"

[network]
listen = ["/ip4/0.0.0.0/tcp/9939", "/ip4/0.0.0.0/tcp/9940/ws"]
external_addresses = ["/dnsaddr/unstoppableswap.net"]
rendezvous_point = "/dnsaddr/discover.unstoppableswap.net/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE"

[bitcoin]
electrum_rpc_url = "ssl://electrum.blockstream.info:60002"
target_block = 1  # My asb still waits for 2 confirmations on the btc lock tx
network = "Testnet"

[monero]
wallet_rpc_url = "http://127.0.0.1:38083/json_rpc"
network = "Stagenet"

[tor]
control_port = 9051
socks5_port = 9050

[maker]
min_buy_btc = 0.0001
max_buy_btc = 0.1
ask_spread = 0.00
price_ticker_ws_url = "wss://ws.kraken.com"
```