### PR TITLE
ci: fix macos-latest and add macos-12

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -20,6 +20,9 @@ jobs:
             archive_ext: tar
           - bin: swap
             target: x86_64-apple-darwin
+            os: macos-12
+          - bin: swap
+            target: aarch64-apple-darwin
             os: macos-latest
             archive_ext: tar
           - bin: swap
@@ -36,6 +39,10 @@ jobs:
             archive_ext: tar
           - bin: asb
             target: x86_64-apple-darwin
+            os: macos-12
+            archive_ext: tar
+          - bin: asb
+            target: aarch64-apple-darwin
             os: macos-latest
             archive_ext: tar
           - bin: asb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
           - target: x86_64-apple-darwin
+            os: macos-12
+          - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
macos-latest is now aarch64, add macos-12 for x64_64 

see broken ci here: https://github.com/comit-network/xmr-btc-swap/actions/runs/8877725844/job/24413012460?pr=1616 
