### PR TITLE
ci: free up space on ubuntu test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: (Free disk space on Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@main
+
       - name: Checkout sources
         uses: actions/checkout@v4.1.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,15 @@ jobs:
       - name: (Free disk space on Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         uses: jlumbroso/free-disk-space@main
+        with:
+          # removing all of these takes ~10 mins, so just do as needed
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          swap-storage: false
+          tool-cache: false
 
       - name: Checkout sources
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: (Free disk space on Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           # removing all of these takes ~10 mins, so just do as needed
           android: true


### PR DESCRIPTION
the ubuntu test job has sometimes been failing with an out of space error. 

this change worked on #1276 so i'm trying it here 