### PR TITLE
fix potential overflow in `max_bitcoin_for_price`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update from monero v17.2.0 to monero v17.3.0
 - Always write logs as JSON to files
 - Change to UTC time for log messages, due to a bug causing no logging at all to be printed (linux/macos), and an [unsoundness issue](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/time/struct.LocalTime.html) with local time in [the time crate](https://github.com/time-rs/time/issues/293#issuecomment-748151025)
+- Fix potential integer overflow in ASB when calculating maximum Bitcoin amount for Monero balance
+- Reduce Monero locking transaction fee amount from 0.000030 to 0.000016 XMR, which is still double the current median fee as reported at [monero.how](https://www.monero.how/monero-transaction-fees)
 
 ### Added
 

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -326,11 +326,15 @@ where
             .ask()
             .context("Failed to compute asking price")?;
 
-        let max_bitcoin_for_monero = self
-            .monero_wallet
-            .get_balance()
-            .await?
-            .max_bitcoin_for_price(ask_price);
+        let xmr = self.monero_wallet.get_balance().await?;
+
+        let max_bitcoin_for_monero = xmr.max_bitcoin_for_price(ask_price).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Bitcoin price ({}) x Monero ({}) calculation overflow",
+                ask_price,
+                xmr,
+            )
+        })?;
 
         if min_buy > max_bitcoin_for_monero {
             tracing::warn!(


### PR DESCRIPTION
In testing, ASB panicked in `max_bitcoin_for_price` when the Monero balance x Bitcoin price was enough to overflow `u64`.

This PR changes the function to do the piconero offset division first, and then to use `checked_mul` to return None if the calculation would overflow. This required changing the function return signature to an `Option`. Additional tests for the function were also added.

MONERO_FEE was also changed from 0.000030 to 0.000016, which is still double the current median transaction fee listed at
https://www.monero.how/monero-transaction-fees as of 2022-07-28.