### PR TITLE
upgrade base64, vergen, bdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bdk"
@@ -4022,7 +4022,7 @@ dependencies = [
  "async-trait",
  "atty",
  "backoff",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bdk",
  "big-bytes",
  "bitcoin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bdk"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e7eb54c6288eca1b698e6e33dd82ebe6c08a93ec1a96bb6926ddceed22c703"
+checksum = "b238a07736baee43ba9663933e44b1c6c27b43ef871b9486e175902335d83880"
 dependencies = [
  "async-trait",
  "bdk-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -4772,9 +4772,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.4.4"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efadd36bc6fde40c6048443897d69511a19161c0756cb704ed403f8dfd2b7d1c"
+checksum = "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -14,7 +14,7 @@ async-compression = { version = "0.3", features = [ "bzip2", "tokio" ] }
 async-trait = "0.1"
 atty = "0.2"
 backoff = { version = "0.4", features = [ "tokio" ] }
-base64 = "0.20"
+base64 = "0.21"
 bdk = "0.25"
 big-bytes = "1"
 bitcoin = { version = "0.29", features = [ "rand", "serde" ] }

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 atty = "0.2"
 backoff = { version = "0.4", features = [ "tokio" ] }
 base64 = "0.21"
-bdk = "0.25"
+bdk = "0.26"
 big-bytes = "1"
 bitcoin = { version = "0.29", features = [ "rand", "serde" ] }
 bmrng = "0.5"

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -88,4 +88,4 @@ testcontainers = "0.12"
 
 [build-dependencies]
 anyhow = "1"
-vergen = { version = "7", default-features = false, features = [ "git", "build" ] }
+vergen = { version = "7.5", default-features = false, features = [ "git", "build" ] }

--- a/swap/src/seed.rs
+++ b/swap/src/seed.rs
@@ -187,6 +187,9 @@ mod tests {
 
     #[test]
     fn seed_from_pem_works() {
+        use base64::engine::general_purpose;
+        use base64::Engine;
+
         let payload: &str = "syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=";
 
         // 32 bytes base64 encoded.
@@ -195,7 +198,7 @@ syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=
 -----END SEED-----
 ";
 
-        let want = base64::decode(payload).unwrap();
+        let want = general_purpose::STANDARD.decode(payload).unwrap();
         let pem = pem::parse(pem_string).unwrap();
         let got = Seed::from_pem(pem).unwrap();
 


### PR DESCRIPTION
Upgrades dependencies, base64 had a breaking change but is only used in a test 

- #1271
- #1266 
- #1264  