### PR TITLE
Update lock timeout to 10 min

### DIFF
--- a/swap/src/env.rs
+++ b/swap/src/env.rs
@@ -46,7 +46,7 @@ pub struct Regtest;
 impl GetConfig for Mainnet {
     fn get_config() -> Config {
         Config {
-            bitcoin_lock_mempool_timeout: 3.std_minutes(),
+            bitcoin_lock_mempool_timeout: 10.std_minutes(),
             bitcoin_lock_confirmed_timeout: 2.std_hours(),
             bitcoin_finality_confirmations: 1,
             bitcoin_avg_block_time: 10.std_minutes(),
@@ -63,7 +63,7 @@ impl GetConfig for Mainnet {
 impl GetConfig for Testnet {
     fn get_config() -> Config {
         Config {
-            bitcoin_lock_mempool_timeout: 3.std_minutes(),
+            bitcoin_lock_mempool_timeout: 10.std_minutes(),
             bitcoin_lock_confirmed_timeout: 1.std_hours(),
             bitcoin_finality_confirmations: 1,
             bitcoin_avg_block_time: 10.std_minutes(),


### PR DESCRIPTION
This updates the lock timeout from 3 min to 10 min.

Over Tor, it is sometimes very slow to setup a swap, completely missing the 3 minute window. The BTC will still lock and broadcast, but the ASB will have already stopped watching for the lock tx, thus will not lock the XMR once the BTC lock tx confirms. This mitigates that issue.