### PR TITLE
DO NOT MERGE: Allow cancel, refund for swap that are in `SwapSetupCompleted` state

### DIFF
--- a/swap/src/cli/cancel.rs
+++ b/swap/src/cli/cancel.rs
@@ -14,6 +14,7 @@ pub async fn cancel(
     let state = db.get_state(swap_id).await?.try_into()?;
 
     let state6 = match state {
+        BobState::SwapSetupCompleted(state2) => state2.cancel(),
         BobState::BtcLocked { state3, .. } => state3.cancel(),
         BobState::XmrLockProofReceived { state, .. } => state.cancel(),
         BobState::XmrLocked(state4) => state4.cancel(),
@@ -23,7 +24,6 @@ pub async fn cancel(
         BobState::BtcCancelled(state6) => state6,
 
         BobState::Started { .. }
-        | BobState::SwapSetupCompleted(_)
         | BobState::BtcRedeemed(_)
         | BobState::XmrRedeemed { .. }
         | BobState::BtcPunished { .. }

--- a/swap/src/cli/refund.rs
+++ b/swap/src/cli/refund.rs
@@ -14,6 +14,7 @@ pub async fn refund(
     let state = db.get_state(swap_id).await?.try_into()?;
 
     let state6 = match state {
+        BobState::SwapSetupCompleted(state2) => state2.cancel(),
         BobState::BtcLocked { state3, .. } => state3.cancel(),
         BobState::XmrLockProofReceived { state, .. } => state.cancel(),
         BobState::XmrLocked(state4) => state4.cancel(),
@@ -21,7 +22,6 @@ pub async fn refund(
         BobState::CancelTimelockExpired(state6) => state6,
         BobState::BtcCancelled(state6) => state6,
         BobState::Started { .. }
-        | BobState::SwapSetupCompleted(_)
         | BobState::BtcRedeemed(_)
         | BobState::BtcRefunded(_)
         | BobState::XmrRedeemed { .. }

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -331,6 +331,22 @@ impl State2 {
         }
     }
 
+    pub fn cancel(&self) -> State6 {
+        State6 {
+            A: self.A,
+            b: self.b.clone(),
+            s_b: self.s_b,
+            cancel_timelock: self.cancel_timelock,
+            punish_timelock: self.punish_timelock,
+            refund_address: self.refund_address.clone(),
+            tx_lock: self.tx_lock.clone(),
+            tx_cancel_sig_a: self.tx_cancel_sig_a.clone(),
+            tx_refund_encsig: self.tx_refund_encsig.clone(),
+            tx_refund_fee: self.tx_refund_fee,
+            tx_cancel_fee: self.tx_cancel_fee,
+        }
+    }
+
     pub async fn lock_btc(self) -> Result<(State3, TxLock)> {
         Ok((
             State3 {


### PR DESCRIPTION
Small patch to allow cancel, refund in `SwapSetupCompleted` state. Allows refund when BtcLocked state was not saved due to corrupted database (?)