### PR TITLE
fix btc for xmr calculation error

### DIFF
--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -329,12 +329,10 @@ where
         let xmr = self.monero_wallet.get_balance().await?;
 
         let max_bitcoin_for_monero = xmr.max_bitcoin_for_price(ask_price).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Bitcoin price ({}) x Monero ({}) calculation overflow",
-                ask_price,
-                xmr,
-            )
+            anyhow::anyhow!("Bitcoin price ({}) x Monero ({}) overflow", ask_price, xmr)
         })?;
+
+        tracing::debug!(%ask_price, %xmr, %max_bitcoin_for_monero);
 
         if min_buy > max_bitcoin_for_monero {
             tracing::warn!(


### PR DESCRIPTION
The calculation overflow fix in #1068 did not account for XMR < 1 which
resulted in truncation when dividing by the PICO_OFFSET.

This commit uses `Decimal` to do the calculation at fixed precision and
adds a number of test values to verify the calculation.

Closes #1084