### PR TITLE
Attach offer duration to quote

### DIFF
--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::convert::{Infallible, TryInto};
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -44,6 +45,7 @@ where
     latest_rate: LR,
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
+    max_swap_timeout: Duration,
     external_redeem_address: Option<bitcoin::Address>,
 
     swap_sender: mpsc::Sender<Swap>,
@@ -77,6 +79,7 @@ where
         latest_rate: LR,
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
+        max_swap_timeout: Duration,
         external_redeem_address: Option<bitcoin::Address>,
     ) -> Result<(Self, mpsc::Receiver<Swap>)> {
         let swap_channel = MpscChannels::default();
@@ -91,6 +94,7 @@ where
             swap_sender: swap_channel.sender,
             min_buy,
             max_buy,
+            max_swap_timeout,
             external_redeem_address,
             recv_encrypted_signature: Default::default(),
             inflight_encrypted_signatures: Default::default(),
@@ -186,7 +190,7 @@ where
                             tracing::warn!(%peer, "Ignoring spot price request: {}", error);
                         }
                         SwarmEvent::Behaviour(OutEvent::QuoteRequested { channel, peer }) => {
-                            let quote = match self.make_quote(self.min_buy, self.max_buy).await {
+                            let quote = match self.make_quote(self.min_buy, self.max_buy, self.max_swap_timeout).await {
                                 Ok(quote) => quote,
                                 Err(error) => {
                                     tracing::warn!(%peer, "Failed to make quote: {:#}", error);
@@ -322,6 +326,7 @@ where
         &mut self,
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
+        max_swap_timeout: Duration,
     ) -> Result<BidQuote> {
         let ask_price = self
             .latest_rate
@@ -351,6 +356,7 @@ where
                 price: ask_price,
                 min_quantity: bitcoin::Amount::ZERO,
                 max_quantity: bitcoin::Amount::ZERO,
+                valid_duration: Some(max_swap_timeout),
             });
         }
 
@@ -363,6 +369,7 @@ where
                 price: ask_price,
                 min_quantity: min_buy,
                 max_quantity: max_bitcoin_for_monero,
+                valid_duration: Some(max_swap_timeout),
             });
         }
 
@@ -370,6 +377,7 @@ where
             price: ask_price,
             min_quantity: min_buy,
             max_quantity: max_buy,
+            valid_duration: Some(max_swap_timeout),
         })
     }
 

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -127,9 +127,11 @@ pub mod behaviour {
     where
         LR: LatestRate + Send + 'static,
     {
+        #[allow(clippy::too_many_arguments)]
         pub fn new(
             min_buy: bitcoin::Amount,
             max_buy: bitcoin::Amount,
+            max_swap_timeout: Duration,
             latest_rate: LR,
             resume_only: bool,
             env_config: env::Config,
@@ -154,6 +156,7 @@ pub mod behaviour {
                 swap_setup: alice::Behaviour::new(
                     min_buy,
                     max_buy,
+                    max_swap_timeout,
                     env_config,
                     latest_rate,
                     resume_only,

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -22,6 +22,7 @@ use std::convert::TryInto;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use structopt::clap;
 use structopt::clap::ErrorKind;
 use swap::asb::command::{parse_args, Arguments, Command};
@@ -170,6 +171,7 @@ async fn main() -> Result<()> {
                 &seed,
                 config.maker.min_buy_btc,
                 config.maker.max_buy_btc,
+                Duration::from_secs(120),
                 kraken_rate.clone(),
                 resume_only,
                 env_config,
@@ -201,6 +203,7 @@ async fn main() -> Result<()> {
                 kraken_rate.clone(),
                 config.maker.min_buy_btc,
                 config.maker.max_buy_btc,
+                Duration::from_secs(120),
                 config.maker.external_bitcoin_redeem_address,
             )
             .unwrap();

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -403,6 +403,7 @@ mod tests {
             price: Amount::from_btc(0.001).unwrap(),
             max_quantity: Amount::from_btc(btc).unwrap(),
             min_quantity: Amount::ZERO,
+            valid_duration: Some(Duration::from_secs(120)),
         }
     }
 
@@ -411,6 +412,7 @@ mod tests {
             price: Amount::from_btc(0.001).unwrap(),
             max_quantity: Amount::max_value(),
             min_quantity: Amount::from_btc(btc).unwrap(),
+            valid_duration: Some(Duration::from_secs(120)),
         }
     }
 

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -78,6 +78,7 @@ mod tests {
             price: bitcoin::Amount::from_sat(1337),
             min_quantity: bitcoin::Amount::from_sat(42),
             max_quantity: bitcoin::Amount::from_sat(9001),
+            valid_duration: Some(Duration::from_secs(120)),
         };
 
         let mut asb = new_swarm(|_, identity| {

--- a/swap/src/cli/list_sellers.rs
+++ b/swap/src/cli/list_sellers.rs
@@ -344,6 +344,7 @@ mod tests {
                     price: Default::default(),
                     min_quantity: Default::default(),
                     max_quantity: Default::default(),
+                    valid_duration: Some(Duration::from_secs(120)),
                 }),
             },
         ];
@@ -359,6 +360,7 @@ mod tests {
                         price: Default::default(),
                         min_quantity: Default::default(),
                         max_quantity: Default::default(),
+                        valid_duration: Some(Duration::from_secs(120)),
                     })
                 },
                 Seller {

--- a/swap/src/network/quote.rs
+++ b/swap/src/network/quote.rs
@@ -7,6 +7,7 @@ use libp2p::request_response::{
 };
 use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 const PROTOCOL: &str = "/comit/xmr/btc/bid-quote/1.0.0";
 pub type OutEvent = RequestResponseEvent<(), BidQuote>;
@@ -35,6 +36,7 @@ pub struct BidQuote {
     /// The maximum quantity the maker is willing to buy.
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     pub max_quantity: bitcoin::Amount,
+    pub valid_duration: Option<Duration>,
 }
 
 #[derive(Clone, Copy, Debug, thiserror::Error)]

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -7,12 +7,14 @@ use anyhow::Result;
 use libp2p::swarm::{NetworkBehaviour, SwarmBuilder};
 use libp2p::{identity, Multiaddr, Swarm};
 use std::fmt::Debug;
+use std::time::Duration;
 
 #[allow(clippy::too_many_arguments)]
 pub fn asb<LR>(
     seed: &Seed,
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
+    max_swap_timeout: Duration,
     latest_rate: LR,
     resume_only: bool,
     env_config: env::Config,
@@ -38,6 +40,7 @@ where
     let behaviour = asb::Behaviour::new(
         min_buy,
         max_buy,
+        max_swap_timeout,
         latest_rate,
         resume_only,
         env_config,

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -242,6 +242,7 @@ async fn start_alice(
         seed,
         min_buy,
         max_buy,
+        Duration::from_secs(120),
         latest_rate,
         resume_only,
         env_config,
@@ -260,6 +261,7 @@ async fn start_alice(
         FixedRate::default(),
         min_buy,
         max_buy,
+        Duration::from_secs(120),
         None,
     )
     .unwrap();


### PR DESCRIPTION
Eventually I like the idea of this being a "max offer duration", which could be configurable, and then advanced users could have their own variable duration based around things like volatility. But for now I think this accomplishes the goals of #1644 . 