### PR TITLE
Fix issue where Windows cannot open ASB wallet to create lock XMR transaction

### DIFF
--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -174,11 +174,6 @@ impl Wallet {
     pub async fn transfer(&self, request: TransferRequest) -> Result<TransferProof> {
         let inner = self.inner.lock().await;
 
-        inner
-            .open_wallet(self.name.clone())
-            .await
-            .with_context(|| format!("Failed to open wallet {}", self.name))?;
-
         let TransferRequest {
             public_spend_key,
             public_view_key,


### PR DESCRIPTION
It seems on Windows that opening an already opened wallet results in an error/crash. This does not seem to be the case for Linux and macOS. Removing this line fixed the issue on Windows, and had no regressions on macOS/Linux from my testing.