### PR TITLE
feat: add wallet database migration from older bdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,20 @@ jobs:
       - name: Run clippy with all features enabled
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  bdk_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3.1.0
+
+      - uses: Swatinem/rust-cache@v2.0.2
+
+      - name: Build swap
+        run: cargo build --bin swap
+
+      - name: Run BDK regression script
+        run: ./swap/tests/bdk.sh
+
   build:
     strategy:
       matrix:
@@ -56,13 +70,13 @@ jobs:
           cargo build -p swap --target ${{ matrix.target }}
 
       - name: Upload swap binary
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v3
         with:
           name: swap-${{ matrix.target }}
           path: target/${{ matrix.target }}/debug/swap
 
       - name: Upload asb binary
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v3
         with:
           name: asb-${{ matrix.target }}
           path: target/${{ matrix.target }}/debug/asb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -176,12 +176,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -231,28 +225,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64-compat"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "bdk"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03818e03fb03c159053bf474a23c474c92796cc0ebc5f677512e989ee449c04"
+checksum = "c50e3f08fbcd7eb34f11e066a1353986d583f1f87af70f7cd50bff9fce97c817"
 dependencies = [
  "async-trait",
  "bdk-macros",
  "bitcoin",
  "electrum-client",
+ "getrandom 0.2.6",
  "js-sys",
  "log",
  "miniscript",
- "rand 0.7.3",
+ "rand 0.8.3",
  "serde",
  "serde_json",
  "sled",
@@ -272,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "big-bytes"
@@ -314,11 +300,11 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.28.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bba324e6baf655b882df672453dbbc527bc938cadd27750ae510aaccc3a66a"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
- "base64-compat",
+ "base64 0.13.1",
  "bech32",
  "bitcoin_hashes",
  "secp256k1",
@@ -327,8 +313,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-harness"
-version = "0.2.0"
-source = "git+https://github.com/coblox/bitcoin-harness-rs?rev=bff9a64b5cd75dec2ce807cbfade7b98c2e1e0d4#bff9a64b5cd75dec2ce807cbfade7b98c2e1e0d4"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b6a18713ec8acbc96d1e843f6998f00e8c5d81173e38760023b84926b8db3b8"
 dependencies = [
  "base64 0.12.3",
  "bitcoin",
@@ -348,18 +335,18 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2ae16202721ba8c3409045681fac790a5ddc791f05731a2df22c0c6bffc0f1"
+checksum = "c231bea28e314879c5aef240f6052e8a72a369e3c9f9b20d9bfbb33ad18029b2"
 dependencies = [
  "bitcoin",
  "serde",
@@ -568,15 +555,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -980,7 +958,7 @@ checksum = "5caaa75cbd2b960ff1e5392d2cfb1f44717fffe12fc1f32b7b5d1267f99732a6"
 [[package]]
 name = "ecdsa_fun"
 version = "0.7.1"
-source = "git+https://github.com/LLFourn/secp256kfun#7f1ae3db3933e215ae59f115f20c2a4eea23fb29"
+source = "git+https://github.com/LLFourn/secp256kfun#e041ac08117e30170ac418047ecb734652e6b62c"
 dependencies = [
  "bincode",
  "rand_chacha 0.3.1",
@@ -1023,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af53c415260dcb220fa02182669727c730535bfed4edbfde42e1291342af95cd"
+checksum = "82a232d46710f8064b7bb2029d82819fc1f5fba053687e0e3bb47cc762af24f6"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -1320,10 +1298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1618,7 +1594,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -2155,7 +2131,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2172,9 +2148,9 @@ checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
 
 [[package]]
 name = "miniscript"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da39fc7a8adea97a677337b0091779dd86349226b869053af496584a9b9e5847"
+checksum = "7f4975078076f0b7b914a3044ad7432d2a7fcec38edb855afdc672e24ca35b69"
 dependencies = [
  "bitcoin",
  "serde",
@@ -2411,7 +2387,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2421,7 +2397,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2444,7 +2420,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2455,7 +2431,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2765,7 +2741,7 @@ dependencies = [
  "quick-error 2.0.0",
  "rand 0.8.3",
  "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -2881,25 +2857,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift 0.1.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2921,16 +2878,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2988,15 +2935,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -3011,59 +2949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core 0.6.2",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3366,20 +3251,21 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
 dependencies = [
- "rand 0.6.5",
+ "bitcoin_hashes",
+ "rand 0.8.3",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
 ]
@@ -3387,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "secp256kfun"
 version = "0.7.1"
-source = "git+https://github.com/LLFourn/secp256kfun#7f1ae3db3933e215ae59f115f20c2a4eea23fb29"
+source = "git+https://github.com/LLFourn/secp256kfun#e041ac08117e30170ac418047ecb734652e6b62c"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.2",
@@ -3584,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "sigma_fun"
 version = "0.4.1"
-source = "git+https://github.com/LLFourn/secp256kfun#7f1ae3db3933e215ae59f115f20c2a4eea23fb29"
+source = "git+https://github.com/LLFourn/secp256kfun#e041ac08117e30170ac418047ecb734652e6b62c"
 dependencies = [
  "curve25519-dalek-ng",
  "digest 0.10.5",

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
     "static_analysis",
+    "bdk_test",
     "build (x86_64-unknown-linux-gnu, ubuntu-latest)",
     "build (armv7-unknown-linux-gnueabihf, ubuntu-latest)",
     "build (x86_64-apple-darwin, macos-latest)",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -15,9 +15,9 @@ async-trait = "0.1"
 atty = "0.2"
 backoff = { version = "0.4", features = [ "tokio" ] }
 base64 = "0.13"
-bdk = "0.23"
+bdk = "0.24"
 big-bytes = "1"
-bitcoin = { version = "0.28", features = [ "rand", "use-serde" ] }
+bitcoin = { version = "0.29", features = [ "rand", "serde" ] }
 bmrng = "0.5"
 comfy-table = "6.1"
 config = { version = "0.11", default-features = false, features = [ "toml" ] }
@@ -74,7 +74,7 @@ tokio-tar = "0.3"
 zip = "0.5"
 
 [dev-dependencies]
-bitcoin-harness = { git = "https://github.com/coblox/bitcoin-harness-rs", rev = "bff9a64b5cd75dec2ce807cbfade7b98c2e1e0d4" } # waiting on crates.io release
+bitcoin-harness = "0.2.2"
 get-port = "3"
 hyper = "0.14"
 monero-harness = { path = "../monero-harness" }

--- a/swap/src/asb/rate.rs
+++ b/swap/src/asb/rate.rs
@@ -29,7 +29,7 @@ impl Rate {
     ///
     /// This applies the spread to the market asking price.
     pub fn ask(&self) -> Result<bitcoin::Amount> {
-        let sats = self.ask.as_sat();
+        let sats = self.ask.to_sat();
         let sats = Decimal::from(sats);
 
         let additional_sats = sats * self.ask_spread;
@@ -51,13 +51,13 @@ impl Rate {
         // quote (btc) = rate * base (xmr)
         // base = quote / rate
 
-        let quote_in_sats = quote.as_sat();
+        let quote_in_sats = quote.to_sat();
         let quote_in_btc = Decimal::from(quote_in_sats)
-            .checked_div(Decimal::from(bitcoin::Amount::ONE_BTC.as_sat()))
+            .checked_div(Decimal::from(bitcoin::Amount::ONE_BTC.to_sat()))
             .context("Division overflow")?;
 
-        let rate_in_btc = Decimal::from(rate.as_sat())
-            .checked_div(Decimal::from(bitcoin::Amount::ONE_BTC.as_sat()))
+        let rate_in_btc = Decimal::from(rate.to_sat())
+            .checked_div(Decimal::from(bitcoin::Amount::ONE_BTC.to_sat()))
             .context("Division overflow")?;
 
         let base_in_xmr = quote_in_btc
@@ -105,7 +105,7 @@ mod tests {
 
         let amount = rate.ask().unwrap();
 
-        assert_eq!(amount.as_sat(), 102);
+        assert_eq!(amount.to_sat(), 102);
     }
 
     #[test]

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -312,11 +312,10 @@ async fn init_bitcoin_wallet(
     env_config: swap::env::Config,
 ) -> Result<bitcoin::Wallet> {
     tracing::debug!("Opening Bitcoin wallet");
-    let wallet_dir = config.data.dir.join("wallet");
-
+    let data_dir = &config.data.dir;
     let wallet = bitcoin::Wallet::new(
         config.bitcoin.electrum_rpc_url.clone(),
-        &wallet_dir,
+        data_dir,
         seed.derive_extended_private_key(env_config.bitcoin_network)?,
         env_config,
         config.bitcoin.target_block,

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -523,12 +523,12 @@ async fn init_bitcoin_wallet(
     env_config: Config,
     bitcoin_target_block: usize,
 ) -> Result<bitcoin::Wallet> {
-    let wallet_dir = data_dir.join("wallet");
+    let xprivkey = seed.derive_extended_private_key(env_config.bitcoin_network)?;
 
     let wallet = bitcoin::Wallet::new(
         electrum_rpc_url.clone(),
-        &wallet_dir,
-        seed.derive_extended_private_key(env_config.bitcoin_network)?,
+        data_dir,
+        xprivkey,
         env_config,
         bitcoin_target_block,
     )

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -373,8 +373,8 @@ mod tests {
 
     #[tokio::test]
     async fn calculate_transaction_weights() {
-        let alice_wallet = WalletBuilder::new(Amount::ONE_BTC.as_sat()).build();
-        let bob_wallet = WalletBuilder::new(Amount::ONE_BTC.as_sat()).build();
+        let alice_wallet = WalletBuilder::new(Amount::ONE_BTC.to_sat()).build();
+        let bob_wallet = WalletBuilder::new(Amount::ONE_BTC.to_sat()).build();
         let spending_fee = Amount::from_sat(1_000);
         let btc_amount = Amount::from_sat(500_000);
         let xmr_amount = crate::monero::Amount::from_piconero(10000);

--- a/swap/src/bitcoin/lock.rs
+++ b/swap/src/bitcoin/lock.rs
@@ -6,8 +6,8 @@ use ::bitcoin::util::psbt::PartiallySignedTransaction;
 use ::bitcoin::{OutPoint, TxIn, TxOut, Txid};
 use anyhow::{bail, Result};
 use bdk::database::BatchDatabase;
-use bdk::miniscript::{Descriptor, DescriptorTrait};
-use bitcoin::Script;
+use bdk::miniscript::Descriptor;
+use bitcoin::{PackedLockTime, Script, Sequence};
 use serde::{Deserialize, Serialize};
 
 const SCRIPT_SIZE: usize = 34;
@@ -58,14 +58,14 @@ impl TxLock {
         btc: Amount,
     ) -> Result<Self> {
         let shared_output_candidate = match psbt.unsigned_tx.output.as_slice() {
-            [shared_output_candidate, _] if shared_output_candidate.value == btc.as_sat() => {
+            [shared_output_candidate, _] if shared_output_candidate.value == btc.to_sat() => {
                 shared_output_candidate
             }
-            [_, shared_output_candidate] if shared_output_candidate.value == btc.as_sat() => {
+            [_, shared_output_candidate] if shared_output_candidate.value == btc.to_sat() => {
                 shared_output_candidate
             }
             // A single output is possible if Bob funds without any change necessary
-            [shared_output_candidate] if shared_output_candidate.value == btc.as_sat() => {
+            [shared_output_candidate] if shared_output_candidate.value == btc.to_sat() => {
                 shared_output_candidate
             }
             [_, _] => {
@@ -140,14 +140,15 @@ impl TxLock {
     ) -> Transaction {
         let previous_output = self.as_outpoint();
 
+        let sequence = Sequence(sequence.unwrap_or(0xFFFF_FFFF));
         let tx_in = TxIn {
             previous_output,
             script_sig: Default::default(),
-            sequence: sequence.unwrap_or(0xFFFF_FFFF),
+            sequence,
             witness: Default::default(),
         };
 
-        let fee = spending_fee.as_sat();
+        let fee = spending_fee.to_sat();
         let tx_out = TxOut {
             value: self.inner.clone().extract_tx().output[self.lock_output_vout()].value - fee,
             script_pubkey: spend_address.script_pubkey(),
@@ -157,7 +158,7 @@ impl TxLock {
 
         Transaction {
             version: 2,
-            lock_time: 0,
+            lock_time: PackedLockTime(0),
             input: vec![tx_in],
             output: vec![tx_out],
         }
@@ -207,7 +208,7 @@ mod tests {
         let (A, B) = alice_and_bob();
         let fees = 300;
         let agreed_amount = Amount::from_sat(10000);
-        let amount = agreed_amount.as_sat() + fees;
+        let amount = agreed_amount.to_sat() + fees;
         let wallet = WalletBuilder::new(amount).build();
 
         let psbt = bob_make_psbt(A, B, &wallet, agreed_amount).await;

--- a/swap/src/bitcoin/punish.rs
+++ b/swap/src/bitcoin/punish.rs
@@ -4,7 +4,7 @@ use ::bitcoin::util::sighash::SighashCache;
 use ::bitcoin::{EcdsaSighashType, Sighash};
 use anyhow::{Context, Result};
 use bdk::bitcoin::Script;
-use bdk::miniscript::{Descriptor, DescriptorTrait};
+use bdk::miniscript::Descriptor;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl TxPunish {
                     .output_descriptor
                     .script_code()
                     .expect("scriptcode"),
-                tx_cancel.amount().as_sat(),
+                tx_cancel.amount().to_sat(),
                 EcdsaSighashType::All,
             )
             .expect("sighash");

--- a/swap/src/bitcoin/redeem.rs
+++ b/swap/src/bitcoin/redeem.rs
@@ -5,7 +5,7 @@ use crate::bitcoin::{
 };
 use ::bitcoin::{Sighash, Txid};
 use anyhow::{bail, Context, Result};
-use bdk::miniscript::{Descriptor, DescriptorTrait};
+use bdk::miniscript::Descriptor;
 use bitcoin::secp256k1::ecdsa;
 use bitcoin::util::sighash::SighashCache;
 use bitcoin::{EcdsaSighashType, Script};
@@ -34,7 +34,7 @@ impl TxRedeem {
             .segwit_signature_hash(
                 0, // Only one input: lock_input (lock transaction)
                 &tx_lock.output_descriptor.script_code().expect("scriptcode"),
-                tx_lock.lock_amount().as_sat(),
+                tx_lock.lock_amount().to_sat(),
                 EcdsaSighashType::All,
             )
             .expect("sighash");

--- a/swap/src/bitcoin/refund.rs
+++ b/swap/src/bitcoin/refund.rs
@@ -8,7 +8,7 @@ use ::bitcoin::secp256k1::ecdsa;
 use ::bitcoin::util::sighash::SighashCache;
 use ::bitcoin::{EcdsaSighashType, Script, Sighash, Txid};
 use anyhow::{bail, Context, Result};
-use bdk::miniscript::{Descriptor, DescriptorTrait};
+use bdk::miniscript::Descriptor;
 use ecdsa_fun::Signature;
 use std::collections::HashMap;
 
@@ -31,7 +31,7 @@ impl TxRefund {
                     .output_descriptor
                     .script_code()
                     .expect("scriptcode"),
-                tx_cancel.amount().as_sat(),
+                tx_cancel.amount().to_sat(),
                 EcdsaSighashType::All,
             )
             .expect("sighash");

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -338,6 +338,7 @@ struct RawArguments {
     testnet: bool,
 
     #[structopt(
+        short,
         long = "--data-base-dir",
         help = "The base data directory to be used for mainnet / testnet specific data like database, wallets etc"
     )]

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -110,7 +110,7 @@ impl Amount {
         }
 
         // safely convert the BTC/XMR rate to sat/pico
-        let ask_sats = Decimal::from(ask_price.as_sat());
+        let ask_sats = Decimal::from(ask_price.to_sat());
         let pico_per_xmr = Decimal::from(PICONERO_OFFSET);
         let ask_sats_per_pico = ask_sats / pico_per_xmr;
 

--- a/swap/tests/bdk.sh
+++ b/swap/tests/bdk.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+VERSION=0.11.1
+
+mkdir bdk
+stat ./target/debug/swap || exit 1
+cp ./target/debug/swap bdk/swap-current
+pushd bdk
+
+echo "download swap $VERSION"
+curl -L "https://github.com/comit-network/xmr-btc-swap/releases/download/${VERSION}/swap_${VERSION}_Linux_x86_64.tar" | tar xv
+
+echo "create testnet wallet with $VERSION"
+./swap --testnet --data-base-dir . --debug balance || exit 1
+echo "check testnet wallet with this version"
+./swap-current --testnet --data-base-dir . --debug balance || exit 1
+
+echo "create mainnet wallet with $VERSION"
+./swap --version || exit 1
+./swap --data-base-dir . --debug balance || exit 1
+echo "check mainnet wallet with this version"
+./swap-current --version || exit 1
+./swap-current --data-base-dir . --debug balance || exit 1
+
+exit 0

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -56,7 +56,7 @@ where
     monero.init_miner().await.unwrap();
 
     let btc_amount = bitcoin::Amount::from_sat(1_000_000);
-    let xmr_amount = monero::Amount::from_monero(btc_amount.as_btc() / FixedRate::RATE).unwrap();
+    let xmr_amount = monero::Amount::from_monero(btc_amount.to_btc() / FixedRate::RATE).unwrap();
 
     let alice_starting_balances =
         StartingBalances::new(bitcoin::Amount::ZERO, xmr_amount, Some(10));


### PR DESCRIPTION
- upgrades to bdk 0.24 #1198
- adds a regression test for opening older wallets #1183
- adds a migration for older wallets that encounter the ChecksumMismatch error #1182
