### PR TITLE
Make tracing file appender blocking

### DIFF
--- a/swap/src/cli/tracing.rs
+++ b/swap/src/cli/tracing.rs
@@ -13,7 +13,6 @@ pub fn init(debug: bool, json: bool, dir: impl AsRef<Path>) -> Result<()> {
     let registry = Registry::default().with(level_filter);
 
     let appender = tracing_appender::rolling::never(dir.as_ref(), "swap-all.log");
-    let (appender, _guard) = tracing_appender::non_blocking(appender);
 
     let file_logger = registry.with(
         fmt::layer()


### PR DESCRIPTION
There is a bug where sometimes the log file is not flushed. I don't know why.

Furthermore, it's very useful for the GUI (and other programs building on top) if the log file is always up to date with the current state of the swap.