### PR TITLE
ci: specify version of sqlx-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
 
       - name: Install sqlx-cli
-        run: cargo install sqlx-cli --locked
+        run: cargo install --version 0.6.3 sqlx-cli
 
       - name: Run sqlite_dev_setup.sh script
         run: |


### PR DESCRIPTION
sqlx_test in CI has started failing due to a clap upgrade 