### PR TITLE
update CI and bump serde

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -52,12 +52,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.2.0
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: armv7-unknown-linux-gnueabihf
-          override: true
+          targets: armv7-unknown-linux-gnueabihf
 
       - name: Build ${{ matrix.target }} ${{ matrix.bin }} release binary
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,27 +75,21 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.2.0
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: armv7-unknown-linux-gnueabihf
-          override: true
+          targets: armv7-unknown-linux-gnueabihf
 
       - name: Build binary
         if: matrix.target != 'armv7-unknown-linux-gnueabihf'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p swap --target ${{ matrix.target }}
+        run: cargo build -p swap --target ${{ matrix.target }}
+
+      - name: Install cross (armv7)
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        run: cargo install cross --locked
 
       - name: Build binary (armv7)
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p swap --target ${{ matrix.target }}
-          use-cross: true
+        run: cross build -p swap --target ${{ matrix.target }}
 
       - name: Upload swap binary
         uses: actions/upload-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -3526,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
#1254 failed to install `cross` in CI 

It appears that actions-rs is not actively maintained, so this migrates the toolchain actions to dtolnay 