### PR TITLE
update dependencies and update toolchain to 1.59 (stable)

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -67,9 +67,9 @@ jobs:
         run: target/${{ matrix.target }}/release/${{ matrix.bin }} --help
 
       # Remove once python 3 is the default
-      - uses: actions/setup-python@v2.3.2
+      - uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - id: create-archive-name
         shell: python # Use python to have a prettier name for the archive on Windows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"
@@ -89,6 +89,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asn1_der"
@@ -105,7 +111,7 @@ dependencies = [
  "bzip2",
  "futures-core",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -130,7 +136,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -176,14 +182,14 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backoff"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
  "getrandom 0.2.2",
  "instant",
- "pin-project 1.0.5",
+ "pin-project-lite 0.2.8",
  "rand 0.8.3",
  "tokio",
 ]
@@ -235,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.12.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf7e997526ceefbab7dd99fc0da6834ed8853bd051f53523415ed1dc82b870d"
+checksum = "3face7de38293a2f7e2a9f69a48b442f28e864da0fc7a6a977388e31bdc367d7"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -364,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -562,13 +568,13 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "comfy-table"
-version = "4.1.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e95a3e867422fd8d04049041f5671f94d53c32a9dcd82e2be268714942f3f3"
+checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
 dependencies = [
  "crossterm",
- "strum 0.21.0",
- "strum_macros 0.21.0",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -729,15 +735,15 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+checksum = "77b75a27dc8d220f1f8521ea69cd55a34d720a200ebb3a624d9aa19193d3b432"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.0",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -745,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -1184,7 +1190,7 @@ checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1249,7 +1255,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1356,7 +1362,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1515,7 +1521,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa 0.4.7",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "socket2 0.4.0",
  "tokio",
  "tower-service",
@@ -1740,7 +1746,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -1788,7 +1794,7 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project 1.0.5",
  "smallvec",
  "wasm-timer",
@@ -1812,7 +1818,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project 1.0.5",
  "prost",
  "prost-build",
@@ -1861,7 +1867,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint",
@@ -2005,7 +2011,7 @@ source = "git+https://github.com/libp2p/rust-libp2p.git#6d3ab8a3debe8d69dcd00417
 dependencies = [
  "futures",
  "libp2p-core",
- "parking_lot",
+ "parking_lot 0.11.2",
  "thiserror",
  "yamux",
 ]
@@ -2089,9 +2095,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -2555,7 +2561,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2573,14 +2589,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "1.0.1"
+name = "parking_lot_core"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06673860db84d02a63942fa69cd9543f2624a5df3aea7f33173048fa7ad5cf1a"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
  "base64 0.13.0",
- "once_cell",
- "regex",
 ]
 
 [[package]]
@@ -2656,9 +2683,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -3177,7 +3204,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "rustls 0.20.2",
  "rustls-pemfile",
  "serde",
@@ -3186,7 +3213,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.1",
  "tokio-socks",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3222,20 +3249,20 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.18.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b5a9625a7e6060b23db692facf49082cc78889a7e6ac94a735356ae49db4b0"
+checksum = "d37baa70cf8662d2ba1c1868c5983dda16ef32b105cce41fb5c47e72936a90b3"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.18.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a71e447554613b11da876d63d04e78fc3e8e86769488d3b58887671e23bc86"
+checksum = "184abaf7b434800e1a5a8aad3ebc8cd7498df33af72d65371d797a264713a59b"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -3541,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "rustversion",
  "serde",
@@ -3624,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3677,7 +3704,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -3818,7 +3845,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "rustls 0.19.0",
  "serde",
@@ -3928,29 +3955,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
-
-[[package]]
-name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
- "strum_macros 0.23.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb076d8b589fde927ec90d05920d610554ca3a4d9dddb177481cadd071a19c2e"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4029,7 +4038,7 @@ dependencies = [
  "spectral",
  "sqlx",
  "structopt",
- "strum 0.23.0",
+ "strum",
  "tempfile",
  "testcontainers 0.12.0",
  "thiserror",
@@ -4038,7 +4047,7 @@ dependencies = [
  "tokio-socks",
  "tokio-tar",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.7.0",
  "toml",
  "torut",
  "tracing",
@@ -4214,18 +4223,19 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
+ "autocfg 1.0.1",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
- "pin-project-lite 0.2.6",
+ "parking_lot 0.11.2",
+ "pin-project-lite 0.2.8",
  "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
@@ -4283,7 +4293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -4321,15 +4331,29 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -4373,7 +4397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.6",
+ "pin-project-lite 0.2.8",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4500,7 +4524,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -4804,7 +4828,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4929,6 +4953,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,7 +5052,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rand 0.8.3",
  "static_assertions",
 ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ It is not recommended to bump fees when swapping because it can have unpredictab
 We are encourage community contributions whether it be a bug fix or an improvement to the documentation.
 Please have a look at the [contribution guidelines](./CONTRIBUTING.md).
 
+## Rust Version Support
+
+Please note that only the latest stable Rust toolchain is supported.
+All stable toolchains since 1.58 _should_ work.
+
 ## Contact
 
 Feel free to reach out to us in the [COMIT-Monero Matrix channel](https://matrix.to/#/#comit-monero:matrix.org).

--- a/monero-harness/Cargo.toml
+++ b/monero-harness/Cargo.toml
@@ -2,7 +2,7 @@
 name = "monero-harness"
 version = "0.1.0"
 authors = [ "CoBloX Team <team@coblox.tech>" ]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/monero-harness/src/image.rs
+++ b/monero-harness/src/image.rs
@@ -13,7 +13,7 @@ pub const MONEROD_DEFAULT_NETWORK: &str = "monero_network";
 /// this doesn't matter.
 pub const RPC_PORT: u16 = 18081;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Monerod {
     args: MonerodArgs,
 }
@@ -58,15 +58,7 @@ impl Image for Monerod {
     }
 }
 
-impl Default for Monerod {
-    fn default() -> Self {
-        Self {
-            args: MonerodArgs::default(),
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MoneroWalletRpc {
     args: MoneroWalletRpcArgs,
 }
@@ -108,14 +100,6 @@ impl Image for MoneroWalletRpc {
     fn entrypoint(&self) -> Option<String> {
         Some("".to_owned()) // an empty entrypoint disables the entrypoint
                             // script and gives us full control
-    }
-}
-
-impl Default for MoneroWalletRpc {
-    fn default() -> Self {
-        Self {
-            args: MoneroWalletRpcArgs::default(),
-        }
     }
 }
 

--- a/monero-rpc/Cargo.toml
+++ b/monero-rpc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "monero-rpc"
 version = "0.1.0"
 authors = [ "CoBloX Team <team@coblox.tech>" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/monero-rpc/src/wallet.rs
+++ b/monero-rpc/src/wallet.rs
@@ -184,12 +184,7 @@ pub struct Refreshed {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SweepAll {
-    amount_list: Vec<u64>,
-    fee_list: Vec<u64>,
-    multisig_txset: String,
     pub tx_hash_list: Vec<String>,
-    unsigned_txset: String,
-    weight_list: Vec<u32>,
 }
 
 #[derive(Debug, Copy, Clone, Deserialize)]
@@ -244,7 +239,7 @@ mod tests {
           }
         }"#;
 
-        let _: Response<SweepAll> = serde_json::from_str(&response).unwrap();
+        let _: Response<SweepAll> = serde_json::from_str(response).unwrap();
     }
 
     #[test]
@@ -256,6 +251,6 @@ mod tests {
           }
         }"#;
 
-        let _: Response<WalletCreated> = serde_json::from_str(&response).unwrap();
+        let _: Response<WalletCreated> = serde_json::from_str(response).unwrap();
     }
 }

--- a/monero-wallet/Cargo.toml
+++ b/monero-wallet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "monero-wallet"
 version = "0.1.0"
 authors = [ "CoBloX Team <team@coblox.tech>" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/monero-wallet/src/lib.rs
+++ b/monero-wallet/src/lib.rs
@@ -77,8 +77,8 @@ mod tests {
         let result = rpc_client
             .get_outs(
                 key_offsets
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(|varint| GetOutputsOut {
                         amount: 0,
                         index: varint.0,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.53"
+channel = "1.59"
 components = ["clippy"]
 targets = ["armv7-unknown-linux-gnueabihf"]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swap"
 version = "0.10.2"
 authors = [ "The COMIT guys <hello@comit.network>" ]
-edition = "2018"
+edition = "2021"
 description = "XMR/BTC trustless atomic swaps."
 
 [lib]
@@ -13,13 +13,13 @@ anyhow = "1"
 async-compression = { version = "0.3", features = [ "bzip2", "tokio" ] }
 async-trait = "0.1"
 atty = "0.2"
-backoff = { version = "0.3", features = [ "tokio" ] }
+backoff = { version = "0.4", features = [ "tokio" ] }
 base64 = "0.13"
-bdk = "0.12"
+bdk = "0.16"
 big-bytes = "1"
 bitcoin = { version = "0.27", features = [ "rand", "use-serde" ] }
 bmrng = "0.5"
-comfy-table = "4.1.1"
+comfy-table = "5.0"
 config = { version = "0.11", default-features = false, features = [ "toml" ] }
 conquer-once = "0.3"
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4" }
@@ -56,7 +56,7 @@ time = "0.3"
 tokio = { version = "1", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
 tokio-socks = "0.5"
 tokio-tungstenite = { version = "0.15", features = [ "rustls-tls" ] }
-tokio-util = { version = "0.6", features = [ "io" ] }
+tokio-util = { version = "0.7", features = [ "io", "codec" ] }
 toml = "0.5"
 torut = { version = "0.2", default-features = false, features = [ "v3", "control" ] }
 tracing = { version = "0.1", features = [ "attributes" ] }

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
         json,
         cmd,
     } = match parse_args_and_apply_defaults(env::args_os())? {
-        ParseResult::Arguments(args) => args,
+        ParseResult::Arguments(args) => *args,
         ParseResult::PrintAndExitZero { message } => {
             println!("{}", message);
             std::process::exit(0);
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
             tracing::debug!(peer_id = %swarm.local_peer_id(), "Network layer initialized");
 
             let (event_loop, mut event_loop_handle) =
-                EventLoop::new(swap_id, swarm, seller_peer_id, env_config)?;
+                EventLoop::new(swap_id, swarm, seller_peer_id)?;
             let event_loop = tokio::spawn(event_loop.run());
 
             let max_givable = || bitcoin_wallet.max_giveable(TxLock::script_size());
@@ -276,8 +276,7 @@ async fn main() -> Result<()> {
                     .add_address(seller_peer_id, seller_address);
             }
 
-            let (event_loop, event_loop_handle) =
-                EventLoop::new(swap_id, swarm, seller_peer_id, env_config)?;
+            let (event_loop, event_loop_handle) = EventLoop::new(swap_id, swarm, seller_peer_id)?;
             let handle = tokio::spawn(event_loop.run());
 
             let monero_receive_address = db.get_monero_address(swap_id).await?;

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -171,7 +171,7 @@ pub fn verify_sig(
 ) -> Result<()> {
     let ecdsa = ECDSA::verify_only();
 
-    if ecdsa.verify(&verification_key.0, &transaction_sighash.into_inner(), &sig) {
+    if ecdsa.verify(&verification_key.0, &transaction_sighash.into_inner(), sig) {
         Ok(())
     } else {
         bail!(InvalidSignature)
@@ -194,7 +194,7 @@ pub fn verify_encsig(
         &verification_key.0,
         &encryption_key.0,
         &digest.into_inner(),
-        &encsig,
+        encsig,
     ) {
         Ok(())
     } else {
@@ -213,7 +213,7 @@ pub fn build_shared_output_descriptor(A: Point, B: Point) -> Descriptor<bitcoin:
     let A = ToHex::to_hex(&secp256k1::PublicKey::from(A));
     let B = ToHex::to_hex(&secp256k1::PublicKey::from(B));
 
-    let miniscript = MINISCRIPT_TEMPLATE.replace("A", &A).replace("B", &B);
+    let miniscript = MINISCRIPT_TEMPLATE.replace('A', &A).replace('B', &B);
 
     let miniscript =
         bdk::miniscript::Miniscript::<bitcoin::PublicKey, Segwitv0>::from_str(&miniscript)

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -200,9 +200,10 @@ mod tests {
     #[tokio::test]
     async fn bob_can_fund_without_a_change_output() {
         let (A, B) = alice_and_bob();
-        let fees = 610;
+        let fees = 300;
         let agreed_amount = Amount::from_sat(10000);
-        let wallet = WalletBuilder::new(agreed_amount.as_sat() + fees).build();
+        let amount = agreed_amount.as_sat() + fees;
+        let wallet = WalletBuilder::new(amount).build();
 
         let psbt = bob_make_psbt(A, B, &wallet, agreed_amount).await;
         assert_eq!(
@@ -262,7 +263,7 @@ mod tests {
         amount: Amount,
     ) -> PartiallySignedTransaction {
         let change = wallet.new_address().await.unwrap();
-        TxLock::new(&wallet, amount, A, B, change)
+        TxLock::new(wallet, amount, A, B, change)
             .await
             .unwrap()
             .into()

--- a/swap/src/bitcoin/redeem.rs
+++ b/swap/src/bitcoin/redeem.rs
@@ -128,7 +128,7 @@ impl TxRedeem {
 
         let sig = sigs
             .into_iter()
-            .find(|sig| verify_sig(&B, &self.digest(), &sig).is_ok())
+            .find(|sig| verify_sig(&B, &self.digest(), sig).is_ok())
             .context("Neither signature on witness stack verifies against B")?;
 
         Ok(sig)

--- a/swap/src/bitcoin/refund.rs
+++ b/swap/src/bitcoin/refund.rs
@@ -132,7 +132,7 @@ impl TxRefund {
 
         let sig = sigs
             .into_iter()
-            .find(|sig| verify_sig(&B, &self.digest(), &sig).is_ok())
+            .find(|sig| verify_sig(&B, &self.digest(), sig).is_ok())
             .context("Neither signature on witness stack verifies against B")?;
 
         Ok(sig)

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -102,7 +102,7 @@ impl Wallet {
         self.wallet
             .lock()
             .await
-            .broadcast(transaction)
+            .broadcast(&transaction)
             .with_context(|| {
                 format!("Failed to broadcast Bitcoin {} transaction {}", kind, txid)
             })?;
@@ -152,13 +152,13 @@ impl Wallet {
                                 ScriptStatus::Retrying
                             }
                         };
-                        
+
                         if new_status != ScriptStatus::Retrying
                         {
                             last_status = Some(print_status_change(txid, last_status, new_status));
 
                             let all_receivers_gone = sender.send(new_status).is_err();
-    
+
                             if all_receivers_gone {
                                 tracing::debug!(%txid, "All receivers gone, removing subscription");
                                 client.lock().await.subscriptions.remove(&(txid, script));

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -41,7 +41,7 @@ pub struct Arguments {
 #[derive(Debug, PartialEq)]
 pub enum ParseResult {
     /// The arguments we were invoked in.
-    Arguments(Arguments),
+    Arguments(Box<Arguments>),
     /// A flag or command was given that does not need further processing other
     /// than printing the provided message.
     ///
@@ -260,7 +260,7 @@ where
         },
     };
 
-    Ok(ParseResult::Arguments(arguments))
+    Ok(ParseResult::Arguments(Box::new(arguments)))
 }
 
 #[derive(Debug, PartialEq)]
@@ -693,7 +693,8 @@ mod tests {
             MULTI_ADDRESS,
         ];
 
-        let expected_args = ParseResult::Arguments(Arguments::buy_xmr_mainnet_defaults());
+        let expected_args =
+            ParseResult::Arguments(Arguments::buy_xmr_mainnet_defaults().into_boxed());
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
 
         assert_eq!(expected_args, args);
@@ -717,7 +718,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::buy_xmr_testnet_defaults())
+            ParseResult::Arguments(Arguments::buy_xmr_testnet_defaults().into_boxed())
         );
     }
 
@@ -778,7 +779,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_mainnet_defaults())
+            ParseResult::Arguments(Arguments::resume_mainnet_defaults().into_boxed())
         );
     }
 
@@ -790,7 +791,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_testnet_defaults())
+            ParseResult::Arguments(Arguments::resume_testnet_defaults().into_boxed())
         );
     }
 
@@ -802,7 +803,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::cancel_mainnet_defaults())
+            ParseResult::Arguments(Arguments::cancel_mainnet_defaults().into_boxed())
         );
     }
 
@@ -814,7 +815,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::cancel_testnet_defaults())
+            ParseResult::Arguments(Arguments::cancel_testnet_defaults().into_boxed())
         );
     }
 
@@ -826,7 +827,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::refund_mainnet_defaults())
+            ParseResult::Arguments(Arguments::refund_mainnet_defaults().into_boxed())
         );
     }
 
@@ -838,7 +839,7 @@ mod tests {
 
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::refund_testnet_defaults())
+            ParseResult::Arguments(Arguments::refund_testnet_defaults().into_boxed())
         );
     }
 
@@ -866,6 +867,7 @@ mod tests {
             ParseResult::Arguments(
                 Arguments::buy_xmr_mainnet_defaults()
                     .with_data_dir(PathBuf::from_str(data_dir).unwrap().join("mainnet"))
+                    .into_boxed()
             )
         );
 
@@ -890,6 +892,7 @@ mod tests {
             ParseResult::Arguments(
                 Arguments::buy_xmr_testnet_defaults()
                     .with_data_dir(PathBuf::from_str(data_dir).unwrap().join("testnet"))
+                    .into_boxed()
             )
         );
 
@@ -909,6 +912,7 @@ mod tests {
             ParseResult::Arguments(
                 Arguments::resume_mainnet_defaults()
                     .with_data_dir(PathBuf::from_str(data_dir).unwrap().join("mainnet"))
+                    .into_boxed()
             )
         );
 
@@ -929,6 +933,7 @@ mod tests {
             ParseResult::Arguments(
                 Arguments::resume_testnet_defaults()
                     .with_data_dir(PathBuf::from_str(data_dir).unwrap().join("testnet"))
+                    .into_boxed()
             )
         );
     }
@@ -950,7 +955,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::buy_xmr_mainnet_defaults().with_debug())
+            ParseResult::Arguments(
+                Arguments::buy_xmr_mainnet_defaults()
+                    .with_debug()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![
@@ -969,7 +978,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::buy_xmr_testnet_defaults().with_debug())
+            ParseResult::Arguments(
+                Arguments::buy_xmr_testnet_defaults()
+                    .with_debug()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![BINARY_NAME, "--debug", "resume", "--swap-id", SWAP_ID];
@@ -977,7 +990,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_mainnet_defaults().with_debug())
+            ParseResult::Arguments(
+                Arguments::resume_mainnet_defaults()
+                    .with_debug()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![
@@ -992,7 +1009,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_testnet_defaults().with_debug())
+            ParseResult::Arguments(
+                Arguments::resume_testnet_defaults()
+                    .with_debug()
+                    .into_boxed()
+            )
         );
     }
 
@@ -1013,7 +1034,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::buy_xmr_mainnet_defaults().with_json())
+            ParseResult::Arguments(
+                Arguments::buy_xmr_mainnet_defaults()
+                    .with_json()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![
@@ -1032,7 +1057,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::buy_xmr_testnet_defaults().with_json())
+            ParseResult::Arguments(
+                Arguments::buy_xmr_testnet_defaults()
+                    .with_json()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![BINARY_NAME, "--json", "resume", "--swap-id", SWAP_ID];
@@ -1040,7 +1069,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_mainnet_defaults().with_json())
+            ParseResult::Arguments(
+                Arguments::resume_mainnet_defaults()
+                    .with_json()
+                    .into_boxed()
+            )
         );
 
         let raw_ars = vec![
@@ -1055,7 +1088,11 @@ mod tests {
         let args = parse_args_and_apply_defaults(raw_ars).unwrap();
         assert_eq!(
             args,
-            ParseResult::Arguments(Arguments::resume_testnet_defaults().with_json())
+            ParseResult::Arguments(
+                Arguments::resume_testnet_defaults()
+                    .with_json()
+                    .into_boxed()
+            )
         );
     }
 
@@ -1302,6 +1339,10 @@ mod tests {
         pub fn with_json(mut self) -> Self {
             self.json = true;
             self
+        }
+
+        pub fn into_boxed(self) -> Box<Self> {
+            Box::new(self)
         }
     }
 

--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -1,10 +1,10 @@
 use crate::bitcoin::EncryptedSignature;
 use crate::cli::behaviour::{Behaviour, OutEvent};
+use crate::monero;
 use crate::network::encrypted_signature;
 use crate::network::quote::BidQuote;
 use crate::network::swap_setup::bob::NewSwap;
 use crate::protocol::bob::State2;
-use crate::{env, monero};
 use anyhow::{Context, Result};
 use futures::future::{BoxFuture, OptionFuture};
 use futures::{FutureExt, StreamExt};
@@ -50,7 +50,6 @@ impl EventLoop {
         swap_id: Uuid,
         swarm: Swarm<Behaviour>,
         alice_peer_id: PeerId,
-        env_config: env::Config,
     ) -> Result<(Self, EventLoopHandle)> {
         let execution_setup = bmrng::channel_with_timeout(1, Duration::from_secs(60));
         let transfer_proof = bmrng::channel_with_timeout(1, Duration::from_secs(60));
@@ -76,7 +75,6 @@ impl EventLoop {
             transfer_proof: transfer_proof.1,
             encrypted_signature: encrypted_signature.0,
             quote: quote.0,
-            env_config,
         };
 
         Ok((event_loop, handle))
@@ -220,7 +218,6 @@ pub struct EventLoopHandle {
     transfer_proof: bmrng::RequestReceiver<monero::TransferProof, ()>,
     encrypted_signature: bmrng::RequestSender<EncryptedSignature, ()>,
     quote: bmrng::RequestSender<(), BidQuote>,
-    env_config: env::Config,
 }
 
 impl EventLoopHandle {

--- a/swap/src/cli/list_sellers.rs
+++ b/swap/src/cli/list_sellers.rs
@@ -271,7 +271,7 @@ impl EventLoop {
                             QuoteStatus::Received(Status::Online(quote)) => {
                                 let address = self
                                     .reachable_asb_address
-                                    .get(&peer_id)
+                                    .get(peer_id)
                                     .expect("if we got a quote we must have stored an address");
 
                                 Ok(Seller {
@@ -282,7 +282,7 @@ impl EventLoop {
                             QuoteStatus::Received(Status::Unreachable) => {
                                 let address = self
                                     .unreachable_asb_address
-                                    .get(&peer_id)
+                                    .get(peer_id)
                                     .expect("if we got a quote we must have stored an address");
 
                                 Ok(Seller {

--- a/swap/src/env.rs
+++ b/swap/src/env.rs
@@ -138,7 +138,7 @@ mod monero_network {
             Network::Stagenet => "stagenet",
             Network::Testnet => "testnet",
         };
-        s.serialize_str(&str)
+        s.serialize_str(str)
     }
 }
 

--- a/swap/src/kraken.rs
+++ b/swap/src/kraken.rs
@@ -45,7 +45,7 @@ pub fn connect(price_ticker_ws_url: Url) -> Result<PriceUpdates> {
                         }
                     }
 
-                    Err(backoff::Error::Transient(anyhow!("stream ended")))
+                    Err(backoff::Error::transient(anyhow!("stream ended")))
                 }
             },
             |error, next: Duration| {
@@ -108,8 +108,8 @@ fn to_backoff(e: connection::Error) -> backoff::Error<anyhow::Error> {
 
     match e {
         // Connection closures and websocket errors will be retried
-        connection::Error::ConnectionClosed => Transient(anyhow::Error::from(e)),
-        connection::Error::WebSocket(_) => Transient(anyhow::Error::from(e)),
+        connection::Error::ConnectionClosed => backoff::Error::transient(anyhow::Error::from(e)),
+        connection::Error::WebSocket(_) => backoff::Error::transient(anyhow::Error::from(e)),
 
         // Failures while parsing a message are permanent because they most likely present a
         // programmer error
@@ -275,8 +275,6 @@ mod wire {
     pub struct TickerData {
         #[serde(rename = "a")]
         ask: Vec<RateElement>,
-        #[serde(rename = "b")]
-        bid: Vec<RateElement>,
     }
 
     #[derive(Debug, Deserialize)]

--- a/swap/src/proptest.rs
+++ b/swap/src/proptest.rs
@@ -6,7 +6,7 @@ pub mod ecdsa_fun {
     use ::ecdsa_fun::fun::{Point, Scalar, G};
 
     pub fn point() -> impl Strategy<Value = Point> {
-        scalar().prop_map(|mut scalar| Point::from_scalar_mul(&G, &mut scalar).mark::<Normal>())
+        scalar().prop_map(|mut scalar| Point::from_scalar_mul(G, &mut scalar).mark::<Normal>())
     }
 
     pub fn scalar() -> impl Strategy<Value = Scalar> {

--- a/swap/tests/harness/bitcoind.rs
+++ b/swap/tests/harness/bitcoind.rs
@@ -29,7 +29,7 @@ impl Image for Bitcoind {
         container
             .logs()
             .stdout
-            .wait_for_message(&"init message: Done loading")
+            .wait_for_message("init message: Done loading")
             .unwrap();
     }
 

--- a/swap/tests/harness/electrs.rs
+++ b/swap/tests/harness/electrs.rs
@@ -14,7 +14,6 @@ pub struct Electrs {
     entrypoint: Option<String>,
     wait_for_message: String,
     volume: String,
-    bitcoind_container_name: String,
 }
 
 impl Image for Electrs {
@@ -73,7 +72,6 @@ impl Default for Electrs {
             entrypoint: Some("/build/electrs".into()),
             wait_for_message: "Running accept thread".to_string(),
             volume: uuid::Uuid::new_v4().to_string(),
-            bitcoind_container_name: uuid::Uuid::new_v4().to_string(),
         }
     }
 }

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -146,14 +146,14 @@ async fn init_containers(cli: &Cli) -> (Monero, Containers<'_>) {
     let prefix = random_prefix();
     let bitcoind_name = format!("{}_{}", prefix, "bitcoind");
     let (bitcoind, bitcoind_url) =
-        init_bitcoind_container(&cli, prefix.clone(), bitcoind_name.clone(), prefix.clone())
+        init_bitcoind_container(cli, prefix.clone(), bitcoind_name.clone(), prefix.clone())
             .await
             .expect("could not init bitcoind");
-    let electrs = init_electrs_container(&cli, prefix.clone(), bitcoind_name, prefix)
+    let electrs = init_electrs_container(cli, prefix.clone(), bitcoind_name, prefix)
         .await
         .expect("could not init electrs");
     let (monero, monerod_container, monero_wallet_rpc_containers) =
-        Monero::new(&cli, vec![MONERO_WALLET_NAME_ALICE, MONERO_WALLET_NAME_BOB])
+        Monero::new(cli, vec![MONERO_WALLET_NAME_ALICE, MONERO_WALLET_NAME_BOB])
             .await
             .unwrap();
 
@@ -237,7 +237,7 @@ async fn start_alice(
     let resume_only = false;
 
     let mut swarm = swarm::asb(
-        &seed,
+        seed,
         min_buy,
         max_buy,
         latest_rate,
@@ -485,7 +485,7 @@ impl BobParams {
             .behaviour_mut()
             .add_address(self.alice_peer_id, self.alice_address.clone());
 
-        cli::EventLoop::new(swap_id, swarm, self.alice_peer_id, self.env_config)
+        cli::EventLoop::new(swap_id, swarm, self.alice_peer_id)
     }
 }
 


### PR DESCRIPTION
This PR updates the rust-toolchain to the current stable version 1.59, and fixes a number of new clippy warnings from that change. 

This update to the toolchain introduced new clippy warnings indicating fields that are never read - these fields have been removed. 

Also updates a few crates to the Rust 2021 edition.

And includes the following dependency updates:

- #967 
- #964 
- #959 
- #974 
- #957 
- #954 
- #950 
- #949 
- #872 
- #882 


