### PR TITLE
Increase refund window (punish timelock) from 12 hours to 72 hours

### DIFF
--- a/swap/src/env.rs
+++ b/swap/src/env.rs
@@ -51,7 +51,7 @@ impl GetConfig for Mainnet {
             bitcoin_finality_confirmations: 2,
             bitcoin_avg_block_time: 10.std_minutes(),
             bitcoin_cancel_timelock: CancelTimelock::new(72),
-            bitcoin_punish_timelock: PunishTimelock::new(72),
+            bitcoin_punish_timelock: PunishTimelock::new(288),
             bitcoin_network: bitcoin::Network::Bitcoin,
             monero_avg_block_time: 2.std_minutes(),
             monero_finality_confirmations: 10,


### PR DESCRIPTION
In my opinion, there is a significant discrepancy between the risk and reward for Alice and Bob. Alice takes on virtually no risk and is never in jeopardy of losing her funds. Bob, on the other hand, must carefully consider the timing of the publication of his refund transaction if Alice deviates from protocol (e.g., by not publishing her Monero). There is no incentive for Bob to ever act in bad faith, since there is no scenario in which he could benefit financially. Alice, on the other hand, has the opportunity to make money by not locking her Monero, hoping that Bob will not publish the refund transaction, and then punishing him.

The punish scenario should really be the last resort because it's should only happen when Bob looses access to his machine, forgets to resume the swap (risking his funds in the process) or when Alice doesn't lock her Monero (which should never happen because the swap should fail if Alice doesn't have enough XMR for the swap)

By increasing the window of time Bob has to make the refund, I hope we can reduce this discrepancy, at least to some degree. I know this is not a real solution, but rather a quick fix. In the long run, as you said, some kind of system is needed that allows users to rate the reliability of the various ASBs but that is not a trivial problem.