### PR TITLE
ci: add cargo check job on stable rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,3 +172,16 @@ jobs:
 
       - name: Run test ${{ matrix.test_name }}
         run: cargo test --package swap --all-features --test ${{ matrix.test_name }} -- --nocapture
+
+  check_stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.1.2
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Run cargo check on stable rust
+        run: cargo check --all-targets


### PR DESCRIPTION
adds a ci job to run cargo check on stable rust 

re: #1602 