### PR TITLE
ci: fix dprint version for draft action

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -41,8 +41,10 @@ jobs:
 
       - name: Commit changelog and manifest files
         id: make-commit
+        env:
+          DPRINT_VERSION: 0.39.1
         run: |
-          curl -fsSL https://dprint.dev/install.sh | sh
+          curl -fsSL https://dprint.dev/install.sh | sh -s $DPRINT_VERSION
           /home/runner/.dprint/bin/dprint fmt
 
           git add CHANGELOG.md Cargo.lock swap/Cargo.toml


### PR DESCRIPTION
This should fix the dprint issue in the draft release action - [link to failing action](https://github.com/comit-network/xmr-btc-swap/actions/runs/5763212564/job/15624561961) 