### PR TITLE
build(deps): update rust-toolchain to 1.67 and bump uuid to 1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.67
           components: clippy,rustfmt
 
       - uses: Swatinem/rust-cache@v2.4.0
 
       - name: Check formatting
         uses: dprint/check@v2.2
+        with:
+          dprint-version: 0.39.1
 
       - name: Run clippy with default features
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -82,7 +84,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.67
           targets: armv7-unknown-linux-gnueabihf
 
       - name: Build binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822462c1e7b17b31961798a6874b36daea6818e99e0cb7d3b7b0fa3c477751c3"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.12.3",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -956,6 +956,12 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "deranged"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
 
 [[package]]
 name = "derive_more"
@@ -3305,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.29.1"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
+checksum = "d0446843641c69436765a35a5a77088e28c2e6a12da93e84aa3ab1cd4aa5a042"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4164,7 +4170,7 @@ dependencies = [
  "tempfile",
  "testcontainers 0.12.0",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.24",
  "tokio",
  "tokio-socks",
  "tokio-tar",
@@ -4323,10 +4329,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
+ "deranged",
  "itoa 1.0.1",
  "serde",
  "time-core",
@@ -4335,15 +4342,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -4555,7 +4562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.20",
+ "time 0.3.24",
  "tracing-subscriber 0.3.15",
 ]
 
@@ -4645,7 +4652,7 @@ dependencies = [
  "serde_json",
  "sharded-slab",
  "thread_local",
- "time 0.3.20",
+ "time 0.3.24",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4848,9 +4855,9 @@ checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.6",
  "serde",
@@ -4887,7 +4894,7 @@ dependencies = [
  "git2",
  "rustversion",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.24",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Please have a look at the [contribution guidelines](./CONTRIBUTING.md).
 ## Rust Version Support
 
 Please note that only the latest stable Rust toolchain is supported.
-All stable toolchains since 1.63 _should_ work.
+All stable toolchains since 1.67 _should_ work.
 
 ## Contact
 

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -249,7 +249,7 @@ impl<'c> Monerod {
     /// address
     pub async fn start_miner(&self, miner_wallet_address: &str) -> Result<()> {
         let monerod = self.client().clone();
-        let _ = tokio::spawn(mine(monerod, miner_wallet_address.to_string()));
+        tokio::spawn(mine(monerod, miner_wallet_address.to_string()));
         Ok(())
     }
 }

--- a/monero-rpc/src/monerod.rs
+++ b/monero-rpc/src/monerod.rs
@@ -195,7 +195,7 @@ mod monero_serde_hex_block {
     {
         let hex = String::deserialize(deserializer)?;
 
-        let bytes = hex::decode(&hex).map_err(D::Error::custom)?;
+        let bytes = hex::decode(hex).map_err(D::Error::custom)?;
         let mut cursor = Cursor::new(bytes);
 
         let block = monero::Block::consensus_decode(&mut cursor).map_err(D::Error::custom)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.63" # also update this in the readme, changelog, and github actions
+channel = "1.67" # also update this in the readme, changelog, and github actions
 components = ["clippy"]
 targets = ["armv7-unknown-linux-gnueabihf"]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -64,7 +64,7 @@ tracing-appender = "0.2"
 tracing-futures = { version = "0.2", features = [ "std-future", "futures-03" ] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "fmt", "ansi", "env-filter", "time", "tracing-log", "json" ] }
 url = { version = "2", features = [ "serde" ] }
-uuid = { version = "1.3", features = [ "serde", "v4" ] }
+uuid = { version = "1.4", features = [ "serde", "v4" ] }
 void = "1"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -54,7 +54,7 @@ impl Wallet {
     ) -> Result<Self> {
         let data_dir = data_dir.as_ref();
         let wallet_dir = data_dir.join(WALLET);
-        let database = bdk::sled::open(&wallet_dir)?.open_tree(SLED_TREE_NAME)?;
+        let database = bdk::sled::open(wallet_dir)?.open_tree(SLED_TREE_NAME)?;
         let network = env_config.bitcoin_network;
 
         let wallet = match bdk::Wallet::new(
@@ -97,7 +97,7 @@ impl Wallet {
         std::fs::rename(from, to)?;
 
         let wallet_dir = data_dir.join(WALLET);
-        let database = bdk::sled::open(&wallet_dir)?.open_tree(SLED_TREE_NAME)?;
+        let database = bdk::sled::open(wallet_dir)?.open_tree(SLED_TREE_NAME)?;
 
         let wallet = bdk::Wallet::new(
             bdk::template::Bip84(xprivkey, KeychainKind::External),
@@ -738,12 +738,15 @@ impl Client {
         let client = bdk::electrum_client::Client::new(electrum_rpc_url.as_str())
             .context("Failed to initialize Electrum RPC client")?;
         let blockchain = ElectrumBlockchain::from(client);
+        let last_sync = Instant::now()
+            .checked_sub(interval)
+            .expect("no underflow since block time is only 600 secs");
 
         Ok(Self {
             electrum,
             blockchain,
             latest_block_height: BlockHeight::try_from(latest_block)?,
-            last_sync: Instant::now() - interval,
+            last_sync,
             sync_interval: interval,
             script_history: Default::default(),
             subscriptions: Default::default(),

--- a/swap/src/network/test.rs
+++ b/swap/src/network/test.rs
@@ -21,7 +21,7 @@ struct GlobalSpawnTokioExecutor;
 
 impl Executor for GlobalSpawnTokioExecutor {
     fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
-        let _ = tokio::spawn(future);
+        tokio::spawn(future);
     }
 }
 

--- a/swap/src/seed.rs
+++ b/swap/src/seed.rs
@@ -61,7 +61,7 @@ impl Seed {
         let file_path = Path::new(&file_path_buf);
 
         if file_path.exists() {
-            return Self::from_file(&file_path);
+            return Self::from_file(file_path);
         }
 
         tracing::debug!("No seed file found, creating at {}", file_path.display());

--- a/swap/tests/ensure_same_swap_id.rs
+++ b/swap/tests/ensure_same_swap_id.rs
@@ -8,7 +8,7 @@ async fn ensure_same_swap_id_for_alice_and_bob() {
     harness::setup_test(SlowCancelConfig, |mut ctx| async move {
         let (bob_swap, _) = ctx.bob_swap().await;
         let bob_swap_id = bob_swap.id;
-        let _ = tokio::spawn(bob::run(bob_swap));
+        tokio::spawn(bob::run(bob_swap));
 
         // once Bob's swap is spawned we can retrieve Alice's swap and assert on the
         // swap ID

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -928,7 +928,7 @@ async fn init_bitcoind(node_url: Url, spendable_quantity: u32) -> Result<Client>
     bitcoind_client
         .generatetoaddress(101 + spendable_quantity, reward_address.clone())
         .await?;
-    let _ = tokio::spawn(mine(bitcoind_client.clone(), reward_address));
+    tokio::spawn(mine(bitcoind_client.clone(), reward_address));
     Ok(bitcoind_client)
 }
 


### PR DESCRIPTION
some of the dependency updates are requiring a higher version of the rust toolchain. bump up to 1.67 and fix new clippy lints.

also fix dprint to 0.39.1 because 0.40 has breaking changes.