### PR TITLE
Verify hashes of monero cli on download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,6 +4309,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "data-encoding",
  "dialoguer",
+ "digest 0.10.7",
  "directories-next",
  "ecdsa_fun",
  "ed25519-dalek",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -25,6 +25,7 @@ conquer-once = "0.4"
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4" }
 data-encoding = "2.5"
 dialoguer = "0.11"
+digest = "0.10.7"
 directories-next = "2"
 ecdsa_fun = { git = "https://github.com/LLFourn/secp256kfun", default-features = false, features = [ "libsecp_compat", "serde", "adaptor" ] }
 ed25519-dalek = "1"

--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -47,7 +47,7 @@ compile_error!("unsupported operating system");
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-mac-x64-v0.18.1.2.tar.bz2";
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-mac-armv8-v0.18.0.0.tar.bz2";
+const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-mac-armv8-v0.18.1.2.tar.bz2";
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.1.2.tar.bz2";

--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -277,9 +277,10 @@ impl WalletRpc {
             let result = hasher.finalize();
             let result_hash = HEXLOWER.encode(result.as_ref());
             if result_hash != DOWNLOAD_HASH {
-                panic!(
+                bail!(
                     "SHA256 of download ({}) does not match expected ({})!",
-                    result_hash, DOWNLOAD_HASH
+                    result_hash,
+                    DOWNLOAD_HASH
                 );
             } else {
                 tracing::debug!("Hashes match");

--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -1,11 +1,13 @@
 use ::monero::Network;
 use anyhow::{bail, Context, Error, Result};
 use big_bytes::BigByte;
+use data_encoding::HEXLOWER;
 use futures::{StreamExt, TryStreamExt};
 use monero_rpc::wallet::{Client, MoneroWalletRpc as _};
 use reqwest::header::CONTENT_LENGTH;
 use reqwest::Url;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::io::ErrorKind;
@@ -45,19 +47,29 @@ compile_error!("unsupported operating system");
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-mac-x64-v0.18.1.2.tar.bz2";
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const DOWNLOAD_HASH: &str = "ba1108c7a5e5efe15b6a628fb007c50f01c231f61137bba7427605286dbc6f01";
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-mac-armv8-v0.18.1.2.tar.bz2";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const DOWNLOAD_HASH: &str = "620b825c04f84845ed09de03b207a3230a34f74b30a8a07dde504a7d376ee4b9";
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.1.2.tar.bz2";
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const DOWNLOAD_HASH: &str = "7d51e7072351f65d0c7909e745827cfd3b00abe5e7c4cc4c104a3c9b526da07e";
 
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
 const DOWNLOAD_URL: &str =
     "https://downloads.getmonero.org/cli/monero-linux-armv7-v0.18.1.2.tar.bz2";
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+const DOWNLOAD_HASH: &str = "94ece435ed60f85904114643482c2b6716f74bf97040a7af237450574a9cf06d";
 
 #[cfg(target_os = "windows")]
 const DOWNLOAD_URL: &str = "https://downloads.getmonero.org/cli/monero-win-x64-v0.18.1.2.zip";
+#[cfg(target_os = "windows")]
+const DOWNLOAD_HASH: &str = "0a3d4d1af7e094c05352c31b2dafcc6ccbc80edc195ca9eaedc919c36accd05a";
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const PACKED_FILE: &str = "monero-wallet-rpc";
@@ -226,8 +238,14 @@ impl WalletRpc {
                 DOWNLOAD_URL
             );
 
+            let mut hasher = Sha256::new();
+
             let byte_stream = response
                 .bytes_stream()
+                .map_ok(|bytes| {
+                    hasher.update(&bytes);
+                    bytes
+                })
                 .map_err(|err| std::io::Error::new(ErrorKind::Other, err));
 
             #[cfg(not(target_os = "windows"))]
@@ -254,6 +272,17 @@ impl WalletRpc {
                     notified = percent;
                 }
                 file.write_all(&bytes).await?;
+            }
+
+            let result = hasher.finalize();
+            let result_hash = HEXLOWER.encode(result.as_ref());
+            if result_hash != DOWNLOAD_HASH {
+                panic!(
+                    "SHA256 of download ({}) does not match expected ({})!",
+                    result_hash, DOWNLOAD_HASH
+                );
+            } else {
+                tracing::debug!("Hashes match");
             }
 
             file.flush().await?;


### PR DESCRIPTION
Resolves #673

Hardcodes hashes and checks against them, reviewers should use pgp verification of the hashes I've included here to confirm them.

Also bumps the MacOS arm64 version to match the version string for other platforms. 