### PR TITLE
feat(asb): allow asb to register with mulitple rendezvous nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Minimum Supported Rust Version (MSRV) bumped to 1.63
+- Minimum Supported Rust Version (MSRV) bumped to 1.67
+- ASB can now register with multiple rendezvous nodes. The `rendezvous_point` option in `config.toml` can be a string with comma separated addresses, or a toml array of address strings.
 
 ## [0.12.1] - 2023-01-09
 

--- a/docs/asb/README.md
+++ b/docs/asb/README.md
@@ -42,13 +42,16 @@ Since the ASB is a long running task we specify the person running an ASB as ser
 The ASB daemon supports the libp2p [rendezvous-protocol](https://github.com/libp2p/specs/tree/master/rendezvous).
 Usage of the rendezvous functionality is entirely optional.
 
-You can configure a rendezvous point in the `[network]` section of your config file.
+You can configure one or more rendezvous point in the `[network]` section of your config file.
 For the registration to be successful, you also need to configure the externally reachable addresses within the `[network]` section.
 For example:
 
 ```toml
 [network]
-rendezvous_point = "/dns4/discover.unstoppableswap.net/tcp/8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE"
+rendezvous_point = [
+   "/dns4/discover.unstoppableswap.net/tcp/8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
+   "/dns4/eratosthen.es/tcp/7798/p2p/12D3KooWAh7EXXa2ZyegzLGdjvj1W4G3EXrTGrf6trraoT1MEobs",
+]
 external_addresses = ["/dns4/example.com/tcp/9939"]
 ```
 

--- a/swap/src/asb.rs
+++ b/swap/src/asb.rs
@@ -8,6 +8,7 @@ pub mod tracing;
 
 pub use event_loop::{EventLoop, EventLoopHandle, FixedRate, KrakenRate, LatestRate};
 pub use network::behaviour::{Behaviour, OutEvent};
+pub use network::rendezvous::RendezvousNode;
 pub use network::transport;
 pub use rate::Rate;
 pub use recovery::cancel::cancel;
@@ -18,4 +19,4 @@ pub use recovery::safely_abort::safely_abort;
 pub use recovery::{cancel, refund};
 
 #[cfg(test)]
-pub use network::rendezous;
+pub use network::rendezvous;

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -253,8 +253,8 @@ where
                                 channel
                             }.boxed());
                         }
-                        SwarmEvent::Behaviour(OutEvent::Rendezvous(libp2p::rendezvous::client::Event::Registered { .. })) => {
-                            tracing::info!("Successfully registered with rendezvous node");
+                        SwarmEvent::Behaviour(OutEvent::Rendezvous(libp2p::rendezvous::client::Event::Registered { rendezvous_node, ttl, namespace })) => {
+                            tracing::info!("Successfully registered with rendezvous node: {} with namespace: {} and TTL: {:?}", rendezvous_node, namespace, ttl);
                         }
                         SwarmEvent::Behaviour(OutEvent::Rendezvous(libp2p::rendezvous::client::Event::RegisterFailed(error))) => {
                             tracing::error!("Registration with rendezvous node failed: {:?}", error);

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -248,7 +248,7 @@ async fn start_alice(
         resume_only,
         env_config,
         XmrBtcNamespace::Testnet,
-        None,
+        &[],
     )
     .unwrap();
     swarm.listen_on(listen_address).unwrap();


### PR DESCRIPTION
implements #633  

This PR updates the ASB to be able to register with multiple rendezvous nodes. A unit test is added that checks this behaviour. I also tested it manually overnight and it repeatedly reregistered with the specified nodes.  

The config file option is left as `rendezvous_point` for backwards compatibility, but now uses the same deserialization as introduced in #1231 so that multiple addresses can be specified in a comma separated string, or as a toml array of strings.