### PR TITLE
Synchronise Transfer Proof acknowledgement

### DIFF
--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -118,12 +118,13 @@ impl EventLoop {
                             }
 
                             if swap_id != self.swap_id {
-
                                 // TODO: Save unexpected transfer proofs in the database and check for messages in the database when handling swaps
                                 tracing::warn!("Received unexpected transfer proof for swap {} while running swap {}. This transfer proof will be ignored", swap_id, self.swap_id);
 
-                                // When receiving a transfer proof that is unexpected we still have to acknowledge that it was received
-                                let _ = self.swarm.behaviour_mut().transfer_proof.send_response(channel, ());
+                                // When receiving a transfer proof that is unexpected we do not want to acknowledge it.
+                                // If we acknowledge it, Alice will think we have received the transfer proof and will not send it again.
+                                // But we haven't processed the transfer proof yet, so we need to wait for Alice to send it again.
+                                // Ideally we would save the transfer proof in the database and check for messages in the database when handling swaps.
                                 continue;
                             }
 


### PR DESCRIPTION
This PR will fix https://github.com/comit-network/xmr-btc-swap/issues/1018

The problem:
- If Alice sends the transfer proof to Bob while he's running a different swap, Alice will transition to `TransferProofAcknowledged` while Bob stays in `BtcLocked` (waiting for Alice to send the transfer proof)
- Alice will never send the transfer proof again
- Bob will wait indefinitely
- The swap cannot be completed because Alice will never receive the encrypted signature


The fix (not of all this is working)
- Bob only acknowledges the transfer proof if he's running the correct swap
- Alice will wait until Bob acknowledges the transfer proof
- If Bob does not acknowledge the transfer proof on the first try, Alice will try again repeatedly

TODO:
- [ ] Create an integration test for this issue
- [ ] Fix the transfer proof buffer (Alice)