### PR TITLE
build(deps): bump pem to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,11 +2823,12 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
+ "serde",
 ]
 
 [[package]]

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -34,7 +34,7 @@ itertools = "0.10"
 libp2p = { version = "0.42.2", default-features = false, features = [ "tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "request-response", "websocket", "ping", "rendezvous", "identify" ] }
 monero = { version = "0.12", features = [ "serde_support" ] }
 monero-rpc = { path = "../monero-rpc" }
-pem = "1.1"
+pem = "3.0"
 proptest = "1"
 qrcode = "0.12"
 rand = "0.8"

--- a/swap/src/seed.rs
+++ b/swap/src/seed.rs
@@ -106,11 +106,12 @@ impl Seed {
     }
 
     fn from_pem(pem: pem::Pem) -> Result<Self, Error> {
-        if pem.contents.len() != SEED_LENGTH {
-            Err(Error::IncorrectLength(pem.contents.len()))
+        let contents = pem.contents();
+        if contents.len() != SEED_LENGTH {
+            Err(Error::IncorrectLength(contents.len()))
         } else {
             let mut array = [0; SEED_LENGTH];
-            for (i, b) in pem.contents.iter().enumerate() {
+            for (i, b) in contents.iter().enumerate() {
                 array[i] = *b;
             }
 
@@ -122,10 +123,7 @@ impl Seed {
         ensure_directory_exists(&seed_file)?;
 
         let data = self.bytes();
-        let pem = Pem {
-            tag: String::from("SEED"),
-            contents: data.to_vec(),
-        };
+        let pem = Pem::new("SEED", data);
 
         let pem_string = encode(&pem);
 
@@ -224,19 +222,20 @@ VnZUNFZ4dlY=
     }
 
     #[test]
-    #[should_panic]
     fn seed_from_pem_fails_for_long_seed() {
         let long = "-----BEGIN SEED-----
-mbKANv2qKGmNVg1qtquj6Hx1pFPelpqOfE2JaJJAMEg1FlFhNRNlFlE=
-mbKANv2qKGmNVg1qtquj6Hx1pFPelpqOfE2JaJJAMEg1FlFhNRNlFlE=
+MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
 -----END SEED-----
 ";
         let pem = pem::parse(long).unwrap();
+        assert_eq!(pem.contents().len(), 96);
+
         match Seed::from_pem(pem) {
             Ok(_) => panic!("should fail for long payload"),
             Err(e) => {
                 match e {
-                    Error::IncorrectLength(_) => {} // pass
+                    Error::IncorrectLength(len) => assert_eq!(len, 96), // pass
                     _ => panic!("should fail with IncorrectLength error"),
                 }
             }


### PR DESCRIPTION
replaces #1415

also fixes the `seed_from_pem_fails_for_long_seed` unit test, which was "passing" but not actually testing what it meant to.