### PR TITLE
Reduce check interval for Monero `watch_for_transfer`

### DIFF
--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -6,6 +6,7 @@ use ::monero::{Address, Network, PrivateKey, PublicKey};
 use anyhow::{Context, Result};
 use monero_rpc::wallet::{BlockHeight, MoneroWalletRpc as _, Refreshed};
 use monero_rpc::{jsonrpc, wallet};
+use std::ops::Div;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -220,7 +221,7 @@ impl Wallet {
 
         let address = Address::standard(self.network, public_spend_key, public_view_key.into());
 
-        let check_interval = tokio::time::interval(self.sync_interval);
+        let check_interval = tokio::time::interval(self.sync_interval.div(10));
 
         wait_for_confirmations(
             &self.inner,


### PR DESCRIPTION
Oftentimes we fail to check the status of the Monero transaction on the first try (because it hasn't been registered on our Monero daemon yet, it takes a few seconds).

By decreasing the check interval from the default of 2 minutes to a 10th of that, we ensure that Bob get's his transfer proof faster.