### PR TITLE
ci: lock install version for sqlx-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
 
       - name: Install sqlx-cli
-        run: cargo install --version 0.6.3 sqlx-cli
+        run: cargo install --locked --version 0.6.3 sqlx-cli
 
       - name: Run sqlite_dev_setup.sh script
         run: |


### PR DESCRIPTION
fix for the currently failing installation of sqlx-cli in ci 

eg: https://github.com/comit-network/xmr-btc-swap/actions/runs/8419369867/job/23051831867?pr=1590