### PR TITLE
Fix edge case for enc sig and BTC redeem phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
             ensure_same_swap_id,
             concurrent_bobs_before_xmr_lock_proof_sent,
             alice_manually_redeems_after_enc_sig_learned,
+            given_bob_restarts_while_alice_redeems_btc,
           ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
             ensure_same_swap_id,
             concurrent_bobs_before_xmr_lock_proof_sent,
             alice_manually_redeems_after_enc_sig_learned,
-            given_bob_restarts_while_alice_redeems_btc,
+            happy_path_bob_offline_while_alice_redeems_btc,
           ]
     runs-on: ubuntu-latest
     steps:

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -489,6 +489,30 @@ pub struct State4 {
 }
 
 impl State4 {
+    pub async fn check_for_tx_redeem(
+        &self,
+        bitcoin_wallet: &bitcoin::Wallet,
+    ) -> Result<State5> {
+        let tx_redeem =
+            bitcoin::TxRedeem::new(&self.tx_lock, &self.redeem_address, self.tx_redeem_fee);
+        let tx_redeem_encsig = self.b.encsign(self.S_a_bitcoin, tx_redeem.digest());
+
+        let tx_redeem_candidate = bitcoin_wallet.get_raw_transaction(tx_redeem.txid()).await?;
+
+        let tx_redeem_sig =
+            tx_redeem.extract_signature_by_key(tx_redeem_candidate, self.b.public())?;
+        let s_a = bitcoin::recover(self.S_a_bitcoin, tx_redeem_sig, tx_redeem_encsig)?;
+        let s_a = monero::private_key_from_secp256k1_scalar(s_a.into());
+
+        Ok(State5 {
+            s_a,
+            s_b: self.s_b,
+            v: self.v,
+            tx_lock: self.tx_lock.clone(),
+            monero_wallet_restore_blockheight: self.monero_wallet_restore_blockheight,
+        })
+    }
+
     pub fn tx_redeem_encsig(&self) -> bitcoin::EncryptedSignature {
         let tx_redeem =
             bitcoin::TxRedeem::new(&self.tx_lock, &self.redeem_address, self.tx_redeem_fee);

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -489,10 +489,7 @@ pub struct State4 {
 }
 
 impl State4 {
-    pub async fn check_for_tx_redeem(
-        &self,
-        bitcoin_wallet: &bitcoin::Wallet,
-    ) -> Result<State5> {
+    pub async fn check_for_tx_redeem(&self, bitcoin_wallet: &bitcoin::Wallet) -> Result<State5> {
         let tx_redeem =
             bitcoin::TxRedeem::new(&self.tx_lock, &self.redeem_address, self.tx_redeem_fee);
         let tx_redeem_encsig = self.b.encsign(self.S_a_bitcoin, tx_redeem.digest());

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -183,6 +183,13 @@ async fn next_state(
             }
         }
         BobState::XmrLocked(state) => {
+            // In case we send the encrypted signature to Alice, but she doesn't give us a confirmation
+            // We need to check if she still published the Bitcoin redeem transaction
+            // Otherwise we risk staying stuck in "XmrLocked"
+            if let Ok(state5) = state.check_for_tx_redeem(bitcoin_wallet).await {
+                return Ok(BobState::BtcRedeemed(state5));
+            }
+
             let tx_lock_status = bitcoin_wallet.subscribe_to(state.tx_lock.clone()).await;
 
             if let ExpiredTimelocks::None { .. } = state.expired_timelock(bitcoin_wallet).await? {
@@ -207,6 +214,13 @@ async fn next_state(
             }
         }
         BobState::EncSigSent(state) => {
+            // We need to make sure that Alice did not publish the redeem transaction while we were offline
+            // Even if the cancel timelock expired, if Alice published the redeem transaction while we were away we cannot miss it
+            // If we do we cannot refund and will never be able to leave the "CancelTimelockExpired" state
+            if let Ok(state5) = state.check_for_tx_redeem(bitcoin_wallet).await {
+                return Ok(BobState::BtcRedeemed(state5));
+            }
+
             let tx_lock_status = bitcoin_wallet.subscribe_to(state.tx_lock.clone()).await;
 
             if let ExpiredTimelocks::None { .. } = state.expired_timelock(bitcoin_wallet).await? {

--- a/swap/tests/happy_path_bob_offline_while_alice_redeems_btc.rs
+++ b/swap/tests/happy_path_bob_offline_while_alice_redeems_btc.rs
@@ -1,0 +1,45 @@
+pub mod harness;
+
+use tokio::join;
+use swap::asb::FixedRate;
+use swap::protocol::{alice, bob};
+use swap::protocol::bob::BobState;
+use crate::harness::bob_run_until::{is_encsig_sent};
+
+#[tokio::test]
+async fn given_bob_restarts_while_alice_redeems_btc() {
+    harness::setup_test(harness::SlowCancelConfig, |mut ctx| async move {
+        let (bob_swap, bob_handle) = ctx.bob_swap().await;
+        let swap_id = bob_swap.id;
+
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_encsig_sent));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap, FixedRate::default()));
+
+        let (bob_state, alice_state) = join!(bob_swap, alice_swap);
+        ctx.assert_alice_redeemed(alice_state??).await;
+        assert!(matches!(bob_state??, BobState::EncSigSent { .. }));
+
+        
+        let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_handle, swap_id).await;
+        
+        if let BobState::EncSigSent(state4) = bob_swap.state.clone() {
+            bob_swap
+                .bitcoin_wallet
+                .subscribe_to(state4.tx_lock)
+                .await
+                .wait_until_confirmed_with(state4.cancel_timelock)
+                .await?;
+        } else {
+            panic!("Bob in unexpected state {}", bob_swap.state);
+        }
+        
+        // Restart Bob
+        let bob_state = bob::run(bob_swap).await?;
+        ctx.assert_bob_redeemed(bob_state).await;
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/happy_path_bob_offline_while_alice_redeems_btc.rs
+++ b/swap/tests/happy_path_bob_offline_while_alice_redeems_btc.rs
@@ -1,10 +1,10 @@
 pub mod harness;
 
-use tokio::join;
+use crate::harness::bob_run_until::is_encsig_sent;
 use swap::asb::FixedRate;
-use swap::protocol::{alice, bob};
 use swap::protocol::bob::BobState;
-use crate::harness::bob_run_until::{is_encsig_sent};
+use swap::protocol::{alice, bob};
+use tokio::join;
 
 #[tokio::test]
 async fn given_bob_restarts_while_alice_redeems_btc() {
@@ -21,9 +21,8 @@ async fn given_bob_restarts_while_alice_redeems_btc() {
         ctx.assert_alice_redeemed(alice_state??).await;
         assert!(matches!(bob_state??, BobState::EncSigSent { .. }));
 
-        
         let (bob_swap, _) = ctx.stop_and_resume_bob_from_db(bob_handle, swap_id).await;
-        
+
         if let BobState::EncSigSent(state4) = bob_swap.state.clone() {
             bob_swap
                 .bitcoin_wallet
@@ -34,7 +33,7 @@ async fn given_bob_restarts_while_alice_redeems_btc() {
         } else {
             panic!("Bob in unexpected state {}", bob_swap.state);
         }
-        
+
         // Restart Bob
         let bob_state = bob::run(bob_swap).await?;
         ctx.assert_bob_redeemed(bob_state).await;

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -996,6 +996,10 @@ pub mod alice_run_until {
     pub fn is_encsig_learned(state: &AliceState) -> bool {
         matches!(state, AliceState::EncSigLearned { .. })
     }
+
+    pub fn is_btc_redeemed(state: &AliceState) -> bool {
+        matches!(state, AliceState::BtcRedeemed { .. })
+    }
 }
 
 pub mod bob_run_until {


### PR DESCRIPTION
I encountered a weird situation during testing on stagenet, where both a sudden surge of transactions and blocks came in within a short time frame (i.e. dozens of blocks within a few minutes). It seemed to have caused my swap program to crash, leaving me in the state XmrLocked, however I seemed to have actually sent Alice the encrypted signature and Alice was able to redeem the BTC.

Because I was stuck in XmrLocked state, I couldn't watch for the redemption transaction, meaning I could never redeem the XMR. Adding this to the XmrLocked state for Bob fixed the issue, and allowed me to redeem the XMR.


This also fixes https://github.com/comit-network/xmr-btc-swap/issues/1063. This issue would happen if Alice published the Bitcoin redeem transaction while we were offline. When we resumed (and the cancel timelock had expired) we immediately detected the expired timelock and switched to CancelTimelockExpired. This meant that we would never go into BtcRedeemed leaving the swap in state where it cannot be refunded nor will the Monero be redeemed.