### PR TITLE
ci: specify previous dprint version 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Check formatting
         uses: dprint/check@v2.1
+        with:
+          dprint-version: 0.30.3
 
       - name: Run clippy with default features
         run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
The dprint check is failing since the new release, so this commit fixes our CI to the previous working version. 

https://github.com/dprint/check/issues/8