### PR TITLE
ci: add rustfmt to draft-new-release

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -43,7 +43,9 @@ jobs:
         id: make-commit
         env:
           DPRINT_VERSION: 0.39.1
+          RUST_TOOLCHAIN: 1.67
         run: |
+          rustup component add rustfmt --toolchain "$RUST_TOOLCHAIN-x86_64-unknown-linux-gnu"
           curl -fsSL https://dprint.dev/install.sh | sh -s $DPRINT_VERSION
           /home/runner/.dprint/bin/dprint fmt
 


### PR DESCRIPTION
fixing the draft new release action, churn in dprint means that now rustfmt is run separately so it needs to be installed at this step 

previous failure: https://github.com/comit-network/xmr-btc-swap/actions/runs/5787093337/job/15683238703 