### PR TITLE
ci: use cargo cross for binary builds

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -52,15 +52,19 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.2.0
 
-      - name: Install compiler for armhf arch
-        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-arm-linux-gnueabihf
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: armv7-unknown-linux-gnueabihf
+          override: true
 
       - name: Build ${{ matrix.target }} ${{ matrix.bin }} release binary
-
-        run: cargo build --target=${{ matrix.target }} --release --package swap --bin ${{ matrix.bin }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target=${{ matrix.target }} --release --package swap --bin ${{ matrix.bin }}
+          use-cross: true
 
       - name: Smoke test the binary
         if: matrix.target != 'armv7-unknown-linux-gnueabihf' # armv7-unknown-linux-gnueabihf is only cross-compiled, no smoke test


### PR DESCRIPTION
related to #1218

see: https://github.com/comit-network/xmr-btc-swap/pull/1225#issuecomment-1327637918 