### PR TITLE
update option documentation to specify amount format

### DIFF
--- a/swap/src/asb/command.rs
+++ b/swap/src/asb/command.rs
@@ -276,7 +276,7 @@ pub enum RawCommand {
     WithdrawBtc {
         #[structopt(
             long = "amount",
-            help = "Optionally specify the amount of Bitcoin to be withdrawn. If not specified the wallet will be drained."
+            help = "Optionally specify the amount of Bitcoin to be withdrawn. If not specified the wallet will be drained. Amount must be specified in quotes with denomination, e.g `--amount '0.1 BTC'`"
         )]
         amount: Option<Amount>,
         #[structopt(long = "address", help = "The address to receive the Bitcoin.")]


### PR DESCRIPTION
The current amount format is very confusing (see #667). Add documentation to
explain the correct format to use when withdrawing BTC.