### PR TITLE
ci: use cargo cross for armv7 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,27 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.2.0
 
-      - name: Install compiler for armhf arch
-        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-arm-linux-gnueabihf
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: armv7-unknown-linux-gnueabihf
+          override: true
 
       - name: Build binary
-        run: |
-          cargo build -p swap --target ${{ matrix.target }}
+        if: matrix.target != 'armv7-unknown-linux-gnueabihf'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p swap --target ${{ matrix.target }}
+
+      - name: Build binary (armv7)
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p swap --target ${{ matrix.target }}
+          use-cross: true
 
       - name: Upload swap binary
         uses: actions/upload-artifact@v2-preview


### PR DESCRIPTION
armv7 builds have started failing, presumably due to some change in the CI runners. 

this change updates the CI to use `cargo cross` for more reliable cross compilation 

example failure: https://github.com/comit-network/xmr-btc-swap/actions/runs/3496339850/jobs/5855083680 

```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/home/runner/work/xmr-btc-swap/xmr-btc-swap/target/debug/build/ring-3b88841cfec2d8d7/build-script-build` (exit status: 101)
  --- stdout
  OPT_LEVEL = Some("0")
  TARGET = Some("armv7-unknown-linux-gnueabihf")
  HOST = Some("x86_64-unknown-linux-gnu")
  CC_armv7-unknown-linux-gnueabihf = None
  CC_armv7_unknown_linux_gnueabihf = None
  TARGET_CC = None
  CC = None
  CROSS_COMPILE = None
  CFLAGS_armv7-unknown-linux-gnueabihf = None
  CFLAGS_armv7_unknown_linux_gnueabihf = None
  TARGET_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = None

  --- stderr
  running "arm-linux-gnueabihf-gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-march=armv7-a" "-I" "include" "-Wall" "-Wextra" "-pedantic" "-pedantic-errors" "-Wall" "-Wextra" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-fno-strict-aliasing" "-fvisibility=hidden" "-fstack-protector" "-g3" "-DNDEBUG" "-c" "-o/home/runner/work/xmr-btc-swap/xmr-btc-swap/target/armv7-unknown-linux-gnueabihf/debug/build/ring-34b63fa28ccdbd48/out/aesv8-armx-linux32.o" "/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/pregenerated/aesv8-armx-linux32.S"
  cc1: error: ‘-mfloat-abi=hard’: selected architecture lacks an FPU
  thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:656:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```