### PR TITLE
Add concurrent_bobs_after_xmr_lock_proof_sent test to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
             alice_refunds_after_restart_bob_refunded,
             ensure_same_swap_id,
             concurrent_bobs_before_xmr_lock_proof_sent,
+            concurrent_bobs_after_xmr_lock_proof_sent,
             alice_manually_redeems_after_enc_sig_learned,
             happy_path_bob_offline_while_alice_redeems_btc,
           ]


### PR DESCRIPTION
Was browsing the code and noticed the test `concurrent_bobs_after_xmr_lock_proof_sent` was not being run automatically by the CI, but the test runs fine on my machine. If this is simply an oversight, let's add to the CI process. 