### PR TITLE
Lower DEFAULT_BITCOIN_CONFIRMATION_TARGET to 1 to ensure timely confirmation of Bitcoin transactions

### DIFF
--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -23,7 +23,7 @@ const DEFAULT_ELECTRUM_RPC_URL: &str = "ssl://blockstream.info:700";
 // See: https://1209k.com/bitcoin-eye/ele.php?chain=tbtc
 pub const DEFAULT_ELECTRUM_RPC_URL_TESTNET: &str = "ssl://electrum.blockstream.info:60002";
 
-const DEFAULT_BITCOIN_CONFIRMATION_TARGET: usize = 3;
+const DEFAULT_BITCOIN_CONFIRMATION_TARGET: usize = 1;
 pub const DEFAULT_BITCOIN_CONFIRMATION_TARGET_TESTNET: usize = 1;
 
 const DEFAULT_TOR_SOCKS5_PORT: &str = "9050";


### PR DESCRIPTION
I think we should lower this to 1 for the moment until we figure out a better way to go about this.

If Bitcoin transactions are not confirmed in time that represents a huge problem especially for Bob. He might be punished even though he published all his transactions in time.